### PR TITLE
Add elapsed-time metadata to comparisons

### DIFF
--- a/docs/comparison_suite.md
+++ b/docs/comparison_suite.md
@@ -65,6 +65,8 @@ One row per run, including:
 
 - `run_name`
 - `pair_count`
+- `elapsed_seconds`
+- `feature_set`
 - `mean_score`
 - `median_score`
 - `max_score`
@@ -76,6 +78,8 @@ One row per run, including:
 - `vector_backend`
 - `code_metric`
 - `chunking_method`
+
+`elapsed_seconds` is rounded to 4 decimal places. `feature_set` lists the active nonzero feature weights for the run.
 
 ### Optional Files
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,3 +115,4 @@ print(results.head())
 - `vector_backend=auto` uses Hugging Face metadata and tag heuristics when available.
 - CLI progress bars write to stderr and default to interactive terminals only. Use `--progress` or `--no-progress` to override.
 - Python APIs accept `progress=True` for tqdm bars and `progress_callback=...` for structured progress events.
+- Collection results include run metadata in `DataFrame.attrs`, including `elapsed_seconds`, `feature_set`, `vector_backend`, `code_metric`, and `chunking_method`.

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -22,6 +22,7 @@ from matheel.comparison_suite import run_comparison_suite, slugify_run_name
 from matheel.code_metrics import available_code_metric_languages, available_code_metrics
 from matheel.model_routing import available_vector_backends
 from matheel.preprocessing import available_preprocess_modes
