### PR TITLE
Add Ruff linting baseline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,5 +36,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
+      - name: Run Ruff
+        run: python -m ruff check .
+
       - name: Run tests
         run: python -m pytest

--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ Default test runs are intended to be fast and offline-friendly:
 pytest
 ```
 
+Run the Ruff lint check before opening a pull request:
+
+```bash
+ruff check .
+```
+
 Real-model integration tests are opt-in because they may need optional backends, cached model weights, or network access:
 
 ```bash

--- a/matheel/native_codebleu.py
+++ b/matheel/native_codebleu.py
@@ -1029,7 +1029,8 @@ def calc_codebleu(
     if len(weights) != 4:
         raise ValueError("weights should contain exactly 4 values.")
     if tokenizer is None:
-        tokenizer = lambda text: text.split()
+        def tokenizer(text):
+            return text.split()
 
     normalized_references = [[value.strip() for value in reference] if isinstance(reference, list) else [reference.strip()] for reference in references]
     normalized_predictions = [value.strip() for value in predictions]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ all = [
 ]
 dev = [
     "pytest>=8,<9",
+    "ruff>=0.15,<0.16",
     "build>=1,<2",
     "twine>=6,<7"
 ]
@@ -78,3 +79,13 @@ testpaths = ["tests"]
 markers = [
     "integration: real-model tests that use actual embedding backends and cached/downloaded model weights",
 ]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+extend-exclude = [
+    "*.ipynb",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"gradio_app/app.py" = ["E402"]


### PR DESCRIPTION
Closes #21

Summary:
- Add Ruff to development dependencies and configure a conservative lint baseline.
- Exclude notebooks from Ruff linting for now and keep the existing Gradio import setup explicit.
- Add Ruff to the GitHub Actions test workflow.
- Document the Ruff check command in the README.

Testing:
- python -m ruff check .
- python -m pytest
- git diff --check