### PR TITLE
Prepare v0.3.5 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/matheel
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build
+        run: python -m pip install --upgrade build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,3 +15,4 @@ The canonical index is [index.md](index.md).
 - [Code metrics](code_metrics.md)
 - [Comparison suite](comparison_suite.md)
 - [Release checklist](release_checklist.md)
+- [Release notes: v0.3.5](releases/v0.3.5.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ Matheel is organized around a simple flow:
 - [Code metrics](code_metrics.md)
 - [Comparison suite](comparison_suite.md)
 - [Release checklist](release_checklist.md)
+- [Release notes: v0.3.5](releases/v0.3.5.md)
 
 ## Demos and Examples
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -36,6 +36,14 @@ python -m build
 python -m twine check dist/*
 ```
 
+- Publish the checked artifacts to PyPI:
+
+```bash
+python -m twine upload dist/*
+```
+
+- Confirm PyPI shows the new version.
+
 ## GitHub Release
 
 - Confirm the tag exists on GitHub.

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -36,22 +36,15 @@ python -m build
 python -m twine check dist/*
 ```
 
-- Publish the checked artifacts to PyPI:
+## GitHub Release and PyPI
 
-```bash
-python -m twine upload dist/*
-```
-
-- Confirm PyPI shows the new version.
-
-## GitHub Release
-
-- Confirm the tag exists on GitHub.
-- Publish the GitHub Release for the same tag.
+- Create and push the release tag.
+- Publish the GitHub Release for the same tag. The publish workflow uploads the package to PyPI through Trusted Publishing.
 - Mark the release as latest when it is the current stable release.
-- Confirm GitHub Releases, repository tags, and `pyproject.toml` agree:
+- Confirm PyPI, GitHub Releases, repository tags, and `pyproject.toml` agree:
 
 ```bash
+python -m pip index versions matheel
 gh release list --limit 5
 git tag --sort=-version:refname | head
 ```

--- a/docs/releases/v0.3.5.md
+++ b/docs/releases/v0.3.5.md
@@ -1,0 +1,27 @@
+# Matheel v0.3.5
+
+This patch release focuses on repository readiness, safer defaults, and small validation fixes.
+
+## Fixes
+
+- Reject unsupported feature-weight names.
+- Reject code-metric weights when no code metric is active.
+- Validate compare input paths before reading archives.
+- Sanitize Gradio comparison-suite detail export filenames.
+- Fix the README Python version badge.
+
+## Testing and Maintenance
+
+- Exclude real-model integration tests from default pytest runs.
+- Add GitHub Actions tests for Python 3.10, 3.11, and 3.12.
+- Add README status badges.
+- Add a Ruff linting baseline and run Ruff in CI.
+- Add a release checklist.
+- Enable main branch protection with required status checks.
+
+## Verification
+
+- `python -m ruff check .`
+- `python -m pytest`
+- `python -m build`
+- `python -m twine check dist/*`

--- a/docs/releases/v0.3.5.md
+++ b/docs/releases/v0.3.5.md
@@ -28,6 +28,6 @@ This patch release focuses on repository readiness, safer defaults, and small va
 
 ## Publishing
 
-- Publish checked artifacts to PyPI with `python -m twine upload dist/*`.
 - Create tag `v0.3.5`.
 - Publish the GitHub Release and mark it as Latest.
+- The `Publish` workflow uploads the release artifacts to PyPI through Trusted Publishing.

--- a/docs/releases/v0.3.5.md
+++ b/docs/releases/v0.3.5.md
@@ -25,3 +25,9 @@ This patch release focuses on repository readiness, safer defaults, and small va
 - `python -m pytest`
 - `python -m build`
 - `python -m twine check dist/*`
+
+## Publishing
+
+- Publish checked artifacts to PyPI with `python -m twine upload dist/*`.
+- Create tag `v0.3.5`.
+- Publish the GitHub Release and mark it as Latest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
Refs #23

Summary:
- Bump package version to 0.3.5.
- Add v0.3.5 release notes.
- Link the release notes from the docs index.
- Add PyPI Trusted Publishing through a release-triggered Publish workflow.
- Update the release checklist for GitHub Release and PyPI verification.

Verification:
- python -m ruff check .
- python -m pytest
- python -m build
- python -m twine check dist/*

Release note:
- After this PR is green and merged, create and push tag v0.3.5, then publish the GitHub Release. The Publish workflow should upload the package to PyPI.