### PR TITLE
Document tokenization and preprocessing limits

### DIFF
--- a/docs/code_metrics.md
+++ b/docs/code_metrics.md
@@ -1,6 +1,7 @@
 # Code Metrics
 
 Matheel includes built-in code-aware metrics that can be blended into the final score or used on their own.
+Token-based code metrics and parser-backed code metrics use different tokenization/parsing paths. See [Tokenization and preprocessing limits](tokenization.md) for the full comparison.
 
 ## Parameters
 

--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -13,6 +13,8 @@ Matheel can blend lexical similarity with semantic and code-aware scores.
 - `gst`
   Greedy String Tiling over token sequences.
 
+Winnowing and GST use Matheel's shared code-token regex after preprocessing. They are deterministic lexical baselines, not parser-derived token streams. See [Tokenization and preprocessing limits](tokenization.md) for details.
+
 These are most useful when:
 
 - identifier changes are small

--- a/docs/preprocessing.md
+++ b/docs/preprocessing.md
@@ -57,6 +57,12 @@ Preprocessing is still text-first, but the current regression-tested language se
 
 The broader tree-sitter parser inventory makes future language additions realistic, but they should land with matching import/comment heuristics and tests before they are treated as officially supported preprocessing targets.
 
+## Order and Tokenization
+
+Preprocessing runs before lexical baselines, semantic embeddings, and code metrics. `advanced` applies the same cleanup as `basic`, then strips import-like lines, normalizes literals, and canonicalizes identifiers.
+
+See [Tokenization and preprocessing limits](tokenization.md) for the token streams used by Winnowing, GST, CrystalBLEU, RUBY, parser-backed metrics, and embedding backends.
+
 ## When To Use It
 
 - Use `none` when formatting, comments, or whitespace are meaningful for your task.

--- a/docs/tokenization.md
+++ b/docs/tokenization.md
@@ -1,0 +1,62 @@
+# Tokenization and Preprocessing Limits
+
+Matheel combines text-first preprocessing, token-level baselines, embedding backends, and optional parser-backed code metrics. These layers are related, but they do not all use the same token stream.
+
+## Pipeline Order
+
+For `calculate_similarity(...)` and `get_sim_list(...)`, the main order is:
+
+1. Read source text.
+2. Apply `preprocess_mode`.
+3. Build embeddings when the semantic feature is active.
+4. Tokenize for lexical baselines and token-based code metrics.
+5. Parse code for parser-backed code metrics when those metrics are active and their optional runtimes are available.
+6. Blend active feature scores with normalized feature weights.
+
+Preprocessing happens before lexical, semantic, and code-aware scoring. If you enable `advanced`, identifiers and literals may already be canonicalized before token-based metrics run.
+
+## Preprocessing Modes
+
+- `none`
+  Trims trailing whitespace and final surrounding whitespace only.
+- `normalize`
+  Normalizes line endings, trims trailing whitespace, and drops blank lines.
+- `basic`
+  Removes comments with language-aware string handling, drops blank lines, and collapses whitespace.
+- `advanced`
+  Runs `basic`, removes import-like lines, replaces string and numeric literals with placeholders, canonicalizes non-keyword identifiers, and collapses whitespace.
+
+Preprocessing is intentionally text-first. It uses language-specific comment and import heuristics, but it is not an AST rewrite.
+
+## Tokenization By Feature
+
+| Feature or metric | Tokenization or parsing strategy |
+| --- | --- |
+| `levenshtein` | Compares the prepared strings directly. |
+| `jaro_winkler` | Compares the prepared strings directly. |
+| `winnowing` | Uses Matheel's code-token regex over the prepared string. |
+| `gst` | Uses the same code-token regex as Winnowing. |
+| `crystalbleu` | Uses the same code-token regex, then builds n-grams and discounts frequent n-grams. |
+| `ruby` with `ruby_mode=ngram` | Uses the same code-token regex. |
+| `ruby` with `ruby_mode=string` and `ruby_tokenizer=regex` | Uses the same code-token regex. |
+| `ruby` with `ruby_tokenizer=tranx` | Splits punctuation and camel-case boundaries for a more granular token edit sequence. |
+| CodeBLEU syntax/dataflow | Uses tree-sitter-backed syntax and DFG extraction for supported languages. |
+| TSED | Parses syntax trees and compares tree edit distance when optional parser dependencies are installed. |
+| CodeBERTScore | Uses the selected transformer tokenizer. |
+| Semantic embeddings | Use the selected embedding backend's tokenizer or vectorizer. |
+
+The shared code-token regex recognizes identifiers, numbers, and punctuation. It does not split snake_case or camelCase by default. For example, `totalCount` stays one token in regex mode; RUBY's `tranx` tokenizer splits it into `total` and `Count`.
+
+## Parser-Token Limitations
+
+Matheel does not currently expose a parser-derived token stream for `winnowing`, `gst`, `crystalbleu`, or RUBY n-gram mode. That means these metrics are deterministic and lightweight, but they are not equivalent to parser-heavy plagiarism tools that normalize code through AST or grammar tokens.
+
+Important limitations:
+
+- lexical token baselines see surface token order and punctuation
+- parser-backed metrics depend on optional runtime availability
+- unsupported languages fall back only where a metric explicitly supports fallback behavior
+- preprocessing language hints improve comment/import handling, but they do not guarantee full parsing
+- aggressive `advanced` preprocessing can hide identifier and literal differences that some workflows may care about
+
+For parser-heavy comparisons, report the active preprocessing mode, tokenization-sensitive parameters, selected code metric, language, and optional parser availability alongside the score.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,6 +101,7 @@ print(results.head())
 ## Documentation Map
 
 - [Preprocessing](preprocessing.md)
