### PR TITLE
Add release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ print(results.head())
 - Lexical metrics and baselines: [docs/lexical.md](docs/lexical.md)
 - Code metrics: [docs/code_metrics.md](docs/code_metrics.md)
 - Comparison suite: [docs/comparison_suite.md](docs/comparison_suite.md)
+- Release checklist: [docs/release_checklist.md](docs/release_checklist.md)
 
 ## Testing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,4 @@ The canonical index is [index.md](index.md).
 - [Lexical metrics and baselines](lexical.md)
 - [Code metrics](code_metrics.md)
 - [Comparison suite](comparison_suite.md)
+- [Release checklist](release_checklist.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ Matheel is organized around a simple flow:
 - [Lexical metrics and baselines](lexical.md)
 - [Code metrics](code_metrics.md)
 - [Comparison suite](comparison_suite.md)
+- [Release checklist](release_checklist.md)
 
 ## Demos and Examples
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,0 +1,55 @@
+# Release Checklist
+
+Use this checklist before publishing a Matheel release.
+
+## Version
+
+- Confirm `pyproject.toml` has the intended version.
+- Confirm the release tag uses the same version with a leading `v`, for example `v0.3.4`.
+- Confirm release notes describe the user-visible changes.
+
+## Tests
+
+- Run the default offline-friendly test suite:
+
+```bash
+pytest
+```
+
+- Run real-model integration tests when optional backends, cached model weights, or network access are available:
+
+```bash
+pytest -m integration
+```
+
+## Package
+
+- Build the distribution artifacts:
+
+```bash
+python -m build
+```
+
+- Check the distribution metadata:
+
+```bash
+python -m twine check dist/*
+```
+
+## GitHub Release
+
+- Confirm the tag exists on GitHub.
+- Publish the GitHub Release for the same tag.
+- Mark the release as latest when it is the current stable release.
+- Confirm GitHub Releases, repository tags, and `pyproject.toml` agree:
+
+```bash
+gh release list --limit 5
+git tag --sort=-version:refname | head
+```
+
+## Post-Release
+
+- Install the released package in a clean environment.
+- Run a small CLI check against `sample_pairs.zip`.
+- Open an issue for any follow-up that should not block the release.


### PR DESCRIPTION
Closes #9

Summary:
- Add a release checklist covering version, tests, package build, GitHub Release, and post-release checks.
- Link the checklist from the README and docs index pages.
- Include the check that GitHub Releases, tags, and pyproject.toml agree.

Verification:
- Confirmed GitHub Releases currently shows v0.3.4 as Latest.
- Confirmed pyproject.toml version is 0.3.4.
- Confirmed tags include v0.3.4.
- git diff --check