### PR TITLE
Reject unknown feature weight names

### DIFF
--- a/matheel/feature_weights.py
+++ b/matheel/feature_weights.py
@@ -20,6 +20,12 @@ def _validate_weight_name(name):
     key = str(name or "").strip()
     if not key:
         raise ValueError("Feature names must be non-empty.")
+    supported = available_default_features()
+    if key not in supported:
+        supported_text = ", ".join(supported)
+        raise ValueError(
+            f"Unsupported feature weight: {key}. Supported feature weights: {supported_text}."
+        )
     return key
 
 

--- a/tests/test_feature_weights.py
+++ b/tests/test_feature_weights.py
@@ -1,3 +1,5 @@
+import pytest
+
 from matheel.feature_weights import (
     available_default_features,
     default_feature_weights,
@@ -16,6 +18,25 @@ def test_resolve_feature_weights_accepts_string_overrides():
     resolved = resolve_feature_weights(feature_weights="semantic=2,code_metric=2")
 
     assert resolved == {"semantic": 0.5, "code_metric": 0.5}
+
+
+@pytest.mark.parametrize(
+    "feature_weights",
+    [
+        {"levenshten": 1.0},
+        "levenshten=1.0",
+        ["semantic=0.5", "levenshten=0.5"],
+        [("semantic", 0.5), ("levenshten", 0.5)],
+    ],
+)
+def test_resolve_feature_weights_rejects_unknown_feature_names(feature_weights):
+    with pytest.raises(ValueError, match="Unsupported feature weight.*levenshten.*levenshtein"):
+        resolve_feature_weights(feature_weights=feature_weights)
+
+
+def test_normalize_feature_weights_rejects_unknown_feature_names():
+    with pytest.raises(ValueError, match="Unsupported feature weight.*unknown"):
+        normalize_feature_weights({"semantic": 0.5, "unknown": 0.5})
 
 
 def test_resolve_feature_weights_uses_defaults_without_legacy_weights():


### PR DESCRIPTION
Closes #4

Summary:
- Validates feature weight names against Matheel's supported feature set.
- Raises a clear error for unknown names instead of silently ignoring them during scoring.
- Adds regression tests for dict, string, and repeated/list feature-weight inputs.

Testing:
- pytest tests/test_feature_weights.py tests/test_similarity.py
- pytest tests/test_cli.py