### PR TITLE
Sanitize Gradio suite export filenames

### DIFF
--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -13,7 +13,7 @@ import pandas as pd
 from gradio_huggingfacehub_search import HuggingfaceHubSearch
 
 from matheel.chunking import available_chunk_aggregations, available_chunking_methods
-from matheel.comparison_suite import run_comparison_suite
+from matheel.comparison_suite import run_comparison_suite, slugify_run_name
 from matheel.code_metrics import available_code_metric_languages, available_code_metrics
 from matheel.model_routing import available_vector_backends
 from matheel.preprocessing import available_preprocess_modes
@@ -1097,9 +1097,10 @@ def run_suite_gradio(
     details_zip_path = os.path.join(export_root, "comparison_suite_details.zip")
     with zipfile.ZipFile(details_zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for run_name, frame in result_frames.items():
-            detail_path = os.path.join(export_root, f"{run_name}.csv")
+            detail_filename = f"{slugify_run_name(run_name)}.csv"
+            detail_path = os.path.join(export_root, detail_filename)
             frame.to_csv(detail_path, index=False)
-            archive.write(detail_path, arcname=os.path.basename(detail_path))
+            archive.write(detail_path, arcname=detail_filename)
     run_sheet_export = os.path.join(export_root, "comparison_suite_runs.json")
     with open(run_sheet_export, "w", encoding="utf-8") as handle:
         json.dump(run_configs, handle, indent=2)

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -116,10 +116,14 @@ def summary_row_from_results(run_name, options, results):
     }
 
 
-def _slugify(value):
-    slug = _SLUG_RE.sub("_", value.strip())
+def slugify_run_name(value):
+    slug = _SLUG_RE.sub("_", str(value).strip())
     slug = slug.strip("._")
     return slug or "run"
+
+
+def _slugify(value):
+    return slugify_run_name(value)
 
 
 def _rounded_score_frame(frame):
@@ -148,7 +152,7 @@ def write_run_details(run_name, results, details_dir):
     results = _rounded_score_frame(results)
     target_dir = Path(details_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
-    target_path = target_dir / f"{_slugify(run_name)}.csv"
+    target_path = target_dir / f"{slugify_run_name(run_name)}.csv"
     results.to_csv(target_path, index=False, float_format=f"%.{_SCORE_DECIMALS}f")
     return target_path
 

--- a/tests/test_comparison_suite.py
+++ b/tests/test_comparison_suite.py
@@ -3,7 +3,12 @@ import json
 import pandas as pd
 import pytest
 
-from matheel.comparison_suite import load_run_configs, parse_run_configs, run_comparison_suite
+from matheel.comparison_suite import (
+    load_run_configs,
+    parse_run_configs,
+    run_comparison_suite,
+    slugify_run_name,
+)
 
 
 def test_load_run_configs_accepts_runs_wrapper(tmp_path):
@@ -64,6 +69,11 @@ def test_parse_run_configs_rejects_legacy_weight_keys():
         parse_run_configs(
             '[{"run_name":"legacy","options":{"ws":0.7,"wl":0.3}}]'
         )
+
+
+def test_slugify_run_name_removes_path_separators():
+    assert slugify_run_name("../baseline/strong") == "baseline_strong"
+    assert slugify_run_name("...") == "run"
 
 
 def test_run_comparison_suite_writes_summary_and_details(tmp_path, monkeypatch):

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -1,6 +1,8 @@
 import importlib.util
+import zipfile
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 
@@ -139,3 +141,96 @@ def test_build_feature_weights_ignores_code_metric_weight_when_metric_is_inactiv
     )
 
     assert weights == {"semantic": 1.0}
+
+
+def test_run_suite_export_sanitizes_detail_zip_filenames(monkeypatch):
+    row = _build_suite_row(run_name="../baseline/strong")
+    summary = pd.DataFrame(
+        [
+            {
+                "run_name": "../baseline/strong",
+                "pair_count": 1,
+                "mean_score": 1.0,
+                "median_score": 1.0,
+                "max_score": 1.0,
+                "min_score": 1.0,
+                "std_score": 0.0,
+                "top_file_1": "a.py",
+                "top_file_2": "b.py",
+                "top_score": 1.0,
+                "vector_backend": "auto",
+                "code_metric": "none",
+                "chunking_method": "none",
+            }
+        ]
+    )
+    details = pd.DataFrame(
+        [
+            {
+                "file_name_1": "a.py",
+                "file_name_2": "b.py",
+                "similarity_score": 1.0,
+            }
+        ]
+    )
+
+    def fake_run_comparison_suite(
+        zipped_file,
+        run_configs,
+        summary_out=None,
+        details_dir=None,
+        output_format="csv",
+    ):
+        assert run_configs[0]["run_name"] == "../baseline/strong"
+        return summary, {"../baseline/strong": details}
+
+    monkeypatch.setattr(gradio_app, "run_comparison_suite", fake_run_comparison_suite)
+
+    outputs = gradio_app.run_suite_gradio(
+        "codes.zip",
+        [row],
+        "csv",
+        "",
+        ["Levenshtein"],
+        gradio_app.DEFAULT_MODEL,
+        "auto",
+        "cosine",
+        "mean",
+        256,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        "1,1,1",
+        0.1,
+        5,
+        4,
+        5,
+        "codebleu",
+        0.0,
+        "java",
+        "0.25,0.25,0.25,0.25",
+        4,
+        50,
+        gradio_app.DEFAULT_RUBY_MODE,
+        gradio_app.DEFAULT_RUBY_GRAPH_TIMEOUT,
+        gradio_app.DEFAULT_TSED_COSTS,
+        gradio_app.DEFAULT_CODEBERTSCORE_MODEL,
+        gradio_app.DEFAULT_CODEBERTSCORE_MAX_LENGTH,
+        [],
+        "none",
+        "none",
+        120,
+        0,
+        0,
+        "mean",
+        "text",
+        "",
+        0.0,
+        50,
+    )
+
+    details_zip_path = outputs[6]
+    with zipfile.ZipFile(details_zip_path) as archive:
+        assert archive.namelist() == ["baseline_strong.csv"]


### PR DESCRIPTION
Closes #8

Summary:
- Use safe filenames for Gradio comparison-suite detail CSV exports.
- Keep ZIP entries free from raw run-name path separators.
- Add regression coverage for path-like run names.

Testing:
- python -m pytest tests/test_comparison_suite.py tests/test_gradio_app.py