### PR TITLE
Harden similarity input validation

### DIFF
--- a/matheel/code_metrics.py
+++ b/matheel/code_metrics.py
@@ -526,8 +526,10 @@ def parse_component_weights(raw_weights=None):
         values = [float(value.strip()) for value in str(raw_weights).split(",") if value.strip()]
     if len(values) != 4:
         raise ValueError("CodeBLEU component weights must contain exactly 4 values.")
+    if any((not math.isfinite(value)) or value < 0 for value in values):
+        raise ValueError("CodeBLEU component weights must be finite non-negative values.")
     total = sum(values)
-    if total <= 0:
+    if not math.isfinite(total) or total <= 0:
         raise ValueError("CodeBLEU component weights must sum to a positive value.")
     return tuple(value / total for value in values)
 

--- a/matheel/feature_weights.py
+++ b/matheel/feature_weights.py
@@ -1,3 +1,6 @@
+import math
+
+
 _DEFAULT_FEATURE_WEIGHTS = {
     "semantic": 0.7,
     "levenshtein": 0.3,
@@ -31,6 +34,8 @@ def _validate_weight_name(name):
 
 def _validate_weight_value(name, value):
     numeric_value = float(value)
+    if not math.isfinite(numeric_value):
+        raise ValueError(f"{name} must be finite.")
     if numeric_value < 0:
         raise ValueError(f"{name} must be non-negative.")
     return numeric_value

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -247,6 +247,8 @@ def extract_and_read_source(source_path):
 
 def _validate_weight(name, value):
     numeric_value = float(value)
+    if not np.isfinite(numeric_value):
+        raise ValueError(f"{name} must be finite.")
     if numeric_value < 0:
         raise ValueError(f"{name} must be non-negative.")
     return numeric_value
@@ -320,6 +322,15 @@ def validate_vector_options(vector_backend, static_vector_dim, model_name=None, 
         model_info=model_info,
     )
     return backend, max(8, int(static_vector_dim or 0))
+
+
+def validate_embedding_count(embeddings, code_count):
+    embedding_count = 0 if embeddings is None else len(embeddings)
+    if embedding_count != int(code_count):
+        raise ValueError(
+            f"Embedding count ({embedding_count}) must match code count ({int(code_count)})."
+        )
+    return embeddings
 
 
 def semantic_similarity(
@@ -738,6 +749,7 @@ def rank_code_pairs(
     winnowing_window=4,
     gst_min_match_length=5,
 ):
+    validate_embedding_count(embeddings, len(codes))
     results = []
     code_metric_name = (code_metric or "none").strip().lower()
     use_code_metric = code_metric_name not in ("none", "") and feature_weights.get("code_metric", 0.0) > 0.0
@@ -892,6 +904,7 @@ def get_sim_list(
     )
     validate_active_code_metric_weight(code_metric, resolved_feature_weights)
     use_semantic = resolved_feature_weights.get("semantic", 0.0) > 0.0
+    file_names, raw_codes = extract_and_read_source(zipped_file)
     if use_semantic and (vector_backend or "auto").strip().lower() in ("", "auto"):
         model_info = load_hf_model_info(model_name or DEFAULT_MODEL_NAME)
     vector_backend, static_vector_dim = validate_vector_options(
@@ -902,7 +915,6 @@ def get_sim_list(
     )
     selected_similarity = normalize_similarity_function_name(similarity_function)
     selected_pooling = normalize_pooling_method_name(pooling_method)
-    file_names, raw_codes = extract_and_read_source(zipped_file)
     codes = [prepare_code(code, preprocess_mode=preprocess_mode) for code in raw_codes]
     if use_semantic:
         model = load_backend_model(

--- a/tests/test_code_metrics.py
+++ b/tests/test_code_metrics.py
@@ -10,6 +10,7 @@ from matheel.code_metrics import (
     codebleu_runtime_available,
     codebleu_components,
     normalize_code_language,
+    parse_component_weights,
     prepare_crystalbleu_context,
     prepare_ruby_context,
     score_code_metric_pair,
@@ -210,6 +211,21 @@ def test_codebleu_empty_guard_uses_scoring_tokenizer(monkeypatch):
 
     with pytest.raises(ImportError):
         codebleu_components(";", ";", language="python")
+
+
+@pytest.mark.parametrize(
+    "raw_weights",
+    [
+        "-1,1,1,1",
+        "nan,1,1,1",
+        "inf,1,1,1",
+        [0.25, -0.1, 0.25, 0.6],
+        [0.25, float("nan"), 0.25, 0.5],
+    ],
+)
+def test_parse_component_weights_rejects_invalid_values(raw_weights):
+    with pytest.raises(ValueError, match="finite non-negative"):
+        parse_component_weights(raw_weights)
 
 
 def test_crystalbleu_context_can_be_reused_across_pairs():

--- a/tests/test_feature_weights.py
+++ b/tests/test_feature_weights.py
@@ -23,6 +23,27 @@ def test_resolve_feature_weights_accepts_string_overrides():
 @pytest.mark.parametrize(
     "feature_weights",
     [
+        {"semantic": float("nan")},
+        {"semantic": float("inf")},
+        "semantic=nan",
+        "semantic=inf",
+        ["semantic=nan"],
+    ],
+)
+def test_resolve_feature_weights_rejects_non_finite_values(feature_weights):
+    with pytest.raises(ValueError, match="finite"):
+        resolve_feature_weights(feature_weights=feature_weights)
+
+
+@pytest.mark.parametrize("code_metric_weight", [float("nan"), float("inf")])
+def test_default_feature_weights_rejects_non_finite_code_metric_weight(code_metric_weight):
+    with pytest.raises(ValueError, match="finite"):
+        default_feature_weights(code_metric_weight=code_metric_weight)
+
+
+@pytest.mark.parametrize(
+    "feature_weights",
+    [
         {"levenshten": 1.0},
         "levenshten=1.0",
         ["semantic=0.5", "levenshten=0.5"],

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -106,6 +106,49 @@ def test_get_sim_list_rejects_regular_file_source(tmp_path):
         )
 
 
+def test_get_sim_list_validates_source_before_model_metadata_lookup(tmp_path, monkeypatch):
+    source_file = tmp_path / "single.py"
+    source_file.write_text("print(1)", encoding="utf-8")
+
+    def fail_model_info(model_name):
+        raise AssertionError(f"metadata lookup should not run for invalid source: {model_name}")
+
+    monkeypatch.setattr(similarity, "load_hf_model_info", fail_model_info)
+
+    with pytest.raises(ValueError, match="directory or a ZIP archive"):
+        similarity.get_sim_list(
+            source_file,
+            feature_weights={"semantic": 1.0},
+            vector_backend="auto",
+        )
+
+
+def test_get_sim_list_rejects_embedding_count_mismatch(tmp_path, monkeypatch):
+    source_dir = tmp_path / "codes"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("print(1)", encoding="utf-8")
+    (source_dir / "b.py").write_text("print(2)", encoding="utf-8")
+
+    monkeypatch.setattr(
+        similarity,
+        "load_backend_model",
+        lambda model_name, vector_backend="auto", device="auto", similarity_function="cosine", pooling_method="mean", max_token_length=None: FakeModel(),
+    )
+    monkeypatch.setattr(
+        similarity,
+        "build_document_embeddings",
+        lambda *args, **kwargs: [np.asarray([1.0, 0.0], dtype=float)],
+    )
+
+    with pytest.raises(ValueError, match="Embedding count"):
+        similarity.get_sim_list(
+            source_dir,
+            model_name="fake",
+            feature_weights={"semantic": 1.0},
+            vector_backend="sentence_transformers",
+        )
+
+
 def test_calculate_similarity_supports_chunking(monkeypatch):
     pytest.importorskip("chonkie")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- Reject non-finite feature weights and invalid CodeBLEU component weights.
- Validate collection sources before semantic model metadata lookup.
- Raise a clear error when embedding output count does not match the input code count.

## Verification

- `python -m pytest`
- `python -m ruff check .`
- GitHub Actions passed on Python 3.10, 3.11, and 3.12.

## Linked Issues

- Closes #63
- Closes #64
- Closes #66