### PR TITLE
Fix README Python version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/matheel.svg)](https://pypi.org/project/matheel/)
-[![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg)](https://pypi.org/project/matheel/)
+[![Python versions](https://img.shields.io/badge/python-3.10--3.12-blue.svg)](pyproject.toml)
 [![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)
 [![License](https://img.shields.io/github/license/FahadEbrahim/matheel.svg)](LICENSE)
 


### PR DESCRIPTION
Closes #20

Summary:
- Replace the PyPI Python-versions badge with a static supported-version badge.
- Link the badge to pyproject.toml, where the supported Python range is defined.

Testing:
- git diff --check