### PR TITLE
Refresh PyPI badge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matheel
 
 [![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
-[![PyPI](https://img.shields.io/pypi/v/matheel.svg)](https://pypi.org/project/matheel/)
+[![PyPI](https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=300)](https://pypi.org/project/matheel/)
 [![Python versions](https://img.shields.io/badge/python-3.10--3.12-blue.svg)](pyproject.toml)
 [![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)
 [![License](https://img.shields.io/github/license/FahadEbrahim/matheel.svg)](LICENSE)


### PR DESCRIPTION
Summary:
- Add a short cache window to the PyPI badge URL so GitHub fetches a fresh badge image.

Verification:
- git diff --check
- Confirmed the badge URL returns v0.3.5.