### PR TITLE
Make preprocessing comment stripping string-aware

### DIFF
--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -5,6 +5,7 @@ Preprocessing modifies code text before lexical, semantic, or code-aware scoring
 ## Parameter
 
 - `preprocess_mode`
+- `code_language` in comparison APIs, or `language` when calling `preprocess_code(...)` directly
 
 ## Supported Modes
 
@@ -19,10 +20,11 @@ Preprocessing modifies code text before lexical, semantic, or code-aware scoring
 
 ## What It Changes
 
-- `/* ... */` block comments are removed.
-- `// ...` line comments are removed.
-- Lua `--[[ ... ]]` block comments and `-- ...` line comments are removed.
-- `# ...` comments are removed, except common C/C++/C# preprocessor directives such as `#include`, `#define`, `#region`, and `#nullable`.
+- `/* ... */` block comments are removed for C-like languages.
+- `// ...` line comments are removed for C-like languages.
+- Lua `--[[ ... ]]` block comments and `-- ...` line comments are removed for Lua.
+- `# ...` comments are removed for the generic path and non-Lua language hints, except common C/C++/C# preprocessor directives such as `#include`, `#define`, `#region`, and `#nullable`.
+- Comment markers inside quoted string literals are preserved.
 - Import-like lines (`import`, `from ... import`, `package`, `#include`, `#import`, `using`, `use`, `require`, `include`, `library(...)`, `source(...)`, and Node/Lua-style `require(...)` assignments) are stripped in `advanced`.
 - String and numeric literals are normalized to placeholders in `advanced`.
 - Non-keyword identifiers are canonicalized (`id1`, `id2`, ...) in `advanced`.
