### PR TITLE
Add score calibration methodology

### DIFF
--- a/docs/comparison_suite.md
+++ b/docs/comparison_suite.md
@@ -7,6 +7,7 @@ The comparison suite runs multiple configurations against the same directory or 
 - optional summary/detail files on disk
 
 This is the right interface for repeatable ablations, backend comparisons, and parameter sweeps.
+For calibrated decision thresholds, keep labels outside the suite output and use the score reports with the calibration helpers described in [Scoring and calibration](scoring.md).
 
 ## Main Functions
 

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,0 +1,99 @@
+# Scoring and Calibration
+
+Matheel scores are useful for ranking pairs inside one run. They are not automatically calibrated probabilities.
+
+Different algorithms expose different evidence:
+
+- embedding backends compare vector geometry
+- Levenshtein and Jaro-Winkler compare string similarity
+- Winnowing and GST compare token overlap
+- code metrics compare code-specific structure, tokens, or model alignments
+
+Use raw scores for inspection and ranking. Use labeled data when you need thresholds that carry a specific meaning such as "likely same solution" or "needs review".
+
+## Score Ranges
+
+Use `feature_score_range(...)` when you need the documented range in code.
+
+| Feature or metric | Default range | Interpretation |
+| --- | --- | --- |
+| `semantic` with `cosine` | `-1.0` to `1.0` | Larger means closer vector direction. |
+| `semantic` with `dot` | unbounded | Larger means stronger dot product, but magnitude depends on vector scale. |
+| `semantic` with `euclidean` | negative distance to `0.0` | `0.0` means identical vectors; farther vectors are more negative. |
+| `semantic` with `manhattan` | negative distance to `0.0` | `0.0` means identical vectors; farther vectors are more negative. |
+| normalized semantic scores | `0.0` to `1.0` | Enable `normalize_semantic_scores=True` before blending raw `dot`, `euclidean`, or `manhattan` scores with other metrics. |
+| `levenshtein` | `0.0` to `1.0` | Normalized edit-distance similarity. |
+| `jaro_winkler` | `0.0` to `1.0` | String similarity with prefix weighting. |
+| `winnowing` | `0.0` to `1.0` | Fingerprint overlap. |
+| `gst` | `0.0` to `1.0` | Covered-token overlap from greedy string tiling. |
+| `code_metric` | usually `0.0` to `1.0` | Depends on the selected code metric. Built-in CodeBLEU, CrystalBLEU, RUBY, TSED, and CodeBERTScore paths are intended to be bounded. |
+
+Weighted blends are arithmetic blends of selected feature scores after feature weights are normalized. A blended score is only as comparable as the component scales. Matheel guards mixed-feature blends for raw unbounded or distance-style semantic scores; enable semantic normalization when you need a 0-1 blend.
+
+## Thresholds
+
+A threshold should be calibrated for the dataset and workflow that will use it.
+
+Good threshold labels are operational:
+
+- "same assignment solution"
+- "manual review needed"
+- "known clone pair"
+- "not related"
+
+Avoid treating a threshold from one model, language, assignment, or preprocessing setup as universal.
+
+## Calibrating on Labeled Pairs
+
+Use a small labeled sample that matches the workflow:
+
+1. Collect representative code pairs.
+2. Label each pair with the decision you care about.
+3. Score the pairs with the same Matheel options you plan to use later.
+4. Choose the threshold that optimizes the metric you care about.
+5. Re-check the threshold when you change models, metrics, languages, preprocessing, chunking, or feature weights.
+
+```python
+from matheel.calibration import calibrate_threshold
+
+labeled_scores = [
+    (0.95, True),
+    (0.82, True),
+    (0.61, False),
+    (0.40, False),
+]
+
+report = calibrate_threshold(labeled_scores)
+print(report["threshold"])
+print(report["precision"], report["recall"], report["f1"])
+```
+
+`calibrate_threshold(...)` accepts either `(score, label)` pairs or mappings:
+
+```python
+from matheel.calibration import calibrate_threshold
+
+report = calibrate_threshold(
+    [
+        {"similarity_score": 0.92, "label": "same"},
+        {"similarity_score": 0.48, "label": "different"},
+    ],
+    score_key="similarity_score",
+    label_key="label",
+    positive_label="same",
+)
+```
+
+Use `evaluate_threshold(...)` when you already have a threshold and want confusion counts, precision, recall, F1, and accuracy.
+
+## Comparing Runs
+
+When comparing algorithms or configurations:
+
+- keep the input set fixed
+- keep labels separate from scoring
+- compare ranking quality and calibrated threshold quality, not just raw averages
+- report active `feature_weights`, `vector_backend`, `code_metric`, preprocessing, and chunking settings
+- avoid comparing raw `dot` or negative distance scores directly against 0-1 metrics
+
+The comparison suite records `feature_set`, `vector_backend`, `code_metric`, `chunking_method`, summary score statistics, and elapsed time. Use those fields to keep comparisons auditable.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -105,6 +105,7 @@ print(results.head())
 - [Vectors and routing](vectors.md)
 - [Lexical metrics and baselines](lexical.md)
 - [Code metrics](code_metrics.md)
