### PR TITLE
Validate compare input paths

### DIFF
--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -240,6 +240,8 @@ def extract_and_read_source(source_path):
     resolved_path = resolve_file_path(source_path)
     if os.path.isdir(resolved_path):
         return read_directory_source(resolved_path)
+    if not zipfile.is_zipfile(resolved_path):
+        raise ValueError("source_path must be a directory or a ZIP archive.")
     return read_zip_source(resolved_path)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,26 @@ def test_compare_command_accepts_directory_source(tmp_path, monkeypatch):
     assert captured["args"][0] == str(source_dir)
 
 
+def test_compare_command_rejects_regular_file_source(tmp_path):
+    source_file = tmp_path / "single.py"
+    source_file.write_text("print(1)", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "compare",
+            str(source_file),
+            "--feature-weight",
+            "levenshtein=1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ValueError)
+    assert "directory or a ZIP archive" in str(result.exception)
+
+
 def test_compare_command_rejects_inactive_code_metric_weight(tmp_path):
     source_dir = tmp_path / "codes"
     source_dir.mkdir()

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -94,6 +94,18 @@ def test_get_sim_list_accepts_directory_source(tmp_path, monkeypatch):
     assert clean_results.iloc[0]["similarity_score"] == 1.0
 
 
+def test_get_sim_list_rejects_regular_file_source(tmp_path):
+    source_file = tmp_path / "single.py"
+    source_file.write_text("print(1)", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="directory or a ZIP archive"):
+        similarity.get_sim_list(
+            source_file,
+            feature_weights={"levenshtein": 1.0},
+            vector_backend="static_hash",
+        )
+
+
 def test_calculate_similarity_supports_chunking(monkeypatch):
     pytest.importorskip("chonkie")
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #7

Summary:
- Validates source inputs before attempting ZIP loading.
- Returns a clear error when the input is neither a directory nor a ZIP archive.
- Adds API and CLI regression tests for regular-file input.

Testing:
- pytest tests/test_cli.py tests/test_similarity.py