### PR TITLE
Fix post-release docs and Space sync

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -42,6 +42,41 @@ jobs:
       - name: Verify Gradio app version references
         run: python scripts/sync_gradio_app_version.py --check
 
+      - name: Wait for pinned Matheel release on PyPI
+        timeout-minutes: 12
+        run: |
+          python - <<'PY'
+          import re
+          import time
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          requirements = Path("gradio_app/requirements.txt").read_text(encoding="utf-8")
+          match = re.search(r"^matheel(?:\[[^\]]+\])?==([^\s;]+)", requirements, re.MULTILINE)
+          if not match:
+              raise SystemExit("No pinned matheel requirement found in gradio_app/requirements.txt.")
+
+          version = match.group(1)
+          url = f"https://pypi.org/pypi/matheel/{version}/json"
+          deadline = time.monotonic() + 10 * 60
+          delay = 30
+
+          while True:
+              try:
+                  with urllib.request.urlopen(url, timeout=10) as response:
+                      if response.status == 200:
+                          print(f"matheel {version} is available on PyPI.")
+                          break
+              except (TimeoutError, urllib.error.HTTPError, urllib.error.URLError) as exc:
+                  print(f"matheel {version} is not available on PyPI yet: {exc}")
+
+              if time.monotonic() >= deadline:
+                  raise SystemExit(f"Timed out waiting for matheel {version} on PyPI.")
+
+              time.sleep(delay)
+          PY
+
       - name: Sync Gradio app to Hugging Face Space
         uses: huggingface/hub-sync@v0.1.0
         with:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Matheel
 
 [![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
-[![PyPI](https://img.shields.io/pypi/v/matheel.svg)](https://pypi.org/project/matheel/)
-[![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg)](https://pypi.org/project/matheel/)
+[![PyPI](https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=3600)](https://pypi.org/project/matheel/)
+[![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg?cacheSeconds=3600)](https://pypi.org/project/matheel/)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://fahadebrahim.github.io/matheel/)
 [![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)
 [![License](https://img.shields.io/github/license/FahadEbrahim/matheel.svg)](LICENSE)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: Documentation for Matheel source-code similarity workflows.
 site_url: https://fahadebrahim.github.io/matheel/
 repo_url: https://github.com/FahadEbrahim/matheel
 repo_name: FahadEbrahim/matheel
+edit_uri: edit/main/docs/
 
 docs_dir: docs
 site_dir: site


### PR DESCRIPTION
## Summary

- Wait for the pinned Matheel release to exist on PyPI before syncing the Hugging Face Space.
- Fix MkDocs edit links so they point at `main/docs/...` source files.
- Refresh the README PyPI badge URLs so GitHub reloads the current package metadata.

## Verification

- `python -m mkdocs build --strict`
- `python -m ruff check .`
- `python -m pytest`
- `git diff --check`
- Parsed `.github/workflows/sync-hf-space.yml` as YAML
- Checked generated docs edit links point to `edit/main/docs/...`

## Linked Issues

- Closes #87