@@ -73,6 +75,7 @@ cleaned = preprocess_code(
         return a + b
     """,
     mode="basic",
+    language="python",
 )
 print(cleaned)
 ```
@@ -81,5 +84,6 @@ print(cleaned)
 
 ```bash
 matheel compare sample_pairs.zip \
-  --preprocess-mode basic
+  --preprocess-mode basic \
+  --code-language java
 ```

--- a/matheel/preprocessing.py
+++ b/matheel/preprocessing.py
@@ -1,12 +1,7 @@
 import re
 
 
-_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
-_LUA_BLOCK_COMMENT_RE = re.compile(r"--\[\[.*?\]\]", re.DOTALL)
-_INLINE_HASH_COMMENT_RE = re.compile(r"\s#.*$")
-_INLINE_SLASH_COMMENT_RE = re.compile(r"//.*$")
-_INLINE_LUA_COMMENT_RE = re.compile(r"--.*$")
-_STRING_LITERAL_RE = re.compile(r'"(?:\\.|[^"\\])*"|\'(?:\\.|[^\'\\])*\'')
+_STRING_LITERAL_RE = re.compile(r"`(?:\\.|[^`\\])*`|\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'")
 _NUMBER_LITERAL_RE = re.compile(r"\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b")
 _TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*|<STR>|<NUM>|[^\w\s]")
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -294,6 +289,38 @@ _SUPPORTED_PREPROCESS_LANGUAGES = (
     "r",
     "objc",
 )
+_PREPROCESS_LANGUAGE_ALIASES = {
+    "c++": "cpp",
+    "c#": "csharp",
+    "cs": "csharp",
+    "js": "javascript",
+    "objective-c": "objc",
+    "objectivec": "objc",
+    "py": "python",
+    "ts": "typescript",
+}
+_SLASH_LINE_COMMENT_LANGUAGES = {
+    "c",
+    "cpp",
+    "csharp",
+    "dart",
+    "go",
+    "java",
+    "javascript",
+    "kotlin",
+    "objc",
+    "php",
+    "rust",
+    "scala",
+    "solidity",
+    "swift",
+    "typescript",
+}
+_LUA_LINE_COMMENT_LANGUAGES = {"lua"}
+_SLASH_BLOCK_COMMENT_LANGUAGES = _SLASH_LINE_COMMENT_LANGUAGES
+_LUA_BLOCK_COMMENT_LANGUAGES = {"lua"}
+_GENERIC_LINE_COMMENT_MARKERS = ("//", "#")
+_GENERIC_BLOCK_COMMENT_MARKERS = (("/*", "*/"), ("--[[", "]]"))
 
 
 def available_preprocess_modes():
@@ -302,6 +329,11 @@ def available_preprocess_modes():
 
 def available_preprocess_languages():
     return _SUPPORTED_PREPROCESS_LANGUAGES
+
+
+def normalize_preprocess_language(language):
+    key = (language or "").strip().lower().replace("_", "-")
+    return _PREPROCESS_LANGUAGE_ALIASES.get(key, key)
 
 
 def normalize_newlines(text):
@@ -318,29 +350,142 @@ def drop_blank_lines(text):
     return "\n".join(lines)
 
 
-def strip_block_comments(text):
-    value = _BLOCK_COMMENT_RE.sub(" ", normalize_newlines(text))
-    return _LUA_BLOCK_COMMENT_RE.sub(" ", value)
+def _block_comment_markers(language=None):
+    normalized_language = normalize_preprocess_language(language)
+    if not normalized_language:
+        return _GENERIC_BLOCK_COMMENT_MARKERS
+
+    markers = []
+    if normalized_language in _SLASH_BLOCK_COMMENT_LANGUAGES:
+        markers.append(("/*", "*/"))
+    if normalized_language in _LUA_BLOCK_COMMENT_LANGUAGES:
+        markers.append(("--[[", "]]"))
+    if normalized_language not in _SUPPORTED_PREPROCESS_LANGUAGES:
+        markers.extend(_GENERIC_BLOCK_COMMENT_MARKERS)
+    return tuple(markers)
 
 
-def _strip_hash_comment(line):
-    stripped = line.lstrip()
-    if stripped.startswith(_HASH_DIRECTIVES):
+def _line_comment_markers(language=None):
+    normalized_language = normalize_preprocess_language(language)
+    if not normalized_language:
+        return _GENERIC_LINE_COMMENT_MARKERS
+
+    markers = [] if normalized_language in _LUA_LINE_COMMENT_LANGUAGES else ["#"]
+    if normalized_language in _SLASH_LINE_COMMENT_LANGUAGES:
+        markers.append("//")
+    if normalized_language in _LUA_LINE_COMMENT_LANGUAGES:
+        markers.append("--")
+    if normalized_language not in _SUPPORTED_PREPROCESS_LANGUAGES:
+        for marker in _GENERIC_LINE_COMMENT_MARKERS:
+            if marker not in markers:
+                markers.append(marker)
+    return tuple(markers)
+
+
+def _strip_block_comments_with_markers(text, markers):
+    value = normalize_newlines(text)
+    if not markers:
+        return value
+
+    cleaned = []
+    index = 0
+    quote = None
+    escaped = False
+    block_end = None
+
+    while index < len(value):
+        if block_end:
+            if value.startswith(block_end, index):
+                cleaned.append(" ")
+                index += len(block_end)
+                block_end = None
+                continue
+            if value[index] == "\n":
+                cleaned.append("\n")
+            index += 1
+            continue
+
+        char = value[index]
+        if quote:
+            cleaned.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\" and quote != "`":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+
+        if char in ("'", '"', "`"):
+            quote = char
+            cleaned.append(char)
+            index += 1
+            continue
+
+        matched = False
+        for start_marker, end_marker in markers:
+            if value.startswith(start_marker, index):
+                cleaned.append(" ")
+                index += len(start_marker)
+                block_end = end_marker
+                matched = True
+                break
+        if matched:
+            continue
+
+        cleaned.append(char)
+        index += 1
+
+    return "".join(cleaned)
+
+
+def strip_block_comments(text, language=None):
+    return _strip_block_comments_with_markers(text, _block_comment_markers(language))
+
+
+def _strip_line_comment_with_markers(line, markers):
+    if not markers:
         return line
-    if stripped.startswith("#"):
+    if "#" in markers and line.lstrip().startswith(_HASH_DIRECTIVES):
+        return line
+    if "#" in markers and line.lstrip().startswith("#"):
         return ""
-    if _INLINE_HASH_COMMENT_RE.search(line):
-        return _INLINE_HASH_COMMENT_RE.sub("", line).rstrip()
+
+    index = 0
+    quote = None
+    escaped = False
+
+    while index < len(line):
+        char = line[index]
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\" and quote != "`":
+                escaped = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+
+        if char in ("'", '"', "`"):
+            quote = char
+            index += 1
+            continue
+
+        for marker in markers:
+            if line.startswith(marker, index):
+                return line[:index].rstrip()
+        index += 1
+
     return line
 
 
-def strip_line_comments(text):
+def strip_line_comments(text, language=None):
+    markers = _line_comment_markers(language)
     cleaned_lines = []
     for line in normalize_newlines(text).split("\n"):
-        current = _INLINE_SLASH_COMMENT_RE.sub("", line).rstrip()
-        current = _INLINE_LUA_COMMENT_RE.sub("", current).rstrip()
-        current = _strip_hash_comment(current)
-        cleaned_lines.append(current)
+        cleaned_lines.append(_strip_line_comment_with_markers(line, markers).rstrip())
     return "\n".join(cleaned_lines)
 
 
@@ -394,7 +539,7 @@ def canonicalize_identifiers(text):
     return " ".join(normalized)
 
 
-def preprocess_code(text, mode="none"):
+def preprocess_code(text, mode="none", language=None):
     selected_mode = (mode or "none").strip().lower()
     value = trim_trailing_whitespace(text)
 
@@ -405,14 +550,14 @@ def preprocess_code(text, mode="none"):
         return drop_blank_lines(value).strip()
 
     if selected_mode == "basic":
-        value = strip_block_comments(value)
-        value = strip_line_comments(value)
+        value = strip_block_comments(value, language=language)
+        value = strip_line_comments(value, language=language)
         value = drop_blank_lines(value)
         return collapse_whitespace(value)
 
     if selected_mode == "advanced":
-        value = strip_block_comments(value)
-        value = strip_line_comments(value)
+        value = strip_block_comments(value, language=language)
+        value = strip_line_comments(value, language=language)
         value = strip_import_like_lines(value)
         value = drop_blank_lines(value)
         value = normalize_literal_placeholders(value)

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -367,8 +367,8 @@ def aggregate_chunk_embeddings(chunk_embeddings, chunk_aggregation="mean"):
     return vectors.mean(axis=0)
 
 
-def prepare_code(code, preprocess_mode="none"):
-    return preprocess_code(code, mode=preprocess_mode)
+def prepare_code(code, preprocess_mode="none", code_language=None):
+    return preprocess_code(code, mode=preprocess_mode, language=code_language)
 
 
 def _should_use_chunking(chunking_method):
@@ -915,7 +915,10 @@ def get_sim_list(
     )
     selected_similarity = normalize_similarity_function_name(similarity_function)
     selected_pooling = normalize_pooling_method_name(pooling_method)
-    codes = [prepare_code(code, preprocess_mode=preprocess_mode) for code in raw_codes]
+    codes = [
+        prepare_code(code, preprocess_mode=preprocess_mode, code_language=code_language)
+        for code in raw_codes
+    ]
     if use_semantic:
         model = load_backend_model(
             model_name,
@@ -1133,8 +1136,16 @@ def calculate_similarity(
     )
     selected_similarity = normalize_similarity_function_name(similarity_function)
     selected_pooling = normalize_pooling_method_name(pooling_method)
-    prepared_code1 = prepare_code(code1, preprocess_mode=preprocess_mode)
-    prepared_code2 = prepare_code(code2, preprocess_mode=preprocess_mode)
+    prepared_code1 = prepare_code(
+        code1,
+        preprocess_mode=preprocess_mode,
+        code_language=code_language,
+    )
+    prepared_code2 = prepare_code(
+        code2,
+        preprocess_mode=preprocess_mode,
+        code_language=code_language,
+    )
     if use_semantic:
         model = load_backend_model(
             model_name,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -469,7 +469,7 @@ def test_basic_preprocess_removes_comments_and_collapses_whitespace():
 
 @pytest.mark.parametrize("language,code,expected", BASIC_LANGUAGE_CASES)
 def test_basic_preprocess_supports_scoped_languages(language, code, expected):
-    processed = preprocess_code(code, mode="basic")
+    processed = preprocess_code(code, mode="basic", language=language)
 
     assert processed == expected
 
@@ -533,7 +533,7 @@ def test_normalize_preprocess_drops_blank_lines_only():
 
 @pytest.mark.parametrize("language,code,blocked_phrases", ADVANCED_LANGUAGE_CASES)
 def test_advanced_preprocess_supports_scoped_languages(language, code, blocked_phrases):
-    processed = preprocess_code(code, mode="advanced")
+    processed = preprocess_code(code, mode="advanced", language=language)
 
     for phrase in blocked_phrases:
         assert phrase not in processed
@@ -541,6 +541,63 @@ def test_advanced_preprocess_supports_scoped_languages(language, code, blocked_p
     assert "<NUM>" in processed
     assert "return" in processed
     assert "id1" in processed
+
+
+@pytest.mark.parametrize("language", ("java", "javascript", "rust"))
+def test_basic_preprocess_preserves_decrement_syntax_for_non_lua_languages(language):
+    code = """
+    int value = counter--;
+    int next = value;
+    """
+
+    processed = preprocess_code(code, mode="basic", language=language)
+
+    assert processed == "int value = counter--; int next = value;"
+
+
+def test_basic_preprocess_strips_lua_double_hyphen_comments():
+    code = """
+    local value = 1 -- trailing note
+    local next = value
+    """
+
+    processed = preprocess_code(code, mode="basic", language="lua")
+
+    assert processed == "local value = 1 local next = value"
+
+
+def test_basic_preprocess_preserves_slashes_inside_string_literals():
+    code = """
+    String url = "https://example.com/path";
+    int value = 1; // trailing note
+    """
+
+    processed = preprocess_code(code, mode="basic", language="java")
+
+    assert processed == 'String url = "https://example.com/path"; int value = 1;'
+
+
+def test_advanced_preprocess_normalizes_string_with_slashes_before_stripping_comment():
+    code = """
+    String url = "https://example.com/path";
+    return url; // trailing note
+    """
+
+    processed = preprocess_code(code, mode="advanced", language="java")
+
+    assert "<STR>" in processed
+    assert "example" not in processed
+    assert "trailing" not in processed
+
+
+def test_basic_preprocess_preserves_python_floor_division():
+    code = """
+    value = total // count  # average
+    """
+
+    processed = preprocess_code(code, mode="basic", language="python")
+
+    assert processed == "value = total // count"
 
 
 def test_advanced_preprocess_strips_imports_literals_and_identifiers():


### PR DESCRIPTION
## Summary

- Replace regex-based comment stripping with string-aware scanners for block and line comments.
- Scope Lua double-hyphen comments to Lua while preserving decrement syntax in other languages.
- Route comparison preprocessing through the existing code_language option and document the language hint.
- Add regressions for decrement syntax, double-slash inside strings, Lua comments, and Python floor division.

## Checks

- git diff --check
- python -m pytest tests/test_preprocessing.py tests/test_similarity.py
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict

Closes #32