### PR TITLE
Sync Gradio app to Hugging Face Space

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -1,0 +1,53 @@
+name: Sync Hugging Face Space
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "gradio_app/**"
+      - ".github/workflows/sync-hf-space.yml"
+  workflow_run:
+    workflows:
+      - Publish
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hf-space-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync Space files
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Verify Gradio app version references
+        run: python scripts/sync_gradio_app_version.py --check
+
+      - name: Sync Gradio app to Hugging Face Space
+        uses: huggingface/hub-sync@v0.1.0
+        with:
+          github_repo_id: ${{ github.repository }}
+          huggingface_repo_id: ${{ vars.HF_SPACE_REPO || 'buelfhood/matheel-framework' }}
+          hf_token: ${{ secrets.HF_TOKEN }}
+          repo_type: space
+          space_sdk: gradio
+          subdirectory: gradio_app

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -73,6 +73,9 @@ python -m twine check dist/*
 
 - Create and push the release tag from the merged `main` commit.
 - Publish the GitHub Release for the same tag. The publish workflow checks that the release tag matches `pyproject.toml`, builds the package, checks the metadata, and uploads to PyPI through Trusted Publishing.
+- The Hugging Face Space sync workflow runs after the publish workflow succeeds. It also runs after merged changes to `gradio_app/` on `main`.
+- Confirm the repository variable `HF_SPACE_REPO` points to the target Space if the default Space changes.
+- Confirm the `HF_TOKEN` secret is configured with write access to the target Space.
 - Mark the release as latest when it is the current stable release.
 - Confirm PyPI, GitHub Releases, repository tags, and `pyproject.toml` agree:
 
@@ -83,6 +86,7 @@ git tag --sort=-version:refname | head
 ```
 
 - Confirm the GitHub Actions publish run succeeded for the release event.
+- Confirm the GitHub Actions Space sync run succeeded for the release event.
 - Confirm PyPI shows the new version, the `Requires-Python` range, and Python version classifiers.
 - Confirm the README badges show the released PyPI version and supported Python versions after the standard Shields cache refreshes.
 


### PR DESCRIPTION
## Summary

- Add a workflow that syncs `gradio_app/` to the Hugging Face Space with the official `huggingface/hub-sync` action.
- Trigger the sync after merged Gradio app changes, after successful release publishing, and manually.
- Keep the Gradio app version check before syncing.
- Document the required `HF_TOKEN` secret and optional `HF_SPACE_REPO` variable in the release checklist.

## Verification

- Confirmed the `HF_TOKEN` Actions secret exists
- `python scripts/sync_gradio_app_version.py --check`
- `python -m pytest tests/test_gradio_version_sync.py`
- `python -m ruff check .`
- `python -m pytest`

## Linked Issues

- Closes #78
