### PR TITLE
Sync Gradio app version references

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,9 @@ jobs:
               raise SystemExit(1)
           PY
 
+      - name: Verify Gradio app version references
+        run: python scripts/sync_gradio_app_version.py --check
+
       - name: Build package
         run: python -m build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
 
+      - name: Check Gradio app version references
+        run: python scripts/sync_gradio_app_version.py --check
+
       - name: Run Ruff
         run: python -m ruff check .
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -15,6 +15,18 @@ The publish workflow is intentionally triggered by `release.published`. A tag pu
 
 - Confirm `pyproject.toml` has the intended version.
 - Confirm the release tag uses the same version with a leading `v`, for example `v0.3.6`.
+- Sync the Gradio app version references after changing the package version:
+
+```bash
+python scripts/sync_gradio_app_version.py
+```
+
+- Confirm the Gradio app README and requirements pin match `pyproject.toml`:
+
+```bash
+python scripts/sync_gradio_app_version.py --check
+```
+
 - Confirm the GitHub Release notes describe the user-visible changes.
 - Do not add release notes under `docs/releases`; keep release notes on GitHub Releases.
 - Confirm the README PyPI badges are dynamic and use the standard Shields cache:

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.3.4` and includes:
+This Space is aligned with `matheel==0.3.5` and includes:
 
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.3.4
+matheel[all]==0.3.5

--- a/scripts/sync_gradio_app_version.py
+++ b/scripts/sync_gradio_app_version.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Sync Gradio app Matheel version references from pyproject.toml."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    tomllib = None
+
+
+README_VERSION_RE = re.compile(r"`matheel==[^`]+`")
+REQUIREMENTS_VERSION_RE = re.compile(r"(?m)^matheel\[all\]==[^\s]+$")
+PROJECT_VERSION_RE = re.compile(r'(?m)^version\s*=\s*"([^"]+)"\s*$')
+
+
+def project_version(root):
+    pyproject_path = root / "pyproject.toml"
+    if tomllib is not None:
+        with pyproject_path.open("rb") as pyproject:
+            return tomllib.load(pyproject)["project"]["version"]
+
+    project_lines = []
+    in_project_section = False
+    for line in pyproject_path.read_text(encoding="utf-8").splitlines():
+        if line == "[project]":
+            in_project_section = True
+            continue
+        if in_project_section and line.startswith("["):
+            break
+        if in_project_section:
+            project_lines.append(line)
+
+    match = PROJECT_VERSION_RE.search("\n".join(project_lines))
+    if not match:
+        raise ValueError("Could not find project.version in pyproject.toml.")
+    return match.group(1)
+
+
+def replace_single(path, pattern, replacement):
+    original = path.read_text(encoding="utf-8")
+    updated, count = pattern.subn(replacement, original, count=1)
+    if count != 1:
+        raise ValueError(f"Expected exactly one Matheel version reference in {path}.")
+    return original, updated
+
+
+def planned_updates(root):
+    version = project_version(root)
+    targets = (
+        (
+            root / "gradio_app" / "README.md",
+            README_VERSION_RE,
+            f"`matheel=={version}`",
+        ),
+        (
+            root / "gradio_app" / "requirements.txt",
+            REQUIREMENTS_VERSION_RE,
+            f"matheel[all]=={version}",
+        ),
+    )
+
+    updates = []
+    for path, pattern, replacement in targets:
+        original, updated = replace_single(path, pattern, replacement)
+        if original != updated:
+            updates.append((path, updated))
+    return updates
+
+
+def sync_gradio_app_version(root, check=False):
+    updates = planned_updates(root)
+    if check:
+        if updates:
+            for path, _ in updates:
+                print(f"{path.relative_to(root)} is not synced with pyproject.toml.", file=sys.stderr)
+            return 1
+        print("Gradio app version references are synced.")
+        return 0
+
+    if not updates:
+        print("Gradio app version references are already synced.")
+        return 0
+
+    for path, updated in updates:
+        path.write_text(updated, encoding="utf-8")
+        print(f"Updated {path.relative_to(root)}.")
+    return 0
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Sync Gradio app Matheel version references from pyproject.toml."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if Gradio app version references are stale.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of the scripts directory.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    return sync_gradio_app_version(args.root.resolve(), check=args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gradio_version_sync.py
+++ b/tests/test_gradio_version_sync.py
@@ -1,0 +1,44 @@
+from scripts.sync_gradio_app_version import sync_gradio_app_version
+
+
+def write_sample_repo(root, version="1.2.3", gradio_version="0.1.0"):
+    (root / "gradio_app").mkdir()
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "matheel"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    (root / "gradio_app" / "README.md").write_text(
+        f"This Space is aligned with `matheel=={gradio_version}` and includes:\n",
+        encoding="utf-8",
+    )
+    (root / "gradio_app" / "requirements.txt").write_text(
+        f"matheel[all]=={gradio_version}\n",
+        encoding="utf-8",
+    )
+
+
+def test_sync_gradio_app_version_updates_stale_files(tmp_path):
+    write_sample_repo(tmp_path)
+
+    assert sync_gradio_app_version(tmp_path) == 0
+
+    assert "`matheel==1.2.3`" in (tmp_path / "gradio_app" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert (tmp_path / "gradio_app" / "requirements.txt").read_text(
+        encoding="utf-8"
+    ) == "matheel[all]==1.2.3\n"
+    assert sync_gradio_app_version(tmp_path, check=True) == 0
+
+
+def test_sync_gradio_app_version_check_reports_stale_files(tmp_path):
+    write_sample_repo(tmp_path)
+
+    assert sync_gradio_app_version(tmp_path, check=True) == 1
+
+    assert "`matheel==0.1.0`" in (tmp_path / "gradio_app" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assert (tmp_path / "gradio_app" / "requirements.txt").read_text(
+        encoding="utf-8"
+    ) == "matheel[all]==0.1.0\n"


### PR DESCRIPTION
## Summary

- Add `scripts/sync_gradio_app_version.py` to sync Gradio app Matheel version references from `pyproject.toml`.
- Check Gradio app version references in CI and before release publishing.
- Update the Gradio app README and requirements pin to the current package version.
- Document the sync command in the release checklist.

## Verification

- `python scripts/sync_gradio_app_version.py --check`
- `python -m pytest tests/test_gradio_version_sync.py`
- `python -m ruff check .`
- `python -m pytest`

## Linked Issues

- Closes #77
