### PR TITLE
Normalize semantic score scale handling

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,6 +85,7 @@ print(results.head())
 
 - Use a ZIP archive or a directory path with `matheel compare`.
 - Use `feature_weights` to combine semantic, lexical, and code-aware scores.
+- Use `--normalize-semantic-scores` when blending `dot`, `euclidean`, or `manhattan` semantic scores with other 0-1 metrics.
 - Add `--preprocess-mode` when code should be normalized before scoring.
 - Add `--chunking-method` when large files should be split before embedding.
 - Use `matheel compare-suite` with a JSON config for repeatable multi-run comparisons.

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -13,6 +13,7 @@ You can also use `vector_backend=auto` and let Matheel route based on Hugging Fa
 - `vector_backend`
 - `max_token_length`
 - `similarity_function`
+- `normalize_semantic_scores`
 - `pooling_method`
 - `static_vector_dim`
 - `static_vector_lowercase`
@@ -88,7 +89,11 @@ These apply to single-vector backends:
 Notes:
 
 - `cosine` and `dot` are the most common similarity choices.
-- `euclidean` and `manhattan` are distance-style scores, so thresholds may need to be lower and can be negative.
+- Raw `cosine` scores are bounded from -1 to 1.
+- Raw `dot` scores are unbounded.
+- Raw `euclidean` and `manhattan` scores are negative distances. Identical vectors score `0.0`; farther vectors become more negative.
+- `normalize_semantic_scores=True` maps single-vector semantic scores to the 0-1 range before weighting. Distance scores use `1 / (1 + distance)`, so identical vectors score `1.0` and farther vectors approach `0.0`.
+- Keep normalization as an option when you need raw distance or dot values for analysis. Enable it before combining `dot`, `euclidean`, or `manhattan` semantic scores with lexical or code-metric weights.
 
 ## Pooling Methods
 
