### PR TITLE
Prepare v0.3.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/matheel.svg)](https://pypi.org/project/matheel/)
 [![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg)](https://pypi.org/project/matheel/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://fahadebrahim.github.io/matheel/)
 [![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)
 [![License](https://img.shields.io/github/license/FahadEbrahim/matheel.svg)](LICENSE)
 

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.3.5` and includes:
+This Space is aligned with `matheel==0.3.6` and includes:
 
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.3.5
+matheel[all]==0.3.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
## Summary

- Bump package metadata to `0.3.6`.
- Sync Gradio app README and requirements to `matheel==0.3.6`.
- Add a documentation badge linking to the GitHub Pages docs.

## Verification

- `python scripts/sync_gradio_app_version.py --check`
- `python -m ruff check .`
- `python -m mkdocs build --strict`
- `git diff --check`
- `python -m pip check`
- `python -m pytest`
- `python -m build`
- `python -m twine check dist/*`
- Inspected wheel metadata for version, Python classifiers, `Requires-Python`, and extras

## Linked Issues

- Closes #86
- References #71
