### PR TITLE
Add progress reporting for comparisons

### DIFF
--- a/docs/comparison_suite.md
+++ b/docs/comparison_suite.md
@@ -85,6 +85,10 @@ One row per run, including:
   Writes one CSV per run with the detailed ranked pairs.
 - `output_format`
   `csv` or `json` for the summary file.
+- `progress`
+  Enables tqdm progress bars when set to `True`.
+- `progress_callback`
+  Receives structured progress event dictionaries for run-level and pair-level work.
 - Numeric score fields are rounded to 4 decimal places in suite output artifacts.
 
 ## Python Example
@@ -116,7 +120,7 @@ runs = [
     },
 ]
 
-summary, details = run_comparison_suite("sample_pairs.zip", runs)
+summary, details = run_comparison_suite("sample_pairs.zip", runs, progress=True)
 print(summary)
 print(details["dense_baseline"].head())
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,3 +113,5 @@ print(results.head())
 - Gradio remains ZIP-only for uploads.
 - `feature_weights` is the canonical scoring input.
 - `vector_backend=auto` uses Hugging Face metadata and tag heuristics when available.
+- CLI progress bars write to stderr and default to interactive terminals only. Use `--progress` or `--no-progress` to override.
+- Python APIs accept `progress=True` for tqdm bars and `progress_callback=...` for structured progress events.

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -67,6 +67,24 @@ FEATURE_UI_CHOICES = [
     "Code Metric",
 ]
 DEFAULT_FEATURE_SELECTION = ["Embedding", "Levenshtein"]
