### PR TITLE
Minimize README and expand usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,46 +9,21 @@
 
 Matheel is a Python package and CLI for source-code similarity. It combines semantic embeddings, lexical similarity, chunking, preprocessing, and code evaluation metrics in one workflow.
 
-## Demos
-
-- Hugging Face Space demo: [buelfhood/matheel-framework](https://huggingface.co/spaces/buelfhood/matheel-framework)
-- Gradio Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/gradio_app/matheel_gradio_colab_demo.ipynb)
-- Examples Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_examples_colab.ipynb)
-
 ## Installation
 
-Use Python `3.10` to `3.13`. Installation can take some time.
-
-Base install:
+Matheel supports Python `3.10` to `3.13`.
 
 ```bash
 pip install matheel
 ```
 
-Optional extras:
-
-```bash
-pip install "matheel[semantic]"
-pip install "matheel[chunking]"
-pip install "matheel[metrics]"
-pip install "matheel[gradio]"
-pip install "matheel[all]"
-```
-
-`matheel[semantic]` installs the supported semantic backends. `matheel[chunking]` installs Chonkie chunkers. `matheel[metrics]` installs optional code metric runtimes. `matheel[gradio]` installs the web app dependencies. `matheel[all]` installs all supported optional backends.
-
-Compatibility extras remain available for narrower installs: `sentence_transformers`, `model2vec`, `pylate`, and `chunking_code`.
-
-Examples that use semantic weights assume `matheel[semantic]` or `matheel[all]` is installed. See the [usage guide](https://fahadebrahim.github.io/matheel/usage/) for more install details.
+Optional semantic, chunking, metrics, and Gradio extras are covered in the [usage guide](https://fahadebrahim.github.io/matheel/usage/#installation).
 
 ## Quick Start
 
 ```bash
 matheel compare sample_pairs.zip \
-  --model huggingface/CodeBERTa-small-v1 \
-  --feature-weight semantic=0.7 \
-  --feature-weight levenshtein=0.3 \
-  --threshold 0.2 \
+  --feature-weight levenshtein=1.0 \
   --num 10
 ```
 
@@ -63,26 +38,20 @@ score = calculate_similarity(
 print(round(score, 4))
 ```
 
-See the [usage guide](https://fahadebrahim.github.io/matheel/usage/) for archive, suite, chunking, embedding, and code-metric examples.
+See the [usage guide](https://fahadebrahim.github.io/matheel/usage/) for semantic models, archives, comparison suites, chunking, preprocessing, and code metrics.
 
-## Docs
+## Links
 
-- Published docs: [fahadebrahim.github.io/matheel](https://fahadebrahim.github.io/matheel/)
-- Source docs: [docs/index.md](docs/index.md)
-- Usage guide: [docs/usage.md](docs/usage.md)
-- Development: [docs/development.md](docs/development.md)
+- Documentation: [fahadebrahim.github.io/matheel](https://fahadebrahim.github.io/matheel/)
+- Hugging Face Space demo: [buelfhood/matheel-framework](https://huggingface.co/spaces/buelfhood/matheel-framework)
+- Gradio Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/gradio_app/matheel_gradio_colab_demo.ipynb)
+- Examples Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_examples_colab.ipynb)
+- Examples folder: [examples/](https://github.com/FahadEbrahim/matheel/tree/main/examples)
+- Development: [development docs](https://fahadebrahim.github.io/matheel/development/)
 
 ## Development
 
-Install Matheel in editable mode with the development tools, then run the default checks:
-
-```bash
-python -m pip install -e ".[dev]"
-python -m pytest
-python -m ruff check .
-```
-
-More development and release checks are in the [development docs](docs/development.md).
+Contributor setup, tests, linting, package checks, and release preparation are documented in the [development docs](https://fahadebrahim.github.io/matheel/development/).
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The published site is <https://fahadebrahim.github.io/matheel/>.
 ## Start Here
 
 - [Documentation index](index.md)
-- [Quick usage](usage.md)
+- [Usage](usage.md)
 - [Preprocessing](preprocessing.md)
 - [Chunking](chunking.md)
 - [Vectors and routing](vectors.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Matheel Documentation
 
-Use this page as the main Matheel docs index.
+Matheel is a Python package and CLI for source-code similarity. It combines semantic embeddings, lexical similarity, chunking, preprocessing, and code evaluation metrics in one workflow.
 
 Matheel is organized around a simple flow:
 
@@ -10,9 +10,11 @@ Matheel is organized around a simple flow:
 4. add code-aware metrics when needed
 5. compare one pair or rank a whole archive
 
+Start with the [usage guide](usage.md) for installation, optional extras, quick checks, demos, and example links.
+
 ## Guides
 
-- [Quick usage](usage.md)
+- [Usage](usage.md)
 - [Preprocessing](preprocessing.md)
 - [Chunking](chunking.md)
 - [Vectors and routing](vectors.md)
@@ -24,13 +26,14 @@ Matheel is organized around a simple flow:
 
 ## Demos and Examples
 
-- [Repository demos](https://github.com/FahadEbrahim/matheel#demos)
+- [Hugging Face Space demo](https://huggingface.co/spaces/buelfhood/matheel-framework)
+- [Gradio Colab notebook](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/gradio_app/matheel_gradio_colab_demo.ipynb)
 - [Examples Colab notebook](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_examples_colab.ipynb)
 - [Examples folder](https://github.com/FahadEbrahim/matheel/tree/main/examples)
 
 ## Suggested Reading Order
 
-1. Start with [Quick usage](usage.md).
+1. Start with [Usage](usage.md).
 2. Read [Vectors and routing](vectors.md) to choose the embedding path.
 3. Add [Chunking](chunking.md) and [Preprocessing](preprocessing.md) if you need code-aware shaping before scoring.
 4. Add [Lexical metrics and baselines](lexical.md) and [Code metrics](code_metrics.md) if you want hybrid scoring.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,8 +1,10 @@
 # Usage Guide
 
-This page is the quick-start entry point. The detailed parameter guides live in the topic pages linked below.
+This page is the quick-start entry point for installing Matheel and running the main CLI and Python workflows. Detailed parameter guides live in the topic pages linked below.
 
-## Install
+## Installation
+
+Matheel supports Python `3.10` to `3.13`.
 
 Base install:
 
@@ -10,7 +12,7 @@ Base install:
 pip install matheel
 ```
 
-Recommended optional installs:
+The base package includes the CLI, preprocessing, lexical similarity, and the core comparison workflow. Install optional extras when you need larger semantic backends, chunkers, metric runtimes, or the Gradio app:
 
 ```bash
 pip install "matheel[semantic]"
@@ -20,15 +22,44 @@ pip install "matheel[gradio]"
 pip install "matheel[all]"
 ```
 
-`matheel[semantic]` installs the supported semantic backends. `matheel[chunking]` installs Chonkie chunkers. `matheel[metrics]` installs optional code metric runtimes. `matheel[gradio]` installs the web app dependencies. `matheel[all]` installs all supported optional backends.
+| Extra | Use it for |
+| --- | --- |
+| `matheel[semantic]` | Sentence Transformers, Model2Vec, and PyLate semantic scoring backends. |
+| `matheel[chunking]` | Chonkie chunkers for splitting code before embedding. |
+| `matheel[metrics]` | Optional code metric runtimes such as TSED and CodeBERTScore. |
+| `matheel[gradio]` | Dependencies for running the Gradio web app. |
+| `matheel[all]` | All supported optional backends in one install. |
 
 Compatibility extras remain available for narrower installs: `sentence_transformers`, `model2vec`, `pylate`, and `chunking_code`.
 
-## Quick Check
+Examples that use semantic weights assume `matheel[semantic]` or `matheel[all]` is installed. Optional installs can take some time because they may include model and ML runtime dependencies.
+
+## Quick Checks
 
 The repository root includes `sample_pairs.zip`, a small Java archive you can use immediately.
 
-CLI:
+Base CLI check:
+
+```bash
+matheel compare sample_pairs.zip \
+  --feature-weight levenshtein=1.0 \
+  --num 10
+```
+
+Base Python check:
+
+```python
+from matheel.similarity import calculate_similarity
+
+score = calculate_similarity(
+    "def add(a, b):\n    return a + b\n",
+    "def add(x, y):\n    return x + y\n",
+    feature_weights={"levenshtein": 1.0},
+)
+print(round(score, 4))
+```
+
+Semantic CLI check:
 
 ```bash
 matheel compare sample_pairs.zip \
@@ -37,7 +68,7 @@ matheel compare sample_pairs.zip \
   --feature-weight levenshtein=0.3
 ```
 
-Python:
+Semantic Python check:
 
 ```python
 from matheel.similarity import get_sim_list
@@ -50,15 +81,31 @@ results = get_sim_list(
 print(results.head())
 ```
 
+## Common Workflows
+
+- Use a ZIP archive or a directory path with `matheel compare`.
+- Use `feature_weights` to combine semantic, lexical, and code-aware scores.
+- Add `--preprocess-mode` when code should be normalized before scoring.
+- Add `--chunking-method` when large files should be split before embedding.
+- Use `matheel compare-suite` with a JSON config for repeatable multi-run comparisons.
+- Run the Gradio app or notebooks when you want an interactive workflow.
+
+## Demos and Examples
+
+- Hugging Face Space demo: [buelfhood/matheel-framework](https://huggingface.co/spaces/buelfhood/matheel-framework)
+- Gradio Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/gradio_app/matheel_gradio_colab_demo.ipynb)
+- Examples Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_examples_colab.ipynb)
+- Examples folder: [github.com/FahadEbrahim/matheel/tree/main/examples](https://github.com/FahadEbrahim/matheel/tree/main/examples)
+
 ## Documentation Map
 
-- [docs/index.md](index.md)
-- [docs/preprocessing.md](preprocessing.md)
-- [docs/chunking.md](chunking.md)
-- [docs/vectors.md](vectors.md)
-- [docs/lexical.md](lexical.md)
-- [docs/code_metrics.md](code_metrics.md)
-- [docs/comparison_suite.md](comparison_suite.md)
+- [Preprocessing](preprocessing.md)
+- [Chunking](chunking.md)
+- [Vectors and routing](vectors.md)
+- [Lexical metrics and baselines](lexical.md)
+- [Code metrics](code_metrics.md)
+- [Comparison suite](comparison_suite.md)
+- [Development](development.md)
 
 ## Interface Notes
 


### PR DESCRIPTION
## Summary

- Slim the README to project essentials, base install, minimal quick start, and links.
- Move installation extras, semantic quick checks, workflow notes, demos, and examples into the usage docs.
- Refresh the docs index labels and demo links.

## Checks

- git diff --check
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict

Closes #89