+- [Tokenization and preprocessing limits](tokenization.md)
 - [Chunking](chunking.md)
 - [Vectors and routing](vectors.md)
 - [Lexical metrics and baselines](lexical.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Home: index.md
   - Usage: usage.md
   - Preprocessing: preprocessing.md
+  - Tokenization and limits: tokenization.md
   - Chunking: chunking.md
   - Vectors and routing: vectors.md
   - Lexical metrics and baselines: lexical.md

--- a/tests/test_code_metrics.py
+++ b/tests/test_code_metrics.py
@@ -14,6 +14,7 @@ from matheel.code_metrics import (
     prepare_crystalbleu_context,
     prepare_ruby_context,
     score_code_metric_pair,
+    tokenize_for_code_metrics,
 )
 
 try:
@@ -174,6 +175,59 @@ def test_available_code_metric_languages_expose_expanded_scope():
 
 def test_available_ast_metric_languages_match_structural_scope():
     assert available_ast_metric_languages() == tuple(SUPPORTED_LANGUAGE_SNIPPETS.keys())
+
+
+def test_code_metric_regex_tokenizer_keeps_identifiers_numbers_and_punctuation():
+    tokens = tokenize_for_code_metrics("def add_value(totalCount):\n    return totalCount + 42")
+
+    assert tokens == [
+        "def",
+        "add_value",
+        "(",
+        "totalCount",
+        ")",
+        ":",
+        "return",
+        "totalCount",
+        "+",
+        "42",
+    ]
+
+
+def test_code_metric_regex_tokenizer_does_not_parse_operator_pairs():
+    assert tokenize_for_code_metrics("items[i] += value // 2") == [
+        "items",
+        "[",
+        "i",
+        "]",
+        "+",
+        "=",
+        "value",
+        "/",
+        "/",
+        "2",
+    ]
+
+
+def test_ruby_tranx_tokenizer_splits_camel_case_more_aggressively():
+    assert code_metrics_module._tokenize_tranx("AddValue(totalCount, item2)") == [
+        "Add",
+        "Value",
+        "(",
+        "total",
+        "Count",
+        ",",
+        "item2",
+        ")",
+    ]
+
+
+def test_crystalbleu_context_uses_shared_code_metric_tokenizer():
+    context = prepare_crystalbleu_context(["items[i] += value // 2"], trivial_ngram_count=0)
+
+    assert context["tokens_by_doc"] == [
+        ["items", "[", "i", "]", "+", "=", "value", "/", "/", "2"]
+    ]
 
 
 @REQUIRES_CODEBLEU

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -590,6 +590,18 @@ def test_advanced_preprocess_normalizes_string_with_slashes_before_stripping_com
     assert "trailing" not in processed
 
 
+def test_advanced_preprocess_order_strips_imports_comments_then_normalizes_tokens():
+    code = """
+    import os
+    value = "abc # not comment" # trailing comment
+    return value + 123
+    """
+
+    processed = preprocess_code(code, mode="advanced", language="python")
+
+    assert processed == "id1 = <STR> return id1 + <NUM>"
+
+
 def test_basic_preprocess_preserves_python_floor_division():
     code = """
     value = total // count  # average


### PR DESCRIPTION
Summary:
- Adds a tokenization and preprocessing limits docs page.
- Clarifies preprocessing order and token/parsing strategies across lexical baselines and code metrics.
- Adds regression tests for shared code-token regex behavior, RUBY tranx tokenization, CrystalBLEU context tokens, and advanced preprocessing order.

Checks:
- python -m ruff check .
- python -m pytest
- python -m mkdocs build --strict
- git diff --check

Closes #44