### PR TITLE
Exclude real-model tests from default pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,26 @@ print(results.head())
 - Code metrics: [docs/code_metrics.md](docs/code_metrics.md)
 - Comparison suite: [docs/comparison_suite.md](docs/comparison_suite.md)
 
+## Testing
+
+Install the development dependencies before running the test suite:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Default test runs are intended to be fast and offline-friendly:
+
+```bash
+pytest
+```
+
+Real-model integration tests are opt-in because they may need optional backends, cached model weights, or network access:
+
+```bash
+pytest -m integration
+```
+
 ## Examples
 
 - Colab walkthrough: [examples/matheel_examples_colab.ipynb](examples/matheel_examples_colab.ipynb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ include = ["matheel*"]
 exclude = ["gradio_app*"]
 
 [tool.pytest.ini_options]
+addopts = ["-m", "not integration"]
 testpaths = ["tests"]
 markers = [
     "integration: real-model tests that use actual embedding backends and cached/downloaded model weights",


### PR DESCRIPTION
Closes #6

Summary:
- Exclude integration-marked real-model tests from the default pytest run.
- Keep real-model tests available through an explicit integration marker command.
- Document the default and integration test commands in the README.

Testing:
- python -m pytest
- python -m pytest -m integration --collect-only -q tests/test_real_models.py