### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Check out repository

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Matheel is a Python package and CLI for source-code similarity. It combines sema
 
 ## Installation
 
-Use Python `3.10` to `3.12`. Installation can take some time. 
+Use Python `3.10` to `3.13`. Installation can take some time.
 
 Base install:
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -55,7 +55,7 @@ python -m build
 python -m twine check dist/*
 ```
 
-- Confirm package metadata includes Python classifiers for `3.10`, `3.11`, and `3.12`.
+- Confirm package metadata includes Python classifiers for `3.10`, `3.11`, `3.12`, and `3.13`.
 
 ## GitHub Release and PyPI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Matheel: A CLI and Python package for source-code similarity detection."
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 license = "MIT"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]


### PR DESCRIPTION
## Summary

- Add Python 3.13 to package metadata and classifiers.
- Add Python 3.13 to the CI test matrix.
- Update README and release-checklist support text.

## Verification

- `python -m pytest`
- `python -m ruff check .`
- Python 3.13: `python -m pytest`
- Python 3.13: `python -m ruff check .`
- `python -m build`
- `python -m twine check dist/*`
- GitHub Actions passed on Python 3.10, 3.11, 3.12, and 3.13.

## Linked Issues

- Closes #74