+- [Scoring and calibration](scoring.md)
 - [Comparison suite](comparison_suite.md)
 - [Development](development.md)
 

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -1,4 +1,10 @@
 from .chunking import chunk_text, chunker_parameter_names
+from .calibration import (
+    calibrate_threshold,
+    calibration_curve,
+    evaluate_threshold,
+    feature_score_range,
+)
 from .comparison_suite import load_run_configs, parse_run_configs, run_comparison_suite
 from .code_metrics import (
     available_code_metric_languages,
@@ -30,10 +36,14 @@ __all__ = [
     "available_runtime_devices",
     "available_similarity_functions",
     "available_vector_backends",
+    "calibrate_threshold",
+    "calibration_curve",
     "calculate_similarity",
     "chunk_text",
     "chunker_parameter_names",
     "codebleu_components",
+    "evaluate_threshold",
+    "feature_score_range",
     "get_sim_list",
     "infer_model_backend",
     "infer_model_capabilities",

--- a/matheel/calibration.py
+++ b/matheel/calibration.py
@@ -1,0 +1,213 @@
+import math
+
+from .feature_weights import available_default_features
+from .vectors import similarity_function_score_range
+
+
+_BOUNDED_FEATURES = {
+    "levenshtein",
+    "jaro_winkler",
+    "winnowing",
+    "gst",
+    "code_metric",
+}
+
+
+def _finite_score(value):
+    score = float(value)
+    if not math.isfinite(score):
+        raise ValueError("Scores must be finite numbers.")
+    return score
+
+
+def _coerce_label(value, positive_label=True):
+    if positive_label is True:
+        return bool(value)
+    return value == positive_label
+
+
+def _coerce_score_label_pairs(
+    scores,
+    labels=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+):
+    if labels is not None:
+        score_values = list(scores)
+        label_values = list(labels)
+        if len(score_values) != len(label_values):
+            raise ValueError("scores and labels must have the same length.")
+        pairs = zip(score_values, label_values)
+    else:
+        pairs = []
+        for item in scores:
+            if isinstance(item, dict):
+                if score_key not in item or label_key not in item:
+                    raise ValueError(f"Each labeled score mapping must contain {score_key!r} and {label_key!r}.")
+                pairs.append((item[score_key], item[label_key]))
+            elif isinstance(item, (tuple, list)) and len(item) == 2:
+                pairs.append((item[0], item[1]))
+            else:
+                raise ValueError("Labeled scores must be mappings or (score, label) pairs.")
+
+    parsed = [(_finite_score(score), _coerce_label(label, positive_label=positive_label)) for score, label in pairs]
+    if not parsed:
+        raise ValueError("At least one labeled score is required.")
+    return parsed
+
+
+def _threshold_candidates(scores):
+    unique_scores = sorted(set(float(score) for score in scores))
+    if len(unique_scores) == 1:
+        margin = max(abs(unique_scores[0]) * 1e-12, 1e-12)
+        return (unique_scores[0] - margin, unique_scores[0], unique_scores[0] + margin)
+
+    span = unique_scores[-1] - unique_scores[0]
+    margin = max(span * 1e-12, 1e-12)
+    candidates = [unique_scores[0] - margin, unique_scores[-1] + margin]
+    candidates.extend(unique_scores)
+    candidates.extend(
+        (left + right) / 2.0 for left, right in zip(unique_scores, unique_scores[1:])
+    )
+    return tuple(sorted(set(candidates)))
+
+
+def feature_score_range(
+    feature_name,
+    similarity_function="cosine",
+    normalize_semantic_scores=False,
+):
+    key = str(feature_name or "").strip()
+    if key == "semantic":
+        return similarity_function_score_range(
+            similarity_function,
+            normalize_score=normalize_semantic_scores,
+        )
+    if key in _BOUNDED_FEATURES:
+        return (0.0, 1.0)
+    supported = ", ".join(available_default_features())
+    raise ValueError(f"Unsupported feature name: {feature_name}. Supported features: {supported}.")
+
+
+def evaluate_threshold(
+    scores,
+    labels=None,
+    threshold=0.5,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+):
+    pairs = _coerce_score_label_pairs(
+        scores,
+        labels=labels,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+    )
+    threshold = _finite_score(threshold)
+    true_positive = false_positive = true_negative = false_negative = 0
+    for score, is_positive in pairs:
+        predicted_positive = score >= threshold if greater_is_match else score <= threshold
+        if predicted_positive and is_positive:
+            true_positive += 1
+        elif predicted_positive:
+            false_positive += 1
+        elif is_positive:
+            false_negative += 1
+        else:
+            true_negative += 1
+
+    predicted_positive_count = true_positive + false_positive
+    actual_positive_count = true_positive + false_negative
+    precision = true_positive / predicted_positive_count if predicted_positive_count else 0.0
+    recall = true_positive / actual_positive_count if actual_positive_count else 0.0
+    f1_denom = precision + recall
+    f1 = (2.0 * precision * recall / f1_denom) if f1_denom else 0.0
+    total = len(pairs)
+    accuracy = (true_positive + true_negative) / float(total)
+
+    return {
+        "threshold": threshold,
+        "positive_count": actual_positive_count,
+        "negative_count": true_negative + false_positive,
+        "true_positive": true_positive,
+        "false_positive": false_positive,
+        "true_negative": true_negative,
+        "false_negative": false_negative,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+        "accuracy": accuracy,
+    }
+
+
+def calibration_curve(
+    scores,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+):
+    pairs = _coerce_score_label_pairs(
+        scores,
+        labels=labels,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+    )
+    selected_thresholds = thresholds
+    if selected_thresholds is None:
+        selected_thresholds = _threshold_candidates([score for score, _ in pairs])
+    return [
+        evaluate_threshold(
+            pairs,
+            threshold=threshold,
+            positive_label=True,
+            greater_is_match=greater_is_match,
+        )
+        for threshold in selected_thresholds
+    ]
+
+
+def calibrate_threshold(
+    scores,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+    optimize="f1",
+):
+    metric_name = str(optimize or "f1").strip().lower()
+    if metric_name not in {"f1", "accuracy", "precision", "recall"}:
+        raise ValueError("optimize must be one of: f1, accuracy, precision, recall.")
+
+    curve = calibration_curve(
+        scores,
+        labels=labels,
+        thresholds=thresholds,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+        greater_is_match=greater_is_match,
+    )
+    threshold_direction = 1.0 if greater_is_match else -1.0
+    best = max(
+        curve,
+        key=lambda item: (
+            item[metric_name],
+            item["precision"],
+            item["recall"],
+            item["accuracy"],
+            threshold_direction * item["threshold"],
+        ),
+    )
+    result = dict(best)
+    result["optimized_metric"] = metric_name
+    result["candidate_count"] = len(curve)
+    return result

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - Vectors and routing: vectors.md
   - Lexical metrics and baselines: lexical.md
   - Code metrics: code_metrics.md
+  - Scoring and calibration: scoring.md
   - Comparison suite: comparison_suite.md
   - Development: development.md
   - Release checklist: release_checklist.md

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,129 @@
+import pytest
+
+import matheel
+from matheel.calibration import (
+    calibrate_threshold,
+    calibration_curve,
+    evaluate_threshold,
+    feature_score_range,
+)
+
+
+def test_evaluate_threshold_reports_confusion_counts_and_metrics():
+    report = evaluate_threshold(
+        [0.9, 0.8, 0.4, 0.2],
+        [True, False, True, False],
+        threshold=0.5,
+    )
+
+    assert report["threshold"] == 0.5
+    assert report["true_positive"] == 1
+    assert report["false_positive"] == 1
+    assert report["true_negative"] == 1
+    assert report["false_negative"] == 1
+    assert report["precision"] == pytest.approx(0.5)
+    assert report["recall"] == pytest.approx(0.5)
+    assert report["f1"] == pytest.approx(0.5)
+    assert report["accuracy"] == pytest.approx(0.5)
+
+
+def test_calibration_helpers_are_exported_from_package_root():
+    assert matheel.calibrate_threshold is calibrate_threshold
+    assert matheel.calibration_curve is calibration_curve
+    assert matheel.evaluate_threshold is evaluate_threshold
+    assert matheel.feature_score_range is feature_score_range
+
+
+def test_calibrate_threshold_finds_best_cutoff_for_tiny_labeled_dataset():
+    report = calibrate_threshold(
+        [
+            (0.95, True),
+            (0.82, True),
+            (0.61, False),
+            (0.40, False),
+        ]
+    )
+
+    assert report["threshold"] == pytest.approx(0.82)
+    assert report["true_positive"] == 2
+    assert report["false_positive"] == 0
+    assert report["true_negative"] == 2
+    assert report["false_negative"] == 0
+    assert report["f1"] == pytest.approx(1.0)
+    assert report["optimized_metric"] == "f1"
+
+
+def test_calibrate_threshold_accepts_mapping_rows_and_custom_keys():
+    report = calibrate_threshold(
+        [
+            {"similarity_score": 0.3, "label": "different"},
+            {"similarity_score": 0.7, "label": "same"},
+            {"similarity_score": 0.8, "label": "same"},
+        ],
+        score_key="similarity_score",
+        label_key="label",
+        positive_label="same",
+    )
+
+    assert report["threshold"] == pytest.approx(0.7)
+    assert report["precision"] == pytest.approx(1.0)
+    assert report["recall"] == pytest.approx(1.0)
+
+
+def test_calibration_curve_accepts_explicit_thresholds():
+    curve = calibration_curve(
+        [0.9, 0.6, 0.2],
+        [True, False, False],
+        thresholds=[0.5, 0.8],
+    )
+
+    assert [item["threshold"] for item in curve] == [0.5, 0.8]
+    assert curve[0]["false_positive"] == 1
+    assert curve[1]["false_positive"] == 0
+
+
+def test_calibrate_threshold_supports_lower_scores_as_matches():
+    report = calibrate_threshold(
+        [0.1, 0.2, 0.8, 0.9],
+        [True, True, False, False],
+        greater_is_match=False,
+    )
+
+    assert report["threshold"] == pytest.approx(0.2)
+    assert report["f1"] == pytest.approx(1.0)
+
+
+def test_feature_score_range_documents_raw_and_normalized_scales():
+    assert feature_score_range("semantic", similarity_function="cosine") == (-1.0, 1.0)
+    assert feature_score_range("semantic", similarity_function="dot") == (
+        float("-inf"),
+        float("inf"),
+    )
+    assert feature_score_range("semantic", similarity_function="euclidean") == (
+        float("-inf"),
+        0.0,
+    )
+    assert feature_score_range(
+        "semantic",
+        similarity_function="euclidean",
+        normalize_semantic_scores=True,
+    ) == (0.0, 1.0)
+    assert feature_score_range("levenshtein") == (0.0, 1.0)
+    assert feature_score_range("jaro_winkler") == (0.0, 1.0)
+    assert feature_score_range("winnowing") == (0.0, 1.0)
+    assert feature_score_range("gst") == (0.0, 1.0)
+    assert feature_score_range("code_metric") == (0.0, 1.0)
+
+
+def test_calibration_rejects_invalid_inputs():
+    with pytest.raises(ValueError, match="same length"):
+        evaluate_threshold([0.1], [True, False])
+
+    with pytest.raises(ValueError, match="finite"):
+        evaluate_threshold([float("nan")], [True])
+
+    with pytest.raises(ValueError, match="At least one"):
+        calibrate_threshold([])
+
+    with pytest.raises(ValueError, match="Unsupported feature"):
+        feature_score_range("unknown")


### PR DESCRIPTION
Summary:
- Adds calibration helpers for threshold evaluation, threshold search, calibration curves, and feature score ranges.
- Adds tests covering calibration on tiny labeled datasets and score-range behavior.
- Adds scoring and calibration docs that separate raw scores, normalized semantic scores, weighted blends, and calibrated thresholds.

Checks:
- python -m ruff check .
- python -m pytest
- python -m mkdocs build --strict
- git diff --check

Closes #41