### PR TITLE
Add README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Matheel
 
+[![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
+[![PyPI](https://img.shields.io/pypi/v/matheel.svg)](https://pypi.org/project/matheel/)
+[![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg)](https://pypi.org/project/matheel/)
+[![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)
+[![License](https://img.shields.io/github/license/FahadEbrahim/matheel.svg)](LICENSE)
+
 Matheel is a Python package and CLI for source-code similarity. It combines semantic embeddings, lexical similarity, chunking, preprocessing, and code evaluation metrics in one workflow.
 
 ## Demos


### PR DESCRIPTION
Closes #18

Summary:
- Add README badges for GitHub Actions tests, PyPI version, supported Python versions, latest release, and license.
- Place badges directly under the project title.

Testing:
- git diff --check