### PR TITLE
Reject inactive code metric weights

### DIFF
--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -257,6 +257,16 @@ def validate_code_metric_options(code_metric_weight, codebleu_component_weights)
     )
 
 
+def validate_active_code_metric_weight(code_metric, feature_weights):
+    metric_name = (code_metric or "none").strip().lower()
+    metric_weight = float((feature_weights or {}).get("code_metric", 0.0))
+    if metric_name in ("none", "") and metric_weight > 0.0:
+        raise ValueError(
+            "code_metric_weight requires an active code_metric. "
+            "Set code_metric to a supported metric or set the code_metric feature weight to 0."
+        )
+
+
 def validate_edit_distance_options(levenshtein_weights=None, jaro_winkler_prefix_weight=0.1):
     if levenshtein_weights in (None, ""):
         parsed_levenshtein_weights = (1, 1, 1)
@@ -878,6 +888,7 @@ def get_sim_list(
         feature_weights=feature_weights,
         code_metric_weight=code_metric_weight,
     )
+    validate_active_code_metric_weight(code_metric, resolved_feature_weights)
     use_semantic = resolved_feature_weights.get("semantic", 0.0) > 0.0
     if use_semantic and (vector_backend or "auto").strip().lower() in ("", "auto"):
         model_info = load_hf_model_info(model_name or DEFAULT_MODEL_NAME)
@@ -1092,6 +1103,7 @@ def calculate_similarity(
         feature_weights=feature_weights,
         code_metric_weight=code_metric_weight,
     )
+    validate_active_code_metric_weight(code_metric, resolved_feature_weights)
     use_semantic = resolved_feature_weights.get("semantic", 0.0) > 0.0
     if use_semantic and (vector_backend or "auto").strip().lower() in ("", "auto"):
         model_info = load_hf_model_info(model_name or DEFAULT_MODEL_NAME)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,30 @@ def test_compare_command_accepts_directory_source(tmp_path, monkeypatch):
     assert captured["args"][0] == str(source_dir)
 
 
+def test_compare_command_rejects_inactive_code_metric_weight(tmp_path):
+    source_dir = tmp_path / "codes"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("print(1)", encoding="utf-8")
+    (source_dir / "b.py").write_text("print(1)", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "compare",
+            str(source_dir),
+            "--feature-weight",
+            "levenshtein=1",
+            "--code-metric-weight",
+            "1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
+    assert "code_metric_weight requires an active code_metric" in str(result.exception)
+
+
 def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
     archive_path = tmp_path / "codes.zip"
     archive_path.write_bytes(b"placeholder")

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -120,3 +120,22 @@ def test_default_suite_run_name_uses_algorithm_names():
         )
         == "embedding_levenshtein"
     )
+
+
+def test_build_feature_weights_ignores_code_metric_weight_when_metric_is_inactive():
+    weights = gradio_app.build_feature_weights(
+        True,
+        1.0,
+        False,
+        0.0,
+        False,
+        0.0,
+        False,
+        0.0,
+        False,
+        0.0,
+        "none",
+        1.0,
+    )
+
+    assert weights == {"semantic": 1.0}

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -138,6 +138,29 @@ def test_calculate_similarity_supports_code_metric_without_semantic_weights(monk
     assert score == pytest.approx(1.0)
 
 
+def test_calculate_similarity_rejects_inactive_code_metric_weight():
+    with pytest.raises(ValueError, match="code_metric_weight requires an active code_metric"):
+        similarity.calculate_similarity(
+            "abc",
+            "abc",
+            vector_backend="static_hash",
+            feature_weights={"levenshtein": 1.0},
+            code_metric="none",
+            code_metric_weight=1.0,
+        )
+
+
+def test_calculate_similarity_rejects_code_metric_feature_without_metric():
+    with pytest.raises(ValueError, match="code_metric_weight requires an active code_metric"):
+        similarity.calculate_similarity(
+            "abc",
+            "abc",
+            vector_backend="static_hash",
+            feature_weights={"code_metric": 1.0},
+            code_metric="none",
+        )
+
+
 def test_calculate_similarity_supports_custom_levenshtein_weights():
     default_score = similarity.calculate_similarity(
         "abcd",


### PR DESCRIPTION
Closes #5

Summary:
- Rejects positive code metric feature weight when no code metric is active.
- Covers both explicit code_metric feature weights and the code_metric_weight convenience option.
- Confirms the Gradio helper continues to ignore the slider value when Code Metric is not selected.

Testing:
- pytest tests/test_feature_weights.py tests/test_similarity.py tests/test_cli.py tests/test_gradio_app.py