@@ -126,6 +131,7 @@ score = calculate_similarity(
     vector_backend="sentence_transformers",
     max_token_length=256,
     similarity_function="dot",
+    normalize_semantic_scores=True,
     pooling_method="max",
     feature_weights={"semantic": 1.0},
 )

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -9,7 +9,11 @@ from .code_metrics import (
 from .feature_weights import available_default_features, default_feature_weights, normalize_feature_weights
 from .model_routing import infer_model_backend, infer_model_capabilities, available_vector_backends
 from .preprocessing import preprocess_code
-from .vectors import available_pooling_methods, available_similarity_functions
+from .vectors import (
+    available_pooling_methods,
+    available_similarity_functions,
+    similarity_function_score_range,
+)
 from .similarity import (
     available_runtime_devices,
     calculate_similarity,
@@ -42,4 +46,5 @@ __all__ = [
     "run_comparison_suite",
     "score_code_metric_pair",
     "detect_default_device",
+    "similarity_function_score_range",
 ]

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -153,6 +153,12 @@ def main():
     show_default=True,
     help='Semantic similarity function for single-vector backends.',
 )
+@click.option(
+    '--normalize-semantic-scores/--raw-semantic-scores',
+    default=False,
+    show_default=True,
+    help='Normalize single-vector semantic scores to 0-1 before weighted blending.',
+)
 @click.option('--static-vector-dim', default=256, show_default=True, help='Dimension for local static-vector compatibility fallback.')
 @click.option('--max-token-length', default=0, show_default=True, help='Maximum token length to use for the selected model. 0 keeps the model default.')
 @click.option(
@@ -229,6 +235,7 @@ def compare(
     gst_min_match_length,
     vector_backend,
     similarity_function,
+    normalize_semantic_scores,
     static_vector_dim,
     max_token_length,
     pooling_method,
@@ -293,6 +300,7 @@ def compare(
         gst_min_match_length=gst_min_match_length,
         vector_backend=vector_backend,
         similarity_function=similarity_function,
+        normalize_semantic_scores=normalize_semantic_scores,
         static_vector_dim=static_vector_dim,
         max_token_length=max_token_length,
         pooling_method=pooling_method,

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -35,6 +35,7 @@ from .vectors import (
     load_vector_model,
     multivector_similarity,
     normalize_pooling_method_name,
+    similarity_function_is_unbounded,
     resolve_max_token_length,
     normalize_similarity_function_name,
     single_vector_similarity,
@@ -326,6 +327,27 @@ def validate_vector_options(vector_backend, static_vector_dim, model_name=None, 
     return backend, max(8, int(static_vector_dim or 0))
 
 
+def validate_semantic_score_scale_options(
+    feature_weights,
+    vector_backend,
+    similarity_function,
+    normalize_semantic_scores=False,
+):
+    if normalize_semantic_scores or backend_is_multivector(vector_backend):
+        return
+    active_features = {
+        name for name, value in (feature_weights or {}).items() if float(value) > 0.0
+    }
+    if "semantic" not in active_features or len(active_features) <= 1:
+        return
+    if not similarity_function_is_unbounded(similarity_function):
+        return
+    raise ValueError(
+        "Raw semantic scores from this similarity function are not on the 0-1 feature scale. "
+        "Set normalize_semantic_scores=True before combining semantic scores with other features."
+    )
+
+
 def validate_embedding_count(embeddings, code_count):
     embedding_count = 0 if embeddings is None else len(embeddings)
     if embedding_count != int(code_count):
@@ -341,6 +363,7 @@ def semantic_similarity(
     vector_backend="sentence_transformers",
     multivector_bidirectional=False,
     similarity_function="cosine",
+    normalize_semantic_scores=False,
 ):
     if backend_is_multivector(vector_backend):
         return multivector_similarity(
@@ -353,6 +376,7 @@ def semantic_similarity(
         embedding1,
         embedding2,
         similarity_function=similarity_function,
+        normalize_score=normalize_semantic_scores,
     )
 
 
@@ -593,6 +617,7 @@ def build_feature_scores(
     winnowing_window=4,
     gst_min_match_length=5,
     active_features=None,
+    normalize_semantic_scores=False,
 ):
     requested_features = None
     if active_features is not None:
@@ -614,6 +639,7 @@ def build_feature_scores(
                 vector_backend=vector_backend,
                 multivector_bidirectional=multivector_bidirectional,
                 similarity_function=similarity_function,
+                normalize_semantic_scores=normalize_semantic_scores,
             )
             if (use_all_features or "semantic" in requested_features)
             and embedding1 is not None
@@ -676,7 +702,14 @@ def combined_similarity_from_embeddings(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    normalize_semantic_scores=False,
 ):
+    validate_semantic_score_scale_options(
+        feature_weights,
+        vector_backend,
+        similarity_function,
+        normalize_semantic_scores=normalize_semantic_scores,
+    )
     active_features = {
         name for name, value in (feature_weights or {}).items() if float(value) > 0.0
     }
@@ -696,6 +729,7 @@ def combined_similarity_from_embeddings(
         winnowing_window=winnowing_window,
         gst_min_match_length=gst_min_match_length,
         active_features=active_features,
+        normalize_semantic_scores=normalize_semantic_scores,
     )
     return combine_weighted_scores(feature_scores, feature_weights)
 
@@ -750,6 +784,7 @@ def rank_code_pairs(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    normalize_semantic_scores=False,
     progress=False,
     progress_callback=None,
 ):
@@ -830,6 +865,7 @@ def rank_code_pairs(
             winnowing_kgram=winnowing_kgram,
             winnowing_window=winnowing_window,
             gst_min_match_length=gst_min_match_length,
+            normalize_semantic_scores=normalize_semantic_scores,
         )
         results.append((score, i, j))
     return sorted(results, reverse=True)
@@ -897,6 +933,7 @@ def get_sim_list(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    normalize_semantic_scores=False,
     progress=False,
     progress_callback=None,
 ):
@@ -932,6 +969,13 @@ def get_sim_list(
     )
     selected_similarity = normalize_similarity_function_name(similarity_function)
     selected_pooling = normalize_pooling_method_name(pooling_method)
+    normalize_semantic_scores = bool(normalize_semantic_scores)
+    validate_semantic_score_scale_options(
+        resolved_feature_weights,
+        vector_backend,
+        selected_similarity,
+        normalize_semantic_scores=normalize_semantic_scores,
+    )
     source_iter = progress_iter(
         raw_codes,
         total=len(raw_codes),
@@ -1056,6 +1100,7 @@ def get_sim_list(
         winnowing_kgram=winnowing_kgram,
         winnowing_window=winnowing_window,
         gst_min_match_length=gst_min_match_length,
+        normalize_semantic_scores=normalize_semantic_scores,
         progress=progress,
         progress_callback=progress_callback,
     )
@@ -1143,6 +1188,7 @@ def calculate_similarity(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    normalize_semantic_scores=False,
     progress=False,
     progress_callback=None,
 ):
@@ -1176,6 +1222,13 @@ def calculate_similarity(
     )
     selected_similarity = normalize_similarity_function_name(similarity_function)
     selected_pooling = normalize_pooling_method_name(pooling_method)
+    normalize_semantic_scores = bool(normalize_semantic_scores)
+    validate_semantic_score_scale_options(
+        resolved_feature_weights,
+        vector_backend,
+        selected_similarity,
+        normalize_semantic_scores=normalize_semantic_scores,
+    )
     prepared_codes = [
         prepare_code(code, preprocess_mode=preprocess_mode, code_language=code_language)
         for code in progress_iter(
@@ -1282,5 +1335,6 @@ def calculate_similarity(
             winnowing_kgram=winnowing_kgram,
             winnowing_window=winnowing_window,
             gst_min_match_length=gst_min_match_length,
+            normalize_semantic_scores=normalize_semantic_scores,
         )
     return score

--- a/matheel/vectors.py
+++ b/matheel/vectors.py
@@ -53,6 +53,65 @@ def available_similarity_functions():
     return ("cosine", "dot", "euclidean", "manhattan")
 
 
+def similarity_function_score_range(name, normalize_score=False):
+    selected = normalize_similarity_function_name(name)
+    if normalize_score:
+        return (0.0, 1.0)
+    if selected == "cosine":
+        return (-1.0, 1.0)
+    if selected == "dot":
+        return (float("-inf"), float("inf"))
+    return (float("-inf"), 0.0)
+
+
+def similarity_function_uses_distance_scale(name):
+    selected = normalize_similarity_function_name(name)
+    return selected in ("euclidean", "manhattan")
+
+
+def similarity_function_is_unbounded(name):
+    selected = normalize_similarity_function_name(name)
+    return selected in ("dot", "euclidean", "manhattan")
+
+
+def normalized_similarity_score(score, similarity_function):
+    selected = normalize_similarity_function_name(similarity_function)
+    numeric_score = float(score)
+    if similarity_function_uses_distance_scale(selected):
+        return _distance_to_similarity(abs(numeric_score))
+    return float(np.clip(numeric_score, 0.0, 1.0))
+
+
+def raw_distance_to_similarity(distance):
+    numeric_distance = max(0.0, float(distance))
+    return 1.0 / (1.0 + numeric_distance)
+
+
+def _distance_to_similarity(distance):
+    return raw_distance_to_similarity(distance)
+
+
+def _maybe_normalize_single_vector_score(score, similarity_function, normalize_score=False):
+    if normalize_score:
+        return normalized_similarity_score(score, similarity_function)
+    return float(score)
+
+
+def _distance_score(distance, normalize_score=False):
+    numeric_distance = max(0.0, float(distance))
+    if normalize_score:
+        return _distance_to_similarity(numeric_distance)
+    return -numeric_distance
+
+
+def _raw_cosine_score(left_vector, right_vector):
+    denominator = np.linalg.norm(left_vector) * np.linalg.norm(right_vector)
+    if denominator <= 0:
+        return 0.0
+    score = np.dot(left_vector, right_vector) / denominator
+    return float(np.clip(score, -1.0, 1.0))
+
+
 def normalize_similarity_function_name(name):
     key = str(name or "cosine").strip().lower()
     normalized = _SIMILARITY_FUNCTION_ALIASES.get(key)
@@ -400,7 +459,12 @@ def _extract_scalar_score(value):
     return float(array.reshape(-1)[0])
 
 
-def _pairwise_similarity_with_sentence_transformers(left, right, similarity_function="cosine"):
+def _pairwise_similarity_with_sentence_transformers(
+    left,
+    right,
+    similarity_function="cosine",
+    normalize_score=False,
+):
     from sentence_transformers import util
 
     left_vector = np.asarray(left, dtype=float).reshape(1, -1)
@@ -414,27 +478,46 @@ def _pairwise_similarity_with_sentence_transformers(left, right, similarity_func
         score = util.pairwise_manhattan_sim(left_vector, right_vector)
     else:
         score = util.pairwise_cos_sim(left_vector, right_vector)
-    return _extract_scalar_score(score)
+    return _maybe_normalize_single_vector_score(
+        _extract_scalar_score(score),
+        selected,
+        normalize_score=normalize_score,
+    )
 
 
-def single_vector_similarity(left, right, similarity_function="cosine"):
+def single_vector_similarity(left, right, similarity_function="cosine", normalize_score=False):
     selected = normalize_similarity_function_name(similarity_function)
     try:
-        return _pairwise_similarity_with_sentence_transformers(left, right, similarity_function=selected)
+        return _pairwise_similarity_with_sentence_transformers(
+            left,
+            right,
+            similarity_function=selected,
+            normalize_score=normalize_score,
+        )
     except Exception:
         left_vector = np.asarray(left, dtype=float)
         right_vector = np.asarray(right, dtype=float)
         if selected == "dot":
-            return float(np.dot(left_vector, right_vector))
+            return _maybe_normalize_single_vector_score(
+                np.dot(left_vector, right_vector),
+                selected,
+                normalize_score=normalize_score,
+            )
         if selected == "euclidean":
-            return float(-np.linalg.norm(left_vector - right_vector))
+            return _distance_score(
+                np.linalg.norm(left_vector - right_vector),
+                normalize_score=normalize_score,
+            )
         if selected == "manhattan":
-            return float(-np.abs(left_vector - right_vector).sum())
-        denominator = np.linalg.norm(left_vector) * np.linalg.norm(right_vector)
-        if denominator <= 0:
-            return 0.0
-        score = np.dot(left_vector, right_vector) / denominator
-        return float(np.clip(score, -1.0, 1.0))
+            return _distance_score(
+                np.abs(left_vector - right_vector).sum(),
+                normalize_score=normalize_score,
+            )
+        return _maybe_normalize_single_vector_score(
+            _raw_cosine_score(left_vector, right_vector),
+            selected,
+            normalize_score=normalize_score,
+        )
 
 
 def _encode_to_numpy(model, inputs):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,6 +114,7 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
             "auto",
             "--similarity-function",
             "dot",
+            "--normalize-semantic-scores",
             "--winnowing-kgram",
             "6",
             "--winnowing-window",
@@ -170,6 +171,7 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     assert captured["kwargs"]["codebertscore_nthreads"] == 2
     assert captured["kwargs"]["vector_backend"] == "auto"
     assert captured["kwargs"]["similarity_function"] == "dot"
+    assert captured["kwargs"]["normalize_semantic_scores"] is True
     assert captured["kwargs"]["winnowing_kgram"] == 6
     assert captured["kwargs"]["winnowing_window"] == 5
     assert captured["kwargs"]["gst_min_match_length"] == 4

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -435,6 +435,53 @@ def test_calculate_similarity_supports_alternative_similarity_functions():
     assert euclidean_score == pytest.approx(0.0)
 
 
+def test_calculate_similarity_normalizes_semantic_scores_when_requested():
+    raw_score = similarity.calculate_similarity(
+        "def add(a, b):\n    return a + b\n",
+        "def add(a, b):\n    return a + b\n",
+        feature_weights={"semantic": 1.0},
+        vector_backend="static_hash",
+        similarity_function="euclidean",
+        static_vector_dim=64,
+    )
+    normalized_score = similarity.calculate_similarity(
+        "def add(a, b):\n    return a + b\n",
+        "def add(a, b):\n    return a + b\n",
+        feature_weights={"semantic": 1.0},
+        vector_backend="static_hash",
+        similarity_function="euclidean",
+        static_vector_dim=64,
+        normalize_semantic_scores=True,
+    )
+
+    assert raw_score == pytest.approx(0.0)
+    assert normalized_score == pytest.approx(1.0)
+
+
+def test_calculate_similarity_guards_raw_distance_scores_in_weighted_blends():
+    with pytest.raises(ValueError, match="normalize_semantic_scores"):
+        similarity.calculate_similarity(
+            "def add(a, b):\n    return a + b\n",
+            "def add(a, b):\n    return a + b\n",
+            feature_weights={"semantic": 0.5, "levenshtein": 0.5},
+            vector_backend="static_hash",
+            similarity_function="euclidean",
+            static_vector_dim=64,
+        )
+
+    score = similarity.calculate_similarity(
+        "def add(a, b):\n    return a + b\n",
+        "def add(a, b):\n    return a + b\n",
+        feature_weights={"semantic": 0.5, "levenshtein": 0.5},
+        vector_backend="static_hash",
+        similarity_function="euclidean",
+        static_vector_dim=64,
+        normalize_semantic_scores=True,
+    )
+
+    assert score == pytest.approx(1.0)
+
+
 def test_calculate_similarity_falls_back_when_model2vec_is_unavailable(monkeypatch):
     monkeypatch.setattr(
         similarity,

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -9,6 +9,7 @@ from matheel.vectors import (
     detect_model_max_token_length,
     multivector_similarity,
     resolve_max_token_length,
+    similarity_function_score_range,
     single_vector_similarity,
 )
 
@@ -32,6 +33,12 @@ def test_single_vector_similarity_supports_all_supported_functions():
     right = [0.0, 1.0]
 
     assert available_similarity_functions() == ("cosine", "dot", "euclidean", "manhattan")
+    assert similarity_function_score_range("cosine") == (-1.0, 1.0)
+    assert similarity_function_score_range("dot") == (float("-inf"), float("inf"))
+    assert similarity_function_score_range("euclidean") == (float("-inf"), 0.0)
+    assert similarity_function_score_range("manhattan") == (float("-inf"), 0.0)
+    for name in available_similarity_functions():
+        assert similarity_function_score_range(name, normalize_score=True) == (0.0, 1.0)
     assert single_vector_similarity(left, left, similarity_function="cosine") == 1.0
     assert single_vector_similarity(left, left, similarity_function="dot") == 1.0
     assert single_vector_similarity(left, left, similarity_function="euclidean") == 0.0
@@ -40,6 +47,14 @@ def test_single_vector_similarity_supports_all_supported_functions():
     assert single_vector_similarity(left, right, similarity_function="dot") == 0.0
     assert single_vector_similarity(left, right, similarity_function="euclidean") == pytest.approx(-(2.0 ** 0.5))
     assert single_vector_similarity(left, right, similarity_function="manhattan") == -2.0
+    assert single_vector_similarity(left, right, similarity_function="euclidean", normalize_score=True) == pytest.approx(
+        1.0 / (1.0 + (2.0 ** 0.5))
+    )
+    assert single_vector_similarity(left, right, similarity_function="manhattan", normalize_score=True) == pytest.approx(
+        1.0 / 3.0
+    )
+    assert single_vector_similarity([2.0, 0.0], [2.0, 0.0], similarity_function="dot") == 4.0
+    assert single_vector_similarity([2.0, 0.0], [2.0, 0.0], similarity_function="dot", normalize_score=True) == 1.0
 
 
 def test_configure_sentence_transformer_pooling_replaces_single_pooling_mode():


### PR DESCRIPTION
Summary:
- Adds opt-in normalized semantic scoring for single-vector backends.
- Guards mixed weighted blends from raw dot, euclidean, and manhattan scales unless normalization is enabled.
- Documents raw and normalized score interpretation plus the CLI flag.

Checks:
- python -m ruff check .
- python -m pytest
- python -m mkdocs build --strict
- git diff --check

Closes #48