### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark_evaluation.yml
+++ b/.github/ISSUE_TEMPLATE/benchmark_evaluation.yml
@@ -1,0 +1,62 @@
+name: Benchmark or evaluation task
+description: Add ground-truth evaluation, benchmark datasets, metrics, resampling, or comparison methodology.
+title: "[Benchmark]: "
+labels: ["type: benchmark", "status: triage"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What benchmark or evaluation capability is needed?
+    validations:
+      required: true
+  - type: dropdown
+    id: task_family
+    attributes:
+      label: Task family
+      options:
+        - Pair classification
+        - Retrieval/ranking
+        - Score calibration
+        - Resampling/uncertainty
+        - Statistical comparison
+        - Dataset adapter
+        - Benchmark demonstration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: dataset
+    attributes:
+      label: Dataset or labels
+      description: Describe expected input files, ground-truth labels, relevance judgments, or preset source.
+      placeholder: "pairs.csv with left_id, right_id, label; or qrels with query_id, doc_id, relevance."
+    validations:
+      required: true
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Metrics
+      placeholder: "Accuracy, precision, recall, F1, AUROC, AUPRC, MAP, MRR, nDCG@k."
+    validations:
+      required: true
+  - type: textarea
+    id: methodology
+    attributes:
+      label: Methodology
+      description: Explain thresholds, calibration, splits, resampling, and how algorithms will be compared fairly.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Test plan
+      placeholder: "Add tiny fixtures, deterministic metrics tests, and CLI smoke tests."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report incorrect, broken, or surprising behavior in released Matheel code.
+title: "[Bug]: "
+labels: ["type: bug", "status: triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for reproducible behavior that should work but does not.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is the bug?
+      placeholder: "Matheel silently accepts an invalid feature name and returns a zero score."
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - Python API
+        - Gradio app
+        - Similarity algorithms
+        - Code metrics
+        - Preprocessing or chunking
+        - Datasets or evaluation
+        - Packaging or dependencies
+        - Documentation
+        - Tests or CI
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Include the smallest command, script, dataset, or uploaded ZIP that reproduces the problem.
+      placeholder: |
+        1. Run `matheel compare sample_pairs.zip --feature-weight levenshten=1`
+        2. Observe that no validation error is raised.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "Matheel should reject unknown feature names with a clear error."
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: "The run succeeds and scores are silently wrong."
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Matheel version, Python version, OS, install command, and optional extras.
+      placeholder: |
+        Matheel: 0.3.4
+        Python: 3.12
+        OS: macOS
+        Install: pip install "matheel[all]"
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What must be true before this bug can close?
+      placeholder: |
+        - Invalid feature names raise `ValueError`.
+        - CLI surfaces the error cleanly.
+        - Regression test added.
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Test plan
+      placeholder: "Add unit tests in `tests/test_feature_weights.py` and run `pytest --ignore=tests/test_real_models.py`."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,56 @@
+name: Documentation
+description: Improve docs, examples, API guides, or implementation explanations.
+title: "[Docs]: "
+labels: ["type: documentation", "status: triage"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What documentation should change?
+    validations:
+      required: true
+  - type: dropdown
+    id: doc_area
+    attributes:
+      label: Documentation area
+      options:
+        - README
+        - Usage guide
+        - API reference
+        - Algorithm details
+        - Tokenization/preprocessing
+        - Evaluation methodology
+        - Extensibility guide
+        - Gradio guide
+        - Release notes
+        - Manuscript support
+    validations:
+      required: true
+  - type: textarea
+    id: audience
+    attributes:
+      label: Audience
+      placeholder: "Researchers comparing algorithms, instructors using the UI, or contributors adding algorithms."
+    validations:
+      required: true
+  - type: textarea
+    id: content
+    attributes:
+      label: Required content
+      placeholder: "Explain tokenization strategy, normalization steps, limitations, and examples."
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+    validations:
+      required: true
+  - type: textarea
+    id: checks
+    attributes:
+      label: Checks
+      placeholder: "Review links, run examples, or render docs if applicable."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,73 @@
+name: Enhancement
+description: Propose a scoped improvement to Matheel behavior or APIs.
+title: "[Enhancement]: "
+labels: ["type: enhancement", "status: triage"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should be added or changed?
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Progress and runtime reporting
+        - Algorithm implementation
+        - Evaluation methodology
+        - Dataset support
+        - Extensibility
+        - Gradio user experience
+        - Visualization
+        - Packaging
+        - Release process
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Link a related issue, user need, or release goal.
+      placeholder: "Long runs need progress indicators."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed behavior
+      description: Describe the user-facing behavior and API shape.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and non-goals
+      placeholder: |
+        In scope:
+        - Add tqdm progress for pair scoring.
+        - Add elapsed seconds to comparison-suite output.
+
+        Out of scope:
+        - Full benchmark calibration.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - CLI shows progress when stdout is interactive.
+        - Non-interactive output remains script-friendly.
+        - Unit tests cover timing metadata.
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Test plan
+      placeholder: "List unit, integration, Gradio, or manual checks."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/maintenance_release.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance_release.yml
@@ -1,0 +1,47 @@
+name: Maintenance or release task
+description: Track release preparation, packaging, versioning, CI, and project hygiene.
+title: "[Maintenance]: "
+labels: ["type: maintenance", "status: triage"]
+body:
+  - type: textarea
+    id: task
+    attributes:
+      label: Task
+      description: What maintenance or release step is needed?
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - GitHub workflow
+        - Branch/PR process
+        - Versioning
+        - Packaging
+        - Release notes
+        - Dependency update
+        - Repository cleanup
+        - Project metadata
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      placeholder: "Needed before v0.3.5 so every release has repeatable checks."
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      placeholder: "Commands, screenshots, or release checklist items."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/performance_ux.yml
+++ b/.github/ISSUE_TEMPLATE/performance_ux.yml
@@ -1,0 +1,53 @@
+name: Performance or UX
+description: Improve runtime, progress feedback, usability, or result interpretation.
+title: "[Performance/UX]: "
+labels: ["type: performance", "type: ux", "status: triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What runtime, progress, or usability issue affects users?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI progress
+        - Python API progress hooks
+        - Gradio progress
+        - Runtime profiling
+        - Algorithm performance
+        - Result table readability
+        - Score interpretation
+        - Visualization
+    validations:
+      required: true
+  - type: textarea
+    id: scenario
+    attributes:
+      label: User scenario
+      placeholder: "Running 200 submissions in the Gradio app gives no progress feedback."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed improvement
+      placeholder: "Show pair count, active algorithm, elapsed time, and estimated progress."
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Test plan
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/test_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/test_improvement.yml
@@ -1,0 +1,57 @@
+name: Test improvement
+description: Add or strengthen tests, CI, fixtures, or regression coverage.
+title: "[Tests]: "
+labels: ["type: tests", "status: triage"]
+body:
+  - type: textarea
+    id: gap
+    attributes:
+      label: Test gap
+      description: What behavior is untested or weakly tested?
+    validations:
+      required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Test scope
+      options:
+        - Unit tests
+        - Integration tests
+        - CLI tests
+        - Gradio tests
+        - Algorithm correctness tests
+        - Dataset/evaluation tests
+        - CI workflow
+        - Packaging/release tests
+    validations:
+      required: true
+  - type: textarea
+    id: files
+    attributes:
+      label: Target files or modules
+      placeholder: "`matheel/similarity.py`, `tests/test_similarity.py`"
+    validations:
+      required: true
+  - type: textarea
+    id: cases
+    attributes:
+      label: Required cases
+      placeholder: |
+        - Identical code scores as expected.
+        - Completely different code scores lower.
+        - Invalid inputs raise clear errors.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Verification command
+      placeholder: "`pytest --ignore=tests/test_real_models.py`"
+    validations:
+      required: true


### PR DESCRIPTION
Closes #2

Summary:
- Adds structured GitHub issue templates for bugs, enhancements, tests, documentation, benchmark/evaluation work, performance/UX work, and maintenance tasks.
- Disables blank issues so reports follow a consistent format.

Testing:
- Parsed the issue template YAML files successfully.
- Confirmed this change does not modify runtime code.