+from matheel._run_metadata import elapsed_seconds_between, perf_counter
 from matheel.similarity import (
     DEFAULT_MODEL_NAME,
     available_runtime_devices,
@@ -973,11 +974,15 @@ def suite_summary_html(summary):
         return empty_suite_summary_html()
 
     best = summary.iloc[0]
+    elapsed_seconds = float(best.get("elapsed_seconds", 0.0))
+    feature_set = escape_html(best.get("feature_set", "none"))
     return (
         f"<p><strong>Best run:</strong> {escape_html(best['run_name'])} | "
         f"<strong>Runs:</strong> {len(summary)} | "
         f"<strong>Best mean:</strong> {float(summary['mean_score'].max()):.3f} | "
-        f"<strong>Best max:</strong> {float(summary['max_score'].max()):.3f}</p>"
+        f"<strong>Best max:</strong> {float(summary['max_score'].max()):.3f} | "
+        f"<strong>Elapsed:</strong> {elapsed_seconds:.3f}s | "
+        f"<strong>Features:</strong> {feature_set}</p>"
     )
 
 
@@ -1144,9 +1149,18 @@ def run_suite_gradio(
     )
 
 
-def score_card_html(score, vector_backend="sentence_transformers", runtime_device="auto", code_metric="none"):
+def score_card_html(
+    score,
+    vector_backend="sentence_transformers",
+    runtime_device="auto",
+    code_metric="none",
+    elapsed_seconds=None,
+):
     numeric_score = float(score)
-    return f"<p><strong>Similarity score:</strong> {numeric_score:.4f}</p>"
+    elapsed_fragment = ""
+    if elapsed_seconds is not None:
+        elapsed_fragment = f" | <strong>Elapsed:</strong> {float(elapsed_seconds):.3f}s"
+    return f"<p><strong>Similarity score:</strong> {numeric_score:.4f}{elapsed_fragment}</p>"
 
 
 def empty_summary_html():
@@ -1159,12 +1173,16 @@ def results_summary_html(results, vector_backend, code_metric, chunking_method, 
 
     scores = results["similarity_score"].astype(float)
     top_row = results.iloc[0]
+    elapsed_seconds = float(results.attrs.get("elapsed_seconds", 0.0))
+    feature_set = escape_html(results.attrs.get("feature_set", "none"))
     return (
         f"<p><strong>Top pair:</strong> {escape_html(top_row['file_name_1'])} "
         f"vs {escape_html(top_row['file_name_2'])} | "
         f"<strong>Pairs:</strong> {len(results)} | "
         f"<strong>Average:</strong> {scores.mean():.3f} | "
-        f"<strong>Top score:</strong> {scores.max():.3f}</p>"
+        f"<strong>Top score:</strong> {scores.max():.3f} | "
+        f"<strong>Elapsed:</strong> {elapsed_seconds:.3f}s | "
+        f"<strong>Features:</strong> {feature_set}</p>"
     )
 
 
@@ -1271,6 +1289,7 @@ def calculate_similarity_gradio(
         effective_code_metric,
         effective_code_metric_weight,
     )
+    start_time = perf_counter()
     score = calculate_similarity(
         code1,
         code2,
@@ -1303,11 +1322,13 @@ def calculate_similarity_gradio(
         progress_callback=gradio_progress_callback(progress),
         **metric_kwargs,
     )
+    elapsed_seconds = elapsed_seconds_between(start_time, perf_counter())
     return score_card_html(
         score,
         vector_backend=vector_backend,
         runtime_device=runtime_device,
         code_metric=effective_code_metric,
+        elapsed_seconds=elapsed_seconds,
     )
 
 

--- a/matheel/_run_metadata.py
+++ b/matheel/_run_metadata.py
@@ -1,0 +1,42 @@
+from time import perf_counter
+
+
+_METADATA_DECIMALS = 4
+
+
+def active_feature_names(feature_weights):
+    names = [
+        str(name)
+        for name, value in (feature_weights or {}).items()
+        if float(value) > 0.0
+    ]
+    return tuple(sorted(names)) or ("none",)
+
+
+def format_feature_set(feature_weights):
+    return ",".join(active_feature_names(feature_weights))
+
+
+def elapsed_seconds_since(start_time):
+    return elapsed_seconds_between(start_time, perf_counter())
+
+
+def elapsed_seconds_between(start_time, end_time):
+    return round(max(0.0, float(end_time) - float(start_time)), _METADATA_DECIMALS)
+
+
+def attach_run_metadata(
+    frame,
+    *,
+    elapsed_seconds,
+    feature_weights,
+    vector_backend,
+    code_metric,
+    chunking_method,
+):
+    frame.attrs["elapsed_seconds"] = round(float(elapsed_seconds), _METADATA_DECIMALS)
+    frame.attrs["feature_set"] = format_feature_set(feature_weights)
+    frame.attrs["vector_backend"] = vector_backend
+    frame.attrs["code_metric"] = code_metric
+    frame.attrs["chunking_method"] = chunking_method
+    return frame

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -300,6 +300,7 @@ def compare(
         progress=should_show_progress(progress, stream=sys.stderr),
     )
     click.echo(results.to_string(index=False))
+    click.echo(_elapsed_summary_text(results), err=True)
 
 
 @main.command(name="compare-suite")
@@ -347,3 +348,18 @@ def compare_suite(source_path, config_file, summary_out, details_dir, output_for
         click.echo("No runs were executed.")
         return
     click.echo(summary.to_string(index=False))
+
+
+def _elapsed_summary_text(results):
+    elapsed_seconds = float(results.attrs.get("elapsed_seconds", 0.0))
+    feature_set = results.attrs.get("feature_set", "none")
+    vector_backend = results.attrs.get("vector_backend", "auto")
+    code_metric = results.attrs.get("code_metric", "none")
+    chunking_method = results.attrs.get("chunking_method", "none")
+    return (
+        f"Elapsed: {elapsed_seconds:.4f}s | "
+        f"features={feature_set} | "
+        f"backend={vector_backend} | "
+        f"code_metric={code_metric} | "
+        f"chunking={chunking_method}"
+    )

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from .feature_weights import default_feature_weights, parse_feature_weights
 from ._progress import progress_iter
+from ._run_metadata import elapsed_seconds_between, format_feature_set, perf_counter
 from .similarity import DEFAULT_MODEL_NAME, get_sim_list
 
 
@@ -20,6 +21,7 @@ _SCORE_FIELDS = (
     "top_score",
     "similarity_score",
 )
+_RUNTIME_FIELDS = ("elapsed_seconds",)
 
 
 def load_run_configs(config_path):
@@ -81,7 +83,9 @@ def _normalize_run_feature_weights(options):
     options["feature_weights"] = default_feature_weights()
 
 
-def summary_row_from_results(run_name, options, results):
+def summary_row_from_results(run_name, options, results, elapsed_seconds=None):
+    elapsed_value = _resolved_elapsed_seconds(results, elapsed_seconds)
+    metadata = _summary_metadata(options, results, elapsed_value)
     if results is None or results.empty:
         return {
             "run_name": run_name,
@@ -94,9 +98,7 @@ def summary_row_from_results(run_name, options, results):
             "top_file_1": "",
             "top_file_2": "",
             "top_score": 0.0,
-            "vector_backend": options.get("vector_backend", "auto"),
-            "code_metric": options.get("code_metric", "none"),
-            "chunking_method": options.get("chunking_method", "none"),
+            **metadata,
         }
 
     scores = results["similarity_score"].astype(float)
@@ -112,9 +114,7 @@ def summary_row_from_results(run_name, options, results):
         "top_file_1": str(top_row["file_name_1"]),
         "top_file_2": str(top_row["file_name_2"]),
         "top_score": round(float(top_row["similarity_score"]), _SCORE_DECIMALS),
-        "vector_backend": options.get("vector_backend", "auto"),
-        "code_metric": options.get("code_metric", "none"),
-        "chunking_method": options.get("chunking_method", "none"),
+        **metadata,
     }
 
 
@@ -131,6 +131,9 @@ def _slugify(value):
 def _rounded_score_frame(frame):
     rounded = frame.copy()
     for column in _SCORE_FIELDS:
+        if column in rounded.columns:
+            rounded[column] = rounded[column].astype(float).round(_SCORE_DECIMALS)
+    for column in _RUNTIME_FIELDS:
         if column in rounded.columns:
             rounded[column] = rounded[column].astype(float).round(_SCORE_DECIMALS)
     return rounded
@@ -187,15 +190,25 @@ def run_comparison_suite(
         run_options = dict(options)
         run_options.setdefault("progress", progress)
         run_options.setdefault("progress_callback", _run_progress_callback(progress_callback, run_name))
+        start_time = perf_counter()
         results = _rounded_score_frame(
             get_sim_list(
                 zipped_file,
                 **run_options,
             )
         )
+        elapsed_seconds = elapsed_seconds_between(start_time, perf_counter())
+        results.attrs["elapsed_seconds"] = elapsed_seconds
         result_frames[run_name] = results
         write_run_details(run_name, results, details_dir=details_dir)
-        summary_rows.append(summary_row_from_results(run_name, options, results))
+        summary_rows.append(
+            summary_row_from_results(
+                run_name,
+                options,
+                results,
+                elapsed_seconds=elapsed_seconds,
+            )
+        )
 
     summary = pd.DataFrame(summary_rows)
     if not summary.empty:
@@ -205,6 +218,28 @@ def run_comparison_suite(
         write_summary(summary, summary_out, output_format=output_format)
 
     return summary, result_frames
+
+
+def _resolved_elapsed_seconds(results, elapsed_seconds):
+    if elapsed_seconds is not None:
+        return round(float(elapsed_seconds), _SCORE_DECIMALS)
+    if results is not None:
+        value = results.attrs.get("elapsed_seconds")
+        if value is not None:
+            return round(float(value), _SCORE_DECIMALS)
+    return 0.0
+
+
+def _summary_metadata(options, results, elapsed_seconds):
+    attrs = getattr(results, "attrs", {}) if results is not None else {}
+    feature_weights = options.get("feature_weights")
+    return {
+        "elapsed_seconds": round(float(elapsed_seconds), _SCORE_DECIMALS),
+        "feature_set": attrs.get("feature_set") or format_feature_set(feature_weights),
+        "vector_backend": attrs.get("vector_backend") or options.get("vector_backend", "auto"),
+        "code_metric": attrs.get("code_metric") or options.get("code_metric", "none"),
+        "chunking_method": attrs.get("chunking_method") or options.get("chunking_method", "none"),
+    }
 
 
 def _run_progress_callback(progress_callback, run_name):

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -23,6 +23,7 @@ from .model_routing import (
     resolve_vector_backend,
 )
 from ._progress import emit_progress, progress_iter
+from ._run_metadata import attach_run_metadata, elapsed_seconds_since, perf_counter
 from .preprocessing import preprocess_code
 from .vectors import (
     build_multivector_embeddings,
@@ -899,6 +900,7 @@ def get_sim_list(
     progress=False,
     progress_callback=None,
 ):
+    start_time = perf_counter()
     code_metric_weight, component_weights = validate_code_metric_options(
         code_metric_weight,
         codebleu_component_weights,
@@ -1069,7 +1071,15 @@ def get_sim_list(
     ]
 
     similarity_df = pd.DataFrame(pairs_results, columns=RESULT_COLUMNS)
-    return similarity_df.head(max(1, int(number_results)))
+    result = similarity_df.head(max(1, int(number_results)))
+    return attach_run_metadata(
+        result,
+        elapsed_seconds=elapsed_seconds_since(start_time),
+        feature_weights=resolved_feature_weights,
+        vector_backend=vector_backend,
+        code_metric=(code_metric or "none").strip().lower() or "none",
+        chunking_method=(chunking_method or "none").strip().lower() or "none",
+    )
 
 
 def calculate_similarity(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     def fake_get_sim_list(*args, **kwargs):
         captured["args"] = args
         captured["kwargs"] = kwargs
-        return pd.DataFrame(
+        frame = pd.DataFrame(
             [
                 {
                     "file_name_1": "a.py",
@@ -22,6 +22,16 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
                 }
             ]
         )
+        frame.attrs.update(
+            {
+                "elapsed_seconds": 1.2346,
+                "feature_set": "code_metric,semantic",
+                "vector_backend": "sentence_transformers",
+                "code_metric": "codebleu",
+                "chunking_method": "code",
+            }
+        )
+        return frame
 
     monkeypatch.setattr("matheel.cli.get_sim_list", fake_get_sim_list)
 
@@ -168,6 +178,8 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     assert captured["kwargs"]["pooling_method"] == "max"
     assert captured["kwargs"]["device"] == "cpu"
     assert captured["kwargs"]["progress"] is True
+    assert "Elapsed: 1.2346s" in result.stderr
+    assert "features=code_metric,semantic" in result.stderr
 
 
 def test_compare_command_accepts_directory_source(tmp_path, monkeypatch):

--- a/tests/test_comparison_suite.py
+++ b/tests/test_comparison_suite.py
@@ -108,6 +108,8 @@ def test_run_comparison_suite_writes_summary_and_details(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr("matheel.comparison_suite.get_sim_list", fake_get_sim_list)
+    times = iter([10.0, 11.23456, 20.0, 20.5])
+    monkeypatch.setattr("matheel.comparison_suite.perf_counter", lambda: next(times))
 
     summary_path = tmp_path / "summary.csv"
     details_dir = tmp_path / "details"
@@ -128,10 +130,19 @@ def test_run_comparison_suite_writes_summary_and_details(tmp_path, monkeypatch):
     assert set(result_frames.keys()) == {"strong", "weak"}
     assert summary.loc[0, "mean_score"] == 0.5556
     assert summary.loc[0, "top_score"] == 0.9877
+    assert summary.loc[0, "elapsed_seconds"] == 1.2346
+    assert summary.loc[0, "feature_set"] == "levenshtein,semantic"
+    assert summary.loc[0, "vector_backend"] == "auto"
+    assert summary.loc[0, "code_metric"] == "none"
+    assert summary.loc[0, "chunking_method"] == "none"
+    assert result_frames["strong"].attrs["elapsed_seconds"] == 1.2346
     assert result_frames["strong"].iloc[0]["similarity_score"] == 0.9877
 
     summary_text = summary_path.read_text(encoding="utf-8")
     strong_details_text = (details_dir / "strong.csv").read_text(encoding="utf-8")
+    assert "elapsed_seconds" in summary_text
+    assert "feature_set" in summary_text
+    assert "1.2346" in summary_text
     assert "0.9876543" not in summary_text
     assert "0.9877" in summary_text
     assert "0.9876543" not in strong_details_text

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -182,6 +182,8 @@ def test_suite_html_helpers_escape_run_names():
                 "run_name": "<b>best</b>",
                 "mean_score": 0.8,
                 "max_score": 0.9,
+                "elapsed_seconds": 1.2345,
+                "feature_set": "<i>semantic</i>",
             }
         ]
     )
@@ -190,6 +192,8 @@ def test_suite_html_helpers_escape_run_names():
 
     assert "<b>best</b>" not in summary_html
     assert "&lt;b&gt;best&lt;/b&gt;" in summary_html
+    assert "1.234s" in summary_html
+    assert "&lt;i&gt;semantic&lt;/i&gt;" in summary_html
 
 
 def test_results_summary_html_escapes_uploaded_file_names():
@@ -202,6 +206,8 @@ def test_results_summary_html_escapes_uploaded_file_names():
             }
         ]
     )
+    results.attrs["elapsed_seconds"] = 0.4321
+    results.attrs["feature_set"] = "<i>levenshtein</i>"
 
     summary_html = gradio_app.results_summary_html(results, "auto", "none", "none", "cpu")
 
@@ -209,6 +215,15 @@ def test_results_summary_html_escapes_uploaded_file_names():
     assert "<script>" not in summary_html
     assert "&lt;b&gt;a.py&lt;/b&gt;" in summary_html
     assert "&lt;script&gt;x&lt;/script&gt;" in summary_html
+    assert "0.432s" in summary_html
+    assert "&lt;i&gt;levenshtein&lt;/i&gt;" in summary_html
+
+
+def test_score_card_html_displays_elapsed_time():
+    score_html = gradio_app.score_card_html(0.75, elapsed_seconds=2.3456)
+
+    assert "0.7500" in score_html
+    assert "2.346s" in score_html
 
 
 def test_run_suite_export_sanitizes_detail_zip_filenames(monkeypatch):

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -356,7 +356,7 @@ def test_get_sim_list_reports_progress_events(tmp_path):
     (source_dir / "c.py").write_text("delta gamma", encoding="utf-8")
     events = []
 
-    similarity.get_sim_list(
+    results = similarity.get_sim_list(
         source_dir,
         threshold=0.0,
         number_results=5,
@@ -377,6 +377,11 @@ def test_get_sim_list_reports_progress_events(tmp_path):
     assert pair_events[0]["current"] == 0
     assert pair_events[0]["total"] == 3
     assert pair_events[-1]["current"] == 3
+    assert results.attrs["elapsed_seconds"] >= 0.0
+    assert results.attrs["feature_set"] == "levenshtein"
+    assert results.attrs["vector_backend"] == "sentence_transformers"
+    assert results.attrs["code_metric"] == "none"
+    assert results.attrs["chunking_method"] == "none"
 
 
 def test_calculate_similarity_reports_progress_events():


### PR DESCRIPTION
## Summary

- Add elapsed_seconds and feature_set metadata to comparison-suite summaries.
- Attach collection run metadata to get_sim_list DataFrame attrs.
- Print collection elapsed metadata to CLI stderr and show timing in Gradio summaries.
- Document timing metadata and add tests that avoid exact wall-clock assumptions.

## Checks

- git diff --check
- python -m pytest tests/test_similarity.py tests/test_comparison_suite.py tests/test_cli.py tests/test_gradio_app.py
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict

Closes #36