### PR TITLE
Escape Gradio HTML summaries

### DIFF
--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -12,6 +12,11 @@ import gradio as gr
 import pandas as pd
 from gradio_huggingfacehub_search import HuggingfaceHubSearch
 
+try:
+    from gradio_app.html_utils import escape_html
+except ModuleNotFoundError:
+    from html_utils import escape_html
+
 from matheel.chunking import available_chunk_aggregations, available_chunking_methods
 from matheel.comparison_suite import run_comparison_suite, slugify_run_name
 from matheel.code_metrics import available_code_metric_languages, available_code_metrics
@@ -293,21 +298,21 @@ def sync_codebertscore_model_settings_gradio(model_name, codebertscore_max_lengt
 
 
 def profile_status_html(message):
-    return f"<p><strong>Status:</strong> {message}</p>"
+    return f"<p><strong>Status:</strong> {escape_html(message)}</p>"
 
 
 def model_status_html(settings=None, error_message=None):
     if error_message:
-        return f"<p><strong>Model:</strong> {error_message}</p>"
+        return f"<p><strong>Model:</strong> {escape_html(error_message)}</p>"
 
     if not settings:
         return ""
 
-    backend = settings.get("resolved_vector_backend", "auto")
+    backend = escape_html(settings.get("resolved_vector_backend", "auto"))
     detected = int(settings.get("detected_max_token_length") or 0)
     configured = settings.get("configured_max_token_length")
     active = int(configured or detected or 0)
-    device = settings.get("runtime_device", "auto")
+    device = escape_html(settings.get("runtime_device", "auto"))
     return (
         f"<p><strong>Resolved:</strong> {backend} | "
         f"<strong>Detected:</strong> {detected} | "
@@ -914,7 +919,7 @@ def suite_runs_overview_html(rows):
         return "<p><strong>Configured runs:</strong> none.</p>"
 
     names = [str(value).strip() for value in frame["run_name"].tolist() if str(value).strip()]
-    preview = ", ".join(names[:4])
+    preview = ", ".join(escape_html(name) for name in names[:4])
     if len(names) > 4:
         preview = f"{preview}, +{len(names) - 4} more"
     return f"<p><strong>Configured runs:</strong> {len(names)} | {preview}</p>"
@@ -951,7 +956,7 @@ def suite_summary_html(summary):
 
     best = summary.iloc[0]
     return (
-        f"<p><strong>Best run:</strong> {best['run_name']} | "
+        f"<p><strong>Best run:</strong> {escape_html(best['run_name'])} | "
         f"<strong>Runs:</strong> {len(summary)} | "
         f"<strong>Best mean:</strong> {float(summary['mean_score'].max()):.3f} | "
         f"<strong>Best max:</strong> {float(summary['max_score'].max()):.3f}</p>"
@@ -1135,7 +1140,8 @@ def results_summary_html(results, vector_backend, code_metric, chunking_method, 
     scores = results["similarity_score"].astype(float)
     top_row = results.iloc[0]
     return (
-        f"<p><strong>Top pair:</strong> {top_row['file_name_1']} vs {top_row['file_name_2']} | "
+        f"<p><strong>Top pair:</strong> {escape_html(top_row['file_name_1'])} "
+        f"vs {escape_html(top_row['file_name_2'])} | "
         f"<strong>Pairs:</strong> {len(results)} | "
         f"<strong>Average:</strong> {scores.mean():.3f} | "
         f"<strong>Top score:</strong> {scores.max():.3f}</p>"

--- a/gradio_app/html_utils.py
+++ b/gradio_app/html_utils.py
@@ -1,0 +1,5 @@
+import html
+
+
+def escape_html(value):
+    return html.escape("" if value is None else str(value), quote=True)

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -143,6 +143,74 @@ def test_build_feature_weights_ignores_code_metric_weight_when_metric_is_inactiv
     assert weights == {"semantic": 1.0}
 
 
+def test_status_html_helpers_escape_dynamic_values():
+    profile_html = gradio_app.profile_status_html('<script>alert("x")</script>')
+
+    assert "<script>" not in profile_html
+    assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in profile_html
+
+    error_html = gradio_app.model_status_html(error_message="<img src=x>")
+
+    assert "<img" not in error_html
+    assert "&lt;img src=x&gt;" in error_html
+
+    status_html = gradio_app.model_status_html(
+        {
+            "resolved_vector_backend": "<b>semantic</b>",
+            "detected_max_token_length": 512,
+            "configured_max_token_length": 256,
+            "runtime_device": "<svg>",
+        }
+    )
+
+    assert "<b>semantic</b>" not in status_html
+    assert "&lt;b&gt;semantic&lt;/b&gt;" in status_html
+    assert "&lt;svg&gt;" in status_html
+
+
+def test_suite_html_helpers_escape_run_names():
+    rows = pd.DataFrame([{"run_name": '<img src=x onerror="alert(1)">'}])
+
+    overview_html = gradio_app.suite_runs_overview_html(rows)
+
+    assert "<img" not in overview_html
+    assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in overview_html
+
+    summary = pd.DataFrame(
+        [
+            {
+                "run_name": "<b>best</b>",
+                "mean_score": 0.8,
+                "max_score": 0.9,
+            }
+        ]
+    )
+
+    summary_html = gradio_app.suite_summary_html(summary)
+
+    assert "<b>best</b>" not in summary_html
+    assert "&lt;b&gt;best&lt;/b&gt;" in summary_html
+
+
+def test_results_summary_html_escapes_uploaded_file_names():
+    results = pd.DataFrame(
+        [
+            {
+                "file_name_1": "<b>a.py</b>",
+                "file_name_2": "<script>x</script>",
+                "similarity_score": 0.9,
+            }
+        ]
+    )
+
+    summary_html = gradio_app.results_summary_html(results, "auto", "none", "none", "cpu")
+
+    assert "<b>a.py</b>" not in summary_html
+    assert "<script>" not in summary_html
+    assert "&lt;b&gt;a.py&lt;/b&gt;" in summary_html
+    assert "&lt;script&gt;x&lt;/script&gt;" in summary_html
+
+
 def test_run_suite_export_sanitizes_detail_zip_filenames(monkeypatch):
     row = _build_suite_row(run_name="../baseline/strong")
     summary = pd.DataFrame(

--- a/tests/test_gradio_html_utils.py
+++ b/tests/test_gradio_html_utils.py
@@ -1,0 +1,11 @@
+from gradio_app.html_utils import escape_html
+
+
+def test_escape_html_escapes_markup_and_quotes():
+    assert escape_html('<img src=x onerror="alert(1)">') == (
+        "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;"
+    )
+
+
+def test_escape_html_handles_none_as_empty_text():
+    assert escape_html(None) == ""


### PR DESCRIPTION
## Summary

- Escape dynamic values rendered in Gradio HTML summaries and status text.
- Add a reusable HTML escaping helper.
- Add regression tests for markup-like names and error text.

## Verification

- `python -m pytest`
- `python -m ruff check .`
- GitHub Actions passed on Python 3.10, 3.11, and 3.12.

## Linked Issues

- Closes #65