### PR TITLE
Audit dependency bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ pip install matheel
 Optional extras:
 
 ```bash
+pip install "matheel[sentence_transformers]"
+pip install "matheel[semantic]"
 pip install "matheel[chunking]"
 pip install "matheel[chunking_code]"
 pip install "matheel[metrics]"
@@ -37,7 +39,9 @@ pip install "matheel[all]"
 pip install "matheel[dev]"
 ```
 
-`matheel[all]` installs the currently supported optional backends in one command: Chonkie code chunking, metrics runtime dependencies (RUBY graph/tree, TSED, CodeBERTScore), model2vec, PyLate, and the Gradio app dependencies.
+`matheel[sentence_transformers]` installs the default dense semantic backend. `matheel[semantic]` installs all semantic backends: Sentence Transformers, model2vec, and PyLate. `matheel[chunking]` installs Chonkie chunkers; `matheel[chunking_code]` additionally installs Chonkie's code auto-detection support. `matheel[all]` installs the currently supported optional backends in one command.
+
+Examples that use semantic weights assume `matheel[sentence_transformers]`, `matheel[semantic]`, or `matheel[all]` is installed.
 
 Matheel now ships a native CodeBLEU implementation that uses `tree_sitter_language_pack` for parser resolution, so real syntax/dataflow scoring no longer depends on installing the pip `codebleu` package. The pip package is still useful for validation/comparison work if you want to cross-check the native scores on selected examples; Matheel does not currently claim exact pip parity on every possible input.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,44 +33,48 @@ dependencies = [
     "numpy>=2,<3",
     "rapidfuzz>=3,<4",
     "networkx>=3,<4",
+    # 1.x currently has limited wheel coverage across the supported Python matrix.
     "tree-sitter-language-pack>=0.7,<0.8",
     "func-timeout>=4,<5",
+    # PyLate 1.4 pins sentence-transformers==5.1.1.
     "sentence-transformers>=5.1,<5.2",
     "sentencepiece>=0.2,<0.3"
 ]
 
 [project.optional-dependencies]
 chunking = [
-    "chonkie>=1.5,<1.6"
+    "chonkie>=1.5,<1.7"
 ]
 chunking_code = [
-    "chonkie[code]>=1.5,<1.6"
+    "chonkie[code]>=1.5,<1.7"
 ]
 metrics = [
     "apted>=1.0,<2",
     "bert-score>=0.3,<0.4"
 ]
 model2vec = [
-    "model2vec>=0.7,<0.8"
+    "model2vec>=0.7,<0.9"
 ]
 pylate = [
     "pylate>=1.4,<1.5"
 ]
 gradio = [
+    # gradio-huggingfacehub-search 0.0.x requires Gradio <6.
     "gradio>=5,<6",
-    "gradio-huggingfacehub-search==0.0.8"
+    "gradio-huggingfacehub-search>=0.0.8,<0.1"
 ]
 all = [
-    "chonkie[code]>=1.5,<1.6",
+    "chonkie[code]>=1.5,<1.7",
     "apted>=1.0,<2",
     "bert-score>=0.3,<0.4",
-    "model2vec>=0.7,<0.8",
+    "model2vec>=0.7,<0.9",
     "pylate>=1.4,<1.5",
+    # gradio-huggingfacehub-search 0.0.x requires Gradio <6.
     "gradio>=5,<6",
-    "gradio-huggingfacehub-search==0.0.8"
+    "gradio-huggingfacehub-search>=0.0.8,<0.1"
 ]
 dev = [
-    "pytest>=8,<9",
+    "pytest>=8,<10",
     "ruff>=0.15,<0.16",
     "build>=1,<2",
     "twine>=6,<7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,7 @@ dependencies = [
     "networkx>=3,<4",
     # 1.x currently has limited wheel coverage across the supported Python matrix.
     "tree-sitter-language-pack>=0.7,<0.8",
-    "func-timeout>=4,<5",
-    # PyLate 1.4 pins sentence-transformers==5.1.1.
-    "sentence-transformers>=5.1,<5.2",
-    "sentencepiece>=0.2,<0.3"
+    "func-timeout>=4,<5"
 ]
 
 [project.optional-dependencies]
@@ -52,13 +49,29 @@ metrics = [
     "apted>=1.0,<2",
     "bert-score>=0.3,<0.4"
 ]
+sentence_transformers = [
+    "sentence-transformers>=5.1,<5.2",
+    "sentencepiece>=0.2,<0.3"
+]
 model2vec = [
     "model2vec>=0.7,<0.9"
 ]
 pylate = [
+    # PyLate 1.4 pins sentence-transformers==5.1.1.
+    "sentence-transformers>=5.1,<5.2",
+    "sentencepiece>=0.2,<0.3",
+    "pylate>=1.4,<1.5"
+]
+semantic = [
+    # PyLate 1.4 pins sentence-transformers==5.1.1.
+    "sentence-transformers>=5.1,<5.2",
+    "sentencepiece>=0.2,<0.3",
+    "model2vec>=0.7,<0.9",
     "pylate>=1.4,<1.5"
 ]
 gradio = [
+    "sentence-transformers>=5.1,<5.2",
+    "sentencepiece>=0.2,<0.3",
     # gradio-huggingfacehub-search 0.0.x requires Gradio <6.
     "gradio>=5,<6",
     "gradio-huggingfacehub-search>=0.0.8,<0.1"
@@ -67,6 +80,9 @@ all = [
     "chonkie[code]>=1.5,<1.7",
     "apted>=1.0,<2",
     "bert-score>=0.3,<0.4",
+    # PyLate 1.4 pins sentence-transformers==5.1.1.
+    "sentence-transformers>=5.1,<5.2",
+    "sentencepiece>=0.2,<0.3",
     "model2vec>=0.7,<0.9",
     "pylate>=1.4,<1.5",
     # gradio-huggingfacehub-search 0.0.x requires Gradio <6.


### PR DESCRIPTION
## Summary

- Widen tested bounds for Chonkie, model2vec, the Gradio Hub search helper, and pytest.
- Move semantic backends behind explicit extras: `sentence_transformers`, `semantic`, `model2vec`, and `pylate`.
- Keep Sentence Transformers on 5.1.x because PyLate 1.4 requires that line.
- Keep Gradio on 5.x because the current PyPI Hub search helper requires Gradio <6.
- Keep Tree-sitter language pack on 0.7.x for current Python matrix coverage.

## Verification

- `python -m pip check` with full `matheel[all,dev]` on Python 3.10, 3.11, 3.12, and 3.13
- `python -m pytest` with full `matheel[all,dev]` on Python 3.10, 3.11, 3.12, and 3.13
- `python -m pip check` with minimal `matheel[dev]`
- `python -m pytest` with minimal `matheel[dev]`
- `python -m pip check` with `matheel[semantic,dev]`
- `python -m pytest tests/test_vectors.py tests/test_similarity.py tests/test_model_routing.py`
- Tree-sitter parser probe across all supported Matheel languages on Python 3.10 through 3.13
- Gradio 6 resolver check, still blocked by the currently published Hub search helper
- GitHub-only Gradio 6 search helper check, not adopted because it is not on PyPI and requires Python 3.12+
- `python -m ruff check .`
- `git diff --check`
- `python -m build`
- `python -m twine check dist/*`

## Linked Issues

- Closes #72
