### PR TITLE
Improve release publishing metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,11 +29,34 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install build
-        run: python -m pip install --upgrade build
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import tomllib
+
+          tag = os.environ["RELEASE_TAG"]
+          with open("pyproject.toml", "rb") as pyproject:
+              version = tomllib.load(pyproject)["project"]["version"]
+
+          expected_tag = f"v{version}"
+          if tag != expected_tag:
+              print(f"Release tag {tag!r} does not match package version {version!r}.", file=sys.stderr)
+              print(f"Expected tag: {expected_tag}", file=sys.stderr)
+              raise SystemExit(1)
+          PY
 
       - name: Build package
         run: python -m build
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=300)](https://pypi.org/project/matheel/)
-[![Python versions](https://img.shields.io/badge/python-3.10--3.12-blue.svg)](pyproject.toml)
+[![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg?cacheSeconds=300)](https://pypi.org/project/matheel/)
 [![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)
 [![License](https://img.shields.io/github/license/FahadEbrahim/matheel.svg)](LICENSE)
 
@@ -254,25 +254,25 @@ print(results.head())
 Install the development dependencies before running the test suite:
 
 ```bash
-pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
 ```
 
 Default test runs are intended to be fast and offline-friendly:
 
 ```bash
-pytest
+python -m pytest
 ```
 
 Run the Ruff lint check before opening a pull request:
 
 ```bash
-ruff check .
+python -m ruff check .
 ```
 
 Real-model integration tests are opt-in because they may need optional backends, cached model weights, or network access:
 
 ```bash
-pytest -m integration
+python -m pytest -m integration
 ```
 
 ## Examples

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -2,24 +2,42 @@
 
 Use this checklist before publishing a Matheel release.
 
+## Release Flow
+
+- Make release preparation changes on an issue branch.
+- Open a pull request, wait for GitHub Actions to pass, and merge to `main`.
+- Publish from a GitHub Release, not from a tag push or a manual publish run.
+- Keep PyPI publishing tokenless through Trusted Publishing. Do not add PyPI API tokens or repository secrets for publishing.
+
+The publish workflow is intentionally triggered by `release.published`. A tag push alone should not publish to PyPI because release notes and the "latest" setting should be reviewed first. A manual `workflow_dispatch` publish is avoided because it is easier to run from the wrong ref. If a publish run needs to be retried, rerun the failed GitHub Actions job that was created by the GitHub Release event.
+
 ## Version
 
 - Confirm `pyproject.toml` has the intended version.
-- Confirm the release tag uses the same version with a leading `v`, for example `v0.3.4`.
+- Confirm the release tag uses the same version with a leading `v`, for example `v0.3.6`.
 - Confirm release notes describe the user-visible changes.
+- Confirm the README PyPI badges are dynamic and cache-safe:
+  - PyPI version: `https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=300`
+  - Python versions: `https://img.shields.io/pypi/pyversions/matheel.svg?cacheSeconds=300`
 
 ## Tests
 
 - Run the default offline-friendly test suite:
 
 ```bash
-pytest
+python -m pytest
 ```
 
 - Run real-model integration tests when optional backends, cached model weights, or network access are available:
 
 ```bash
-pytest -m integration
+python -m pytest -m integration
+```
+
+- Run Ruff:
+
+```bash
+python -m ruff check .
 ```
 
 ## Package
@@ -36,10 +54,12 @@ python -m build
 python -m twine check dist/*
 ```
 
+- Confirm package metadata includes Python classifiers for `3.10`, `3.11`, and `3.12`.
+
 ## GitHub Release and PyPI
 
-- Create and push the release tag.
-- Publish the GitHub Release for the same tag. The publish workflow uploads the package to PyPI through Trusted Publishing.
+- Create and push the release tag from the merged `main` commit.
+- Publish the GitHub Release for the same tag. The publish workflow checks that the release tag matches `pyproject.toml`, builds the package, checks the metadata, and uploads to PyPI through Trusted Publishing.
 - Mark the release as latest when it is the current stable release.
 - Confirm PyPI, GitHub Releases, repository tags, and `pyproject.toml` agree:
 
@@ -48,6 +68,10 @@ python -m pip index versions matheel
 gh release list --limit 5
 git tag --sort=-version:refname | head
 ```
+
+- Confirm the GitHub Actions publish run succeeded for the release event.
+- Confirm PyPI shows the new version, the `Requires-Python` range, and Python version classifiers.
+- Confirm the README badges show the released PyPI version and supported Python versions after the Shields cache refreshes.
 
 ## Post-Release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,19 @@ description = "Matheel: A CLI and Python package for source-code similarity dete
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Quality Assurance",
+]
 
 dependencies = [
     "click>=8,<9",


### PR DESCRIPTION
Closes #28.

## Summary

- Add Python package classifiers for supported Python versions so PyPI exposes complete version metadata.
- Keep the README PyPI badges dynamic and cache-safe, including the Python versions badge.
- Keep publishing release-triggered through GitHub Releases and Trusted Publishing, with a workflow guard that checks the release tag matches the package version.
- Expand the release checklist with the release flow decision and post-publish verification steps.

## Verification

- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml")'`
- `python3` pyproject classifier parse check

Package build and `twine check` passed after the metadata changes. A final rebuild after README command wording changes was not rerun locally because the local Python 3.10 environment lacks the setuptools build backend without network build isolation.