+
+
+def gradio_progress_callback(progress):
+    if progress is None:
+        return None
+
+    def callback(event):
+        total = max(1, int(event.get("total") or 1))
+        current = min(total, max(0, int(event.get("current") or 0)))
+        description = event.get("message") or event.get("stage") or "Working"
+        try:
+            progress(current / total, desc=str(description))
+        except Exception:
+            return
+
+    return callback
+
+
 SUITE_FEATURE_NAME_MAP = {
     "Embedding": "embedding",
     "Levenshtein": "levenshtein",
@@ -1012,6 +1030,7 @@ def run_suite_gradio(
     chunker_options,
     threshold,
     number_results,
+    progress=gr.Progress(track_tqdm=True),
 ):
     saved_frame = normalize_suite_rows_frame(run_sheet_rows)
     if zipped_file is None:
@@ -1092,6 +1111,7 @@ def run_suite_gradio(
         summary_out=summary_export_path,
         details_dir=details_dir,
         output_format=output_format,
+        progress_callback=gradio_progress_callback(progress),
     )
     details_store = {
         run_name: frame.to_dict(orient="records")
@@ -1188,6 +1208,7 @@ def calculate_similarity_gradio(
     chunk_aggregation,
     chunk_language,
     chunker_options,
+    progress=gr.Progress(track_tqdm=True),
 ):
     selected = set(selected_features or [])
     selected_steps = set(selected_preparation or [])
@@ -1279,6 +1300,7 @@ def calculate_similarity_gradio(
         pooling_method=pooling_method,
         max_token_length=max_token_length,
         device=runtime_device,
+        progress_callback=gradio_progress_callback(progress),
         **metric_kwargs,
     )
     return score_card_html(
@@ -1330,6 +1352,7 @@ def get_sim_list_gradio(
     chunker_options,
     threshold,
     number_results,
+    progress=gr.Progress(track_tqdm=True),
 ):
     if zipped_file is None:
         return empty_summary_html(), pd.DataFrame(columns=["file_name_1", "file_name_2", "similarity_score"])
@@ -1425,6 +1448,7 @@ def get_sim_list_gradio(
         pooling_method=pooling_method,
         max_token_length=max_token_length,
         device=runtime_device,
+        progress_callback=gradio_progress_callback(progress),
         **metric_kwargs,
     )
     return results_summary_html(

--- a/matheel/_progress.py
+++ b/matheel/_progress.py
@@ -1,0 +1,71 @@
+import sys
+
+
+def should_show_progress(progress, stream=None):
+    if progress is None:
+        output_stream = stream or sys.stderr
+        return bool(getattr(output_stream, "isatty", lambda: False)())
+    return bool(progress)
+
+
+def emit_progress(progress_callback, stage, current, total, message=None):
+    if progress_callback is None:
+        return
+    event = {
+        "stage": str(stage),
+        "current": int(current),
+        "total": int(total),
+    }
+    if message:
+        event["message"] = str(message)
+    progress_callback(event)
+
+
+def progress_iter(
+    iterable,
+    *,
+    total=None,
+    desc=None,
+    unit="item",
+    progress=False,
+    progress_callback=None,
+    stage=None,
+):
+    progress_stage = stage or desc or "progress"
+    progress_total = _resolve_total(iterable, total)
+    emit_progress(progress_callback, progress_stage, 0, progress_total, message=desc)
+
+    wrapped = iterable
+    progress_bar = None
+    if progress:
+        try:
+            from tqdm import tqdm
+        except ImportError:
+            tqdm = None
+        if tqdm is not None:
+            progress_bar = tqdm(
+                iterable,
+                total=progress_total,
+                desc=desc,
+                unit=unit,
+                leave=False,
+                file=sys.stderr,
+            )
+            wrapped = progress_bar
+
+    try:
+        for index, item in enumerate(wrapped, start=1):
+            yield item
+            emit_progress(progress_callback, progress_stage, index, progress_total, message=desc)
+    finally:
+        if progress_bar is not None:
+            progress_bar.close()
+
+
+def _resolve_total(iterable, total):
+    if total is not None:
+        return max(0, int(total))
+    try:
+        return max(0, len(iterable))
+    except TypeError:
+        return 0

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -1,6 +1,10 @@
+import sys
+
 import click
+
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
+from ._progress import should_show_progress
 from .similarity import DEFAULT_MODEL_NAME, available_runtime_devices, get_sim_list
 from .chunking import available_chunk_aggregations, available_chunking_methods
 from .model_routing import available_vector_backends
@@ -167,6 +171,11 @@ def main():
 )
 @click.option('--threshold', default=0.0, help='Similarity Threshold')
 @click.option('--num', default=10, help='Number of Results to Display')
+@click.option(
+    '--progress/--no-progress',
+    default=None,
+    help='Show progress bars on stderr. Defaults to auto for interactive terminals.',
+)
 def compare(
     source_path,
     feature_weights,
@@ -226,6 +235,7 @@ def compare(
     device,
     threshold,
     num,
+    progress,
 ):
     """Bulk similarity from a ZIP archive or a directory."""
     results = get_sim_list(
@@ -287,6 +297,7 @@ def compare(
         max_token_length=max_token_length,
         pooling_method=pooling_method,
         device=device,
+        progress=should_show_progress(progress, stream=sys.stderr),
     )
     click.echo(results.to_string(index=False))
 
@@ -316,7 +327,12 @@ def compare(
     show_default=True,
     help="Summary file format.",
 )
-def compare_suite(source_path, config_file, summary_out, details_dir, output_format):
+@click.option(
+    "--progress/--no-progress",
+    default=None,
+    help="Show progress bars on stderr. Defaults to auto for interactive terminals.",
+)
+def compare_suite(source_path, config_file, summary_out, details_dir, output_format, progress):
     """Run multiple similarity configurations from a JSON config file."""
     run_configs = load_run_configs(config_file)
     summary, _ = run_comparison_suite(
@@ -325,6 +341,7 @@ def compare_suite(source_path, config_file, summary_out, details_dir, output_for
         summary_out=summary_out,
         details_dir=details_dir,
         output_format=output_format,
+        progress=should_show_progress(progress, stream=sys.stderr),
     )
     if summary.empty:
         click.echo("No runs were executed.")

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from .feature_weights import default_feature_weights, parse_feature_weights
+from ._progress import progress_iter
 from .similarity import DEFAULT_MODEL_NAME, get_sim_list
 
 
@@ -164,15 +165,34 @@ def run_comparison_suite(
     summary_out=None,
     details_dir=None,
     output_format="csv",
+    progress=False,
+    progress_callback=None,
 ):
     normalized_runs = [normalize_run_config(config, index=index) for index, config in enumerate(run_configs, start=1)]
     summary_rows = []
     result_frames = {}
 
-    for run in normalized_runs:
+    run_iter = progress_iter(
+        normalized_runs,
+        total=len(normalized_runs),
+        desc="Run comparison suite",
+        unit="run",
+        progress=progress,
+        progress_callback=progress_callback,
+        stage="suite_runs",
+    )
+    for run in run_iter:
         run_name = run["run_name"]
         options = dict(run["options"])
-        results = _rounded_score_frame(get_sim_list(zipped_file, **options))
+        run_options = dict(options)
+        run_options.setdefault("progress", progress)
+        run_options.setdefault("progress_callback", _run_progress_callback(progress_callback, run_name))
+        results = _rounded_score_frame(
+            get_sim_list(
+                zipped_file,
+                **run_options,
+            )
+        )
         result_frames[run_name] = results
         write_run_details(run_name, results, details_dir=details_dir)
         summary_rows.append(summary_row_from_results(run_name, options, results))
@@ -185,3 +205,15 @@ def run_comparison_suite(
         write_summary(summary, summary_out, output_format=output_format)
 
     return summary, result_frames
+
+
+def _run_progress_callback(progress_callback, run_name):
+    if progress_callback is None:
+        return None
+
+    def callback(event):
+        payload = dict(event)
+        payload["run_name"] = run_name
+        progress_callback(payload)
+
+    return callback

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -22,6 +22,7 @@ from .model_routing import (
     load_hf_model_info,
     resolve_vector_backend,
 )
+from ._progress import emit_progress, progress_iter
 from .preprocessing import preprocess_code
 from .vectors import (
     build_multivector_embeddings,
@@ -748,13 +749,25 @@ def rank_code_pairs(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    progress=False,
+    progress_callback=None,
 ):
     validate_embedding_count(embeddings, len(codes))
     results = []
     code_metric_name = (code_metric or "none").strip().lower()
     use_code_metric = code_metric_name not in ("none", "") and feature_weights.get("code_metric", 0.0) > 0.0
+    pair_count = len(codes) * (len(codes) - 1) // 2
 
-    for i, j in combinations(range(len(codes)), 2):
+    pair_iter = progress_iter(
+        combinations(range(len(codes)), 2),
+        total=pair_count,
+        desc="Compare pairs",
+        unit="pair",
+        progress=progress,
+        progress_callback=progress_callback,
+        stage="compare_pairs",
+    )
+    for i, j in pair_iter:
         code_metric_score = 0.0
         if use_code_metric:
             code_metric_score = score_code_metric_pair(
@@ -883,6 +896,8 @@ def get_sim_list(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    progress=False,
+    progress_callback=None,
 ):
     code_metric_weight, component_weights = validate_code_metric_options(
         code_metric_weight,
@@ -915,11 +930,21 @@ def get_sim_list(
     )
     selected_similarity = normalize_similarity_function_name(similarity_function)
     selected_pooling = normalize_pooling_method_name(pooling_method)
+    source_iter = progress_iter(
+        raw_codes,
+        total=len(raw_codes),
+        desc="Prepare files",
+        unit="file",
+        progress=progress,
+        progress_callback=progress_callback,
+        stage="prepare_files",
+    )
     codes = [
         prepare_code(code, preprocess_mode=preprocess_mode, code_language=code_language)
-        for code in raw_codes
+        for code in source_iter
     ]
     if use_semantic:
+        emit_progress(progress_callback, "build_embeddings", 0, 1, message="Build embeddings")
         model = load_backend_model(
             model_name,
             vector_backend=vector_backend,
@@ -943,6 +968,7 @@ def get_sim_list(
             static_vector_lowercase=static_vector_lowercase,
             pooling_method=selected_pooling,
         )
+        emit_progress(progress_callback, "build_embeddings", 1, 1, message="Build embeddings")
     else:
         embeddings = [None] * len(codes)
     code_metric_name = (code_metric or "none").strip().lower()
@@ -1028,6 +1054,8 @@ def get_sim_list(
         winnowing_kgram=winnowing_kgram,
         winnowing_window=winnowing_window,
         gst_min_match_length=gst_min_match_length,
+        progress=progress,
+        progress_callback=progress_callback,
     )
 
     pairs_results = [
@@ -1105,6 +1133,8 @@ def calculate_similarity(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    progress=False,
+    progress_callback=None,
 ):
     code_metric_weight, component_weights = validate_code_metric_options(
         code_metric_weight,
@@ -1136,17 +1166,21 @@ def calculate_similarity(
     )
     selected_similarity = normalize_similarity_function_name(similarity_function)
     selected_pooling = normalize_pooling_method_name(pooling_method)
-    prepared_code1 = prepare_code(
-        code1,
-        preprocess_mode=preprocess_mode,
-        code_language=code_language,
-    )
-    prepared_code2 = prepare_code(
-        code2,
-        preprocess_mode=preprocess_mode,
-        code_language=code_language,
-    )
+    prepared_codes = [
+        prepare_code(code, preprocess_mode=preprocess_mode, code_language=code_language)
+        for code in progress_iter(
+            (code1, code2),
+            total=2,
+            desc="Prepare snippets",
+            unit="snippet",
+            progress=progress,
+            progress_callback=progress_callback,
+            stage="prepare_snippets",
+        )
+    ]
+    prepared_code1, prepared_code2 = prepared_codes
     if use_semantic:
+        emit_progress(progress_callback, "build_embeddings", 0, 1, message="Build embeddings")
         model = load_backend_model(
             model_name,
             vector_backend=vector_backend,
@@ -1170,61 +1204,73 @@ def calculate_similarity(
             static_vector_lowercase=static_vector_lowercase,
             pooling_method=selected_pooling,
         )
+        emit_progress(progress_callback, "build_embeddings", 1, 1, message="Build embeddings")
     else:
         embeddings = [None, None]
     code_metric_score = 0.0
-    if (code_metric or "none").strip().lower() not in ("none", "") and resolved_feature_weights.get("code_metric", 0.0) > 0.0:
-        code_metric_score = score_code_metric_pair(
+    score = 0.0
+    for _ in progress_iter(
+        (None,),
+        total=1,
+        desc="Compare pair",
+        unit="pair",
+        progress=progress,
+        progress_callback=progress_callback,
+        stage="compare_pairs",
+    ):
+        if (code_metric or "none").strip().lower() not in ("none", "") and resolved_feature_weights.get("code_metric", 0.0) > 0.0:
+            code_metric_score = score_code_metric_pair(
+                prepared_code1,
+                prepared_code2,
+                metric_name=code_metric,
+                language=code_language,
+                bidirectional=code_metric_bidirectional,
+                component_weights=component_weights,
+                crystalbleu_max_order=crystalbleu_max_order,
+                crystalbleu_trivial_ngram_count=crystalbleu_trivial_ngram_count,
+                ruby_max_order=ruby_max_order,
+                ruby_epsilon=ruby_epsilon,
+                ruby_mode=ruby_mode,
+                ruby_tokenizer=ruby_tokenizer,
+                ruby_denominator=ruby_denominator,
+                ruby_graph_timeout_seconds=ruby_graph_timeout_seconds,
+                ruby_graph_use_edge_cost=ruby_graph_use_edge_cost,
+                ruby_graph_include_leaf_edges=ruby_graph_include_leaf_edges,
+                ruby_tree_max_nodes=ruby_tree_max_nodes,
+                ruby_tree_max_depth=ruby_tree_max_depth,
+                ruby_tree_max_children=ruby_tree_max_children,
+                tsed_delete_cost=tsed_delete_cost,
+                tsed_insert_cost=tsed_insert_cost,
+                tsed_rename_cost=tsed_rename_cost,
+                tsed_max_nodes=tsed_max_nodes,
+                tsed_max_depth=tsed_max_depth,
+                tsed_max_children=tsed_max_children,
+                codebertscore_model=codebertscore_model,
+                codebertscore_num_layers=codebertscore_num_layers,
+                codebertscore_batch_size=codebertscore_batch_size,
+                codebertscore_max_length=codebertscore_max_length,
+                codebertscore_device=codebertscore_device,
+                codebertscore_lang=codebertscore_lang,
+                codebertscore_idf=codebertscore_idf,
+                codebertscore_rescale_with_baseline=codebertscore_rescale_with_baseline,
+                codebertscore_use_fast_tokenizer=codebertscore_use_fast_tokenizer,
+                codebertscore_nthreads=codebertscore_nthreads,
+                codebertscore_verbose=codebertscore_verbose,
+            )
+        score = combined_similarity_from_embeddings(
             prepared_code1,
             prepared_code2,
-            metric_name=code_metric,
-            language=code_language,
-            bidirectional=code_metric_bidirectional,
-            component_weights=component_weights,
-            crystalbleu_max_order=crystalbleu_max_order,
-            crystalbleu_trivial_ngram_count=crystalbleu_trivial_ngram_count,
-            ruby_max_order=ruby_max_order,
-            ruby_epsilon=ruby_epsilon,
-            ruby_mode=ruby_mode,
-            ruby_tokenizer=ruby_tokenizer,
-            ruby_denominator=ruby_denominator,
-            ruby_graph_timeout_seconds=ruby_graph_timeout_seconds,
-            ruby_graph_use_edge_cost=ruby_graph_use_edge_cost,
-            ruby_graph_include_leaf_edges=ruby_graph_include_leaf_edges,
-            ruby_tree_max_nodes=ruby_tree_max_nodes,
-            ruby_tree_max_depth=ruby_tree_max_depth,
-            ruby_tree_max_children=ruby_tree_max_children,
-            tsed_delete_cost=tsed_delete_cost,
-            tsed_insert_cost=tsed_insert_cost,
-            tsed_rename_cost=tsed_rename_cost,
-            tsed_max_nodes=tsed_max_nodes,
-            tsed_max_depth=tsed_max_depth,
-            tsed_max_children=tsed_max_children,
-            codebertscore_model=codebertscore_model,
-            codebertscore_num_layers=codebertscore_num_layers,
-            codebertscore_batch_size=codebertscore_batch_size,
-            codebertscore_max_length=codebertscore_max_length,
-            codebertscore_device=codebertscore_device,
-            codebertscore_lang=codebertscore_lang,
-            codebertscore_idf=codebertscore_idf,
-            codebertscore_rescale_with_baseline=codebertscore_rescale_with_baseline,
-            codebertscore_use_fast_tokenizer=codebertscore_use_fast_tokenizer,
-            codebertscore_nthreads=codebertscore_nthreads,
-            codebertscore_verbose=codebertscore_verbose,
+            embeddings[0],
+            embeddings[1],
+            resolved_feature_weights,
+            code_metric_score=code_metric_score,
+            vector_backend=vector_backend,
+            multivector_bidirectional=multivector_bidirectional,
+            similarity_function=selected_similarity,
+            levenshtein_weights=levenshtein_weights,
+            jaro_winkler_prefix_weight=jaro_winkler_prefix_weight,
+            winnowing_kgram=winnowing_kgram,
+            winnowing_window=winnowing_window,
+            gst_min_match_length=gst_min_match_length,
         )
-    return combined_similarity_from_embeddings(
-        prepared_code1,
-        prepared_code2,
-        embeddings[0],
-        embeddings[1],
-        resolved_feature_weights,
-        code_metric_score=code_metric_score,
-        vector_backend=vector_backend,
-        multivector_bidirectional=multivector_bidirectional,
-        similarity_function=selected_similarity,
-        levenshtein_weights=levenshtein_weights,
-        jaro_winkler_prefix_weight=jaro_winkler_prefix_weight,
-        winnowing_kgram=winnowing_kgram,
-        winnowing_window=winnowing_window,
-        gst_min_match_length=gst_min_match_length,
-    )
+    return score

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy>=2,<3",
     "rapidfuzz>=3,<4",
     "networkx>=3,<4",
+    "tqdm>=4,<5",
     # 1.x currently has limited wheel coverage across the supported Python matrix.
     "tree-sitter-language-pack>=0.7,<0.8",
     "func-timeout>=4,<5"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,7 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
             "max",
             "--device",
             "cpu",
+            "--progress",
         ],
     )
 
@@ -166,6 +167,7 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     assert captured["kwargs"]["max_token_length"] == 128
     assert captured["kwargs"]["pooling_method"] == "max"
     assert captured["kwargs"]["device"] == "cpu"
+    assert captured["kwargs"]["progress"] is True
 
 
 def test_compare_command_accepts_directory_source(tmp_path, monkeypatch):
@@ -252,12 +254,20 @@ def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
         captured["config_file"] = config_file
         return [{"run_name": "baseline", "options": {}}]
 
-    def fake_run_comparison_suite(zipfile, run_configs, summary_out, details_dir, output_format):
+    def fake_run_comparison_suite(
+        zipfile,
+        run_configs,
+        summary_out,
+        details_dir,
+        output_format,
+        progress,
+    ):
         captured["zipfile"] = zipfile
         captured["run_configs"] = run_configs
         captured["summary_out"] = summary_out
         captured["details_dir"] = details_dir
         captured["output_format"] = output_format
+        captured["progress"] = progress
         return (
             pd.DataFrame(
                 [
@@ -297,6 +307,7 @@ def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
             str(tmp_path / "details"),
             "--format",
             "json",
+            "--progress",
         ],
     )
 
@@ -306,3 +317,4 @@ def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
     assert captured["summary_out"].endswith("summary.json")
     assert captured["details_dir"].endswith("details")
     assert captured["output_format"] == "json"
+    assert captured["progress"] is True

--- a/tests/test_comparison_suite.py
+++ b/tests/test_comparison_suite.py
@@ -165,3 +165,30 @@ def test_run_comparison_suite_accepts_already_normalized_configs(monkeypatch):
     assert list(summary["run_name"]) == ["outer"]
     assert captured_options
     assert "run_name" not in captured_options[0]
+
+
+def test_run_comparison_suite_reports_progress_events(monkeypatch):
+    def fake_get_sim_list(zipped_file, **kwargs):
+        callback = kwargs.get("progress_callback")
+        if callback is not None:
+            callback({"stage": "compare_pairs", "current": 1, "total": 1})
+        return pd.DataFrame(
+            [
+                {"file_name_1": "a.py", "file_name_2": "b.py", "similarity_score": 1.0},
+            ]
+        )
+
+    monkeypatch.setattr("matheel.comparison_suite.get_sim_list", fake_get_sim_list)
+    events = []
+
+    run_comparison_suite(
+        "codes.zip",
+        [{"run_name": "baseline", "feature_weights": {"levenshtein": 1.0}}],
+        progress_callback=events.append,
+    )
+
+    suite_events = [event for event in events if event["stage"] == "suite_runs"]
+    pair_events = [event for event in events if event["stage"] == "compare_pairs"]
+    assert suite_events[-1]["current"] == 1
+    assert suite_events[-1]["total"] == 1
+    assert pair_events[-1]["run_name"] == "baseline"

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -248,7 +248,9 @@ def test_run_suite_export_sanitizes_detail_zip_filenames(monkeypatch):
         summary_out=None,
         details_dir=None,
         output_format="csv",
+        progress_callback=None,
     ):
+        _ = zipped_file, summary_out, details_dir, output_format, progress_callback
         assert run_configs[0]["run_name"] == "../baseline/strong"
         return summary, {"../baseline/strong": details}
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -348,6 +348,54 @@ def test_get_sim_list_skips_embedding_loading_without_semantic_feature(tmp_path,
     assert len(results) == 1
 
 
+def test_get_sim_list_reports_progress_events(tmp_path):
+    source_dir = tmp_path / "codes"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("alpha beta", encoding="utf-8")
+    (source_dir / "b.py").write_text("alpha gamma", encoding="utf-8")
+    (source_dir / "c.py").write_text("delta gamma", encoding="utf-8")
+    events = []
+
+    similarity.get_sim_list(
+        source_dir,
+        threshold=0.0,
+        number_results=5,
+        feature_weights={"levenshtein": 1.0},
+        vector_backend="auto",
+        progress_callback=events.append,
+    )
+
+    prepare_events = [event for event in events if event["stage"] == "prepare_files"]
+    pair_events = [event for event in events if event["stage"] == "compare_pairs"]
+    assert prepare_events[0] == {
+        "stage": "prepare_files",
+        "current": 0,
+        "total": 3,
+        "message": "Prepare files",
+    }
+    assert prepare_events[-1]["current"] == 3
+    assert pair_events[0]["current"] == 0
+    assert pair_events[0]["total"] == 3
+    assert pair_events[-1]["current"] == 3
+
+
+def test_calculate_similarity_reports_progress_events():
+    events = []
+
+    similarity.calculate_similarity(
+        "alpha beta",
+        "alpha gamma",
+        feature_weights={"levenshtein": 1.0},
+        vector_backend="auto",
+        progress_callback=events.append,
+    )
+
+    assert any(event["stage"] == "prepare_snippets" for event in events)
+    pair_events = [event for event in events if event["stage"] == "compare_pairs"]
+    assert pair_events[-1]["current"] == 1
+    assert pair_events[-1]["total"] == 1
+
+
 def test_calculate_similarity_supports_static_hash_backend():
     score = similarity.calculate_similarity(
         "def add(a, b):\n    return a + b\n",


### PR DESCRIPTION
## Summary

- Add tqdm-backed progress iteration and structured progress callback events for collection and pair comparisons.
- Add progress switches to compare and compare-suite commands while keeping bars on stderr.
- Wire comparison-suite and Gradio callbacks to progress events.
- Document progress flags and add regression coverage for callback events and CLI propagation.

## Checks

- git diff --check
- python -m pytest tests/test_similarity.py tests/test_comparison_suite.py tests/test_cli.py tests/test_gradio_app.py
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict

Closes #35