### PR TITLE
Add concurrency guards for shared caches

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -40,3 +40,9 @@ python -m twine check dist/*
 ```
 
 Use the [release checklist](release_checklist.md) for the full release flow.
+
+## Cache Safety
+
+Matheel uses module-level caches for Hugging Face model metadata, detected tokenizer limits, CodeBLEU keyword sets, tree-sitter parsers, and CodeBERTScore scorer objects.
+
+Request-path cache writes are protected with locks so concurrent API or Gradio calls do not mutate the same cache at the same time. Keyword cache entries are stored as immutable values. Pair-level caches inside prepared run contexts are scoped to that run context and should not be reused across independent requests.

--- a/matheel/code_metrics.py
+++ b/matheel/code_metrics.py
@@ -3,6 +3,7 @@ import re
 import time
 from collections import Counter
 from pathlib import Path
+from threading import RLock
 
 from .native_codebleu import AVAILABLE_LANGUAGES as NATIVE_CODEBLEU_LANGUAGES
 from .native_codebleu import calc_codebleu as native_calc_codebleu
@@ -142,6 +143,12 @@ _CODEBLEU_KEYWORD_CACHE = {}
 _TREE_SITTER_PARSER_CACHE = {}
 _CODEBERTSCORE_SCORER_CACHE = {}
 _CODEBERTSCORE_LAYER_CACHE = {}
+_CODEBLEU_KEYWORD_CACHE_LOCK = RLock()
+_TREE_SITTER_PARSER_CACHE_LOCK = RLock()
+_TREE_SITTER_PARSE_LOCK = RLock()
+_CODEBERTSCORE_SCORER_CACHE_LOCK = RLock()
+_CODEBERTSCORE_SCORER_USAGE_LOCK = RLock()
+_CODEBERTSCORE_LAYER_CACHE_LOCK = RLock()
 _KEYWORDS = {
     "c": {
         "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else",
@@ -389,14 +396,15 @@ def keyword_set_for_language(language):
     if key not in _SUPPORTED_CODE_LANGUAGES:
         supported = ", ".join(_SUPPORTED_CODE_LANGUAGES)
         raise ValueError(f"Code metrics currently support: {supported}. Got: {language}")
-    if key in _CODEBLEU_KEYWORD_CACHE:
+    with _CODEBLEU_KEYWORD_CACHE_LOCK:
+        if key in _CODEBLEU_KEYWORD_CACHE:
+            return _CODEBLEU_KEYWORD_CACHE[key]
+        keywords = _fallback_keyword_set(key)
+        package_keywords = _load_package_keywords(key)
+        if package_keywords is not None:
+            keywords.update(package_keywords)
+        _CODEBLEU_KEYWORD_CACHE[key] = frozenset(keywords)
         return _CODEBLEU_KEYWORD_CACHE[key]
-    keywords = _fallback_keyword_set(key)
-    package_keywords = _load_package_keywords(key)
-    if package_keywords is not None:
-        keywords.update(package_keywords)
-    _CODEBLEU_KEYWORD_CACHE[key] = keywords
-    return _CODEBLEU_KEYWORD_CACHE[key]
 
 
 def tokenize_for_code_metrics(text):
@@ -913,31 +921,32 @@ def _tsed_runtime_available():
 
 def _resolve_tsed_parser(language):
     normalized_language = normalize_code_language(language)
-    if normalized_language in _TREE_SITTER_PARSER_CACHE:
-        return _TREE_SITTER_PARSER_CACHE[normalized_language]
+    with _TREE_SITTER_PARSER_CACHE_LOCK:
+        if normalized_language in _TREE_SITTER_PARSER_CACHE:
+            return _TREE_SITTER_PARSER_CACHE[normalized_language]
 
-    parser = None
-    if get_tree_sitter_parser is not None:
-        try:
-            parser = get_tree_sitter_parser(normalized_language)
-        except Exception:
-            parser = None
-
-    if parser is None and TreeSitterParser is not None and codebleu_get_tree_sitter_language is not None:
-        try:
-            ts_language = codebleu_get_tree_sitter_language(
-                _CODEBLEU_TREE_SITTER_LANGUAGE_NAMES.get(normalized_language, normalized_language)
-            )
+        parser = None
+        if get_tree_sitter_parser is not None:
             try:
-                parser = TreeSitterParser(ts_language)
-            except TypeError:
-                parser = TreeSitterParser()
-                parser.language = ts_language
-        except Exception:
-            parser = None
+                parser = get_tree_sitter_parser(normalized_language)
+            except Exception:
+                parser = None
 
-    _TREE_SITTER_PARSER_CACHE[normalized_language] = parser
-    return parser
+        if parser is None and TreeSitterParser is not None and codebleu_get_tree_sitter_language is not None:
+            try:
+                ts_language = codebleu_get_tree_sitter_language(
+                    _CODEBLEU_TREE_SITTER_LANGUAGE_NAMES.get(normalized_language, normalized_language)
+                )
+                try:
+                    parser = TreeSitterParser(ts_language)
+                except TypeError:
+                    parser = TreeSitterParser()
+                    parser.language = ts_language
+            except Exception:
+                parser = None
+
+        _TREE_SITTER_PARSER_CACHE[normalized_language] = parser
+        return parser
 
 
 def _tsed_from_tree_sitter_node(ts_node, depth, path, remaining_budget, max_depth, max_children):
@@ -973,7 +982,8 @@ def _tsed_get_tree(language, code, max_nodes=180, max_depth=10, max_children=8):
     if parser is None:
         return None
     try:
-        tree = parser.parse(bytes(code or "", encoding="utf-8"))
+        with _TREE_SITTER_PARSE_LOCK:
+            tree = parser.parse(bytes(code or "", encoding="utf-8"))
     except Exception:
         return None
     root = getattr(tree, "root_node", None)
@@ -1091,23 +1101,24 @@ def _resolve_codebertscore_device(requested):
 
 
 def _infer_codebertscore_num_layers(model_type):
-    if model_type in _CODEBERTSCORE_LAYER_CACHE:
-        return _CODEBERTSCORE_LAYER_CACHE[model_type]
-    if AutoConfig is None:
+    with _CODEBERTSCORE_LAYER_CACHE_LOCK:
+        if model_type in _CODEBERTSCORE_LAYER_CACHE:
+            return _CODEBERTSCORE_LAYER_CACHE[model_type]
+        if AutoConfig is None:
+            _CODEBERTSCORE_LAYER_CACHE[model_type] = None
+            return None
+        try:
+            config = AutoConfig.from_pretrained(model_type)
+        except Exception:
+            _CODEBERTSCORE_LAYER_CACHE[model_type] = None
+            return None
+        for attr in ("num_hidden_layers", "n_layer", "num_layers"):
+            value = getattr(config, attr, None)
+            if isinstance(value, int) and value > 0:
+                _CODEBERTSCORE_LAYER_CACHE[model_type] = int(value)
+                return int(value)
         _CODEBERTSCORE_LAYER_CACHE[model_type] = None
         return None
-    try:
-        config = AutoConfig.from_pretrained(model_type)
-    except Exception:
-        _CODEBERTSCORE_LAYER_CACHE[model_type] = None
-        return None
-    for attr in ("num_hidden_layers", "n_layer", "num_layers"):
-        value = getattr(config, attr, None)
-        if isinstance(value, int) and value > 0:
-            _CODEBERTSCORE_LAYER_CACHE[model_type] = int(value)
-            return int(value)
-    _CODEBERTSCORE_LAYER_CACHE[model_type] = None
-    return None
 
 
 def _infer_codebertscore_position_limit(scorer):
@@ -1200,21 +1211,22 @@ def _resolve_codebertscore_scorer(
         bool(use_fast_tokenizer),
         int(nthreads),
     )
-    if cache_key in _CODEBERTSCORE_SCORER_CACHE:
-        return _CODEBERTSCORE_SCORER_CACHE[cache_key]
+    with _CODEBERTSCORE_SCORER_CACHE_LOCK:
+        if cache_key in _CODEBERTSCORE_SCORER_CACHE:
+            return _CODEBERTSCORE_SCORER_CACHE[cache_key]
 
-    scorer = BERTScorer(
-        model_type=str(model_type),
-        num_layers=parsed_layers,
-        lang=normalized_lang,
-        idf=bool(idf),
-        rescale_with_baseline=bool(rescale_with_baseline),
-        use_fast_tokenizer=bool(use_fast_tokenizer),
-        nthreads=max(1, int(nthreads)),
-        device=resolved_device,
-    )
-    _CODEBERTSCORE_SCORER_CACHE[cache_key] = scorer
-    return scorer
+        scorer = BERTScorer(
+            model_type=str(model_type),
+            num_layers=parsed_layers,
+            lang=normalized_lang,
+            idf=bool(idf),
+            rescale_with_baseline=bool(rescale_with_baseline),
+            use_fast_tokenizer=bool(use_fast_tokenizer),
+            nthreads=max(1, int(nthreads)),
+            device=resolved_device,
+        )
+        _CODEBERTSCORE_SCORER_CACHE[cache_key] = scorer
+        return scorer
 
 
 def prepare_codebertscore_context(codes):
@@ -1264,16 +1276,17 @@ def _score_codebertscore_pair(
         use_fast_tokenizer=use_fast_tokenizer,
         nthreads=nthreads,
     )
-    _configure_codebertscore_tokenizer_max_length(scorer=scorer, requested_max_length=max_length)
     batch = max(1, int(batch_size))
 
-    _, _, f1_forward = scorer.score(cands=[right], refs=[left], batch_size=batch, verbose=bool(verbose))
-    score_forward = _tensor_values_to_float_list(f1_forward)[0]
-    if not bidirectional:
-        return float(score_forward)
+    with _CODEBERTSCORE_SCORER_USAGE_LOCK:
+        _configure_codebertscore_tokenizer_max_length(scorer=scorer, requested_max_length=max_length)
+        _, _, f1_forward = scorer.score(cands=[right], refs=[left], batch_size=batch, verbose=bool(verbose))
+        score_forward = _tensor_values_to_float_list(f1_forward)[0]
+        if not bidirectional:
+            return float(score_forward)
 
-    _, _, f1_reverse = scorer.score(cands=[left], refs=[right], batch_size=batch, verbose=bool(verbose))
-    score_reverse = _tensor_values_to_float_list(f1_reverse)[0]
+        _, _, f1_reverse = scorer.score(cands=[left], refs=[right], batch_size=batch, verbose=bool(verbose))
+        score_reverse = _tensor_values_to_float_list(f1_reverse)[0]
     return float((score_forward + score_reverse) * 0.5)
 
 

--- a/matheel/model_routing.py
+++ b/matheel/model_routing.py
@@ -1,3 +1,6 @@
+from threading import RLock
+
+
 _BACKEND_ALIASES = {
     "auto": "auto",
     "transformer": "sentence_transformers",
@@ -17,6 +20,7 @@ _BACKEND_ALIASES = {
 _PUBLIC_VECTOR_BACKENDS = ("auto", "sentence_transformers", "model2vec", "pylate")
 _DEPRECATED_VECTOR_BACKENDS = ("static_hash",)
 _HF_MODEL_INFO_CACHE = {}
+_HF_MODEL_INFO_CACHE_LOCK = RLock()
 
 
 def available_vector_backends(include_deprecated=False):
@@ -38,19 +42,20 @@ def load_hf_model_info(model_name):
     if not model_name:
         return None
     model_key = str(model_name).strip()
-    if model_key in _HF_MODEL_INFO_CACHE:
-        return _HF_MODEL_INFO_CACHE[model_key]
-    try:
-        from huggingface_hub import HfApi
-    except ImportError:  # pragma: no cover - sentence-transformers usually installs this
-        return None
+    with _HF_MODEL_INFO_CACHE_LOCK:
+        if model_key in _HF_MODEL_INFO_CACHE:
+            return _HF_MODEL_INFO_CACHE[model_key]
+        try:
+            from huggingface_hub import HfApi
+        except ImportError:  # pragma: no cover - sentence-transformers usually installs this
+            return None
 
-    try:
-        model_info = HfApi().model_info(model_key)
-    except Exception:  # pragma: no cover - network and auth are environment-specific
-        return None
-    _HF_MODEL_INFO_CACHE[model_key] = model_info
-    return model_info
+        try:
+            model_info = HfApi().model_info(model_key)
+        except Exception:  # pragma: no cover - network and auth are environment-specific
+            return None
+        _HF_MODEL_INFO_CACHE[model_key] = model_info
+        return model_info
 
 
 def _library_name_from_info(model_info):

--- a/matheel/vectors.py
+++ b/matheel/vectors.py
@@ -1,4 +1,5 @@
 import re
+from threading import RLock
 import zlib
 
 import numpy as np
@@ -47,6 +48,7 @@ _POOLING_MODE_FLAGS = {
     "lasttoken": "pooling_mode_lasttoken",
 }
 _MODEL_NAME_TOKEN_LENGTH_CACHE = {}
+_MODEL_NAME_TOKEN_LENGTH_CACHE_LOCK = RLock()
 
 
 def available_similarity_functions():
@@ -205,30 +207,31 @@ def _detect_token_length_from_model_name(model_name):
     model_key = str(model_name or "").strip()
     if not model_key:
         return None
-    if model_key in _MODEL_NAME_TOKEN_LENGTH_CACHE:
-        return _MODEL_NAME_TOKEN_LENGTH_CACHE[model_key]
+    with _MODEL_NAME_TOKEN_LENGTH_CACHE_LOCK:
+        if model_key in _MODEL_NAME_TOKEN_LENGTH_CACHE:
+            return _MODEL_NAME_TOKEN_LENGTH_CACHE[model_key]
 
-    try:
-        from transformers import AutoConfig, AutoTokenizer
-    except ImportError:
-        return None
+        try:
+            from transformers import AutoConfig, AutoTokenizer
+        except ImportError:
+            return None
 
-    try:
-        tokenizer = AutoTokenizer.from_pretrained(model_key)
-    except Exception:
-        tokenizer = None
-    detected = _detect_token_length_from_tokenizer(tokenizer)
-    if detected is not None:
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(model_key)
+        except Exception:
+            tokenizer = None
+        detected = _detect_token_length_from_tokenizer(tokenizer)
+        if detected is not None:
+            _MODEL_NAME_TOKEN_LENGTH_CACHE[model_key] = detected
+            return detected
+
+        try:
+            config = AutoConfig.from_pretrained(model_key)
+        except Exception:
+            config = None
+        detected = _detect_token_length_from_config(config)
         _MODEL_NAME_TOKEN_LENGTH_CACHE[model_key] = detected
         return detected
-
-    try:
-        config = AutoConfig.from_pretrained(model_key)
-    except Exception:
-        config = None
-    detected = _detect_token_length_from_config(config)
-    _MODEL_NAME_TOKEN_LENGTH_CACHE[model_key] = detected
-    return detected
 
 
 def detect_model_max_token_length(model=None, model_name=None, default=_DEFAULT_MAX_TOKEN_LENGTH):

--- a/tests/test_code_metrics.py
+++ b/tests/test_code_metrics.py
@@ -1,3 +1,7 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
 import pytest
 
 import matheel.code_metrics as code_metrics_module
@@ -228,6 +232,26 @@ def test_crystalbleu_context_uses_shared_code_metric_tokenizer():
     assert context["tokens_by_doc"] == [
         ["items", "[", "i", "]", "+", "=", "value", "/", "/", "2"]
     ]
+
+
+def test_keyword_cache_is_immutable_and_shared_across_concurrent_loads(monkeypatch):
+    calls = []
+
+    def fake_load_package_keywords(language):
+        calls.append(language)
+        time.sleep(0.01)
+        return {"custom_keyword"}
+
+    code_metrics_module._CODEBLEU_KEYWORD_CACHE.clear()
+    monkeypatch.setattr(code_metrics_module, "_load_package_keywords", fake_load_package_keywords)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(code_metrics_module.keyword_set_for_language, ["python"] * 8))
+
+    assert calls == ["python"]
+    assert len({id(result) for result in results}) == 1
+    assert "custom_keyword" in results[0]
+    assert isinstance(results[0], frozenset)
 
 
 @REQUIRES_CODEBLEU
@@ -807,6 +831,63 @@ def test_codebertscore_cache_key_includes_score_options(
     assert len(calls) == 2
 
 
+def test_codebertscore_layer_cache_is_shared_across_concurrent_inference(monkeypatch):
+    calls = []
+
+    class FakeAutoConfig:
+        @staticmethod
+        def from_pretrained(model_type):
+            calls.append(model_type)
+            time.sleep(0.01)
+            return SimpleNamespace(num_hidden_layers=7)
+
+    code_metrics_module._CODEBERTSCORE_LAYER_CACHE.clear()
+    monkeypatch.setattr(code_metrics_module, "AutoConfig", FakeAutoConfig)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(
+            executor.map(
+                code_metrics_module._infer_codebertscore_num_layers,
+                ["demo-codebert"] * 8,
+            )
+        )
+
+    assert results == [7] * 8
+    assert calls == ["demo-codebert"]
+
+
+def test_codebertscore_scorer_cache_is_shared_across_concurrent_resolution(monkeypatch):
+    calls = []
+
+    class FakeBERTScorer:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+            time.sleep(0.01)
+
+    code_metrics_module._CODEBERTSCORE_SCORER_CACHE.clear()
+    monkeypatch.setattr(code_metrics_module, "BERTScorer", FakeBERTScorer)
+    monkeypatch.setattr(code_metrics_module, "_infer_codebertscore_num_layers", lambda model_type: 7)
+    monkeypatch.setattr(code_metrics_module, "_resolve_codebertscore_device", lambda device: "cpu")
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(
+            executor.map(
+                lambda _: code_metrics_module._resolve_codebertscore_scorer(
+                    model_type="demo-codebert",
+                    num_layers=None,
+                    device="auto",
+                ),
+                range(8),
+            )
+        )
+
+    assert len({id(result) for result in results}) == 1
+    assert len(calls) == 1
+    assert calls[0]["model_type"] == "demo-codebert"
+    assert calls[0]["num_layers"] == 7
+    assert calls[0]["device"] == "cpu"
+
+
 def test_tsed_metric_scores_identical_higher_than_different():
     if not code_metrics_module._tsed_runtime_available():
         pytest.skip("TSED optional runtime is not available.")
@@ -875,6 +956,26 @@ def test_tsed_metric_uses_context_and_cost_options(monkeypatch):
         "right_tree": "right-tree",
         "costs": (2.0, 3.0, 4.0),
     }
+
+
+def test_tsed_parser_cache_is_shared_across_concurrent_resolution(monkeypatch):
+    calls = []
+    parser = object()
+
+    def fake_get_parser(language):
+        calls.append(language)
+        time.sleep(0.01)
+        return parser
+
+    code_metrics_module._TREE_SITTER_PARSER_CACHE.clear()
+    monkeypatch.setattr(code_metrics_module, "get_tree_sitter_parser", fake_get_parser)
+    monkeypatch.setattr(code_metrics_module, "TreeSitterParser", None)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(code_metrics_module._resolve_tsed_parser, ["python"] * 8))
+
+    assert results == [parser] * 8
+    assert calls == ["python"]
 
 
 @pytest.mark.parametrize("language,snippet", NEW_TREE_SITTER_LANGUAGE_SNIPPETS.items())

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -1,7 +1,14 @@
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import matheel.model_routing as model_routing_module
 from matheel.model_routing import (
     available_vector_backends,
     infer_model_backend,
     infer_model_capabilities,
+    load_hf_model_info,
     resolve_vector_backend,
 )
 
@@ -79,3 +86,23 @@ def test_colbert_tag_marks_model_as_multivector():
     assert capabilities["preferred_backend"] == "pylate"
     assert capabilities["supports_static"] is False
     assert capabilities["supports_multivector"] is True
+
+
+def test_hf_model_info_cache_is_shared_across_concurrent_loads(monkeypatch):
+    calls = []
+    model_info = FakeModelInfo(library_name="sentence-transformers")
+
+    class FakeHfApi:
+        def model_info(self, model_name):
+            calls.append(model_name)
+            time.sleep(0.01)
+            return model_info
+
+    model_routing_module._HF_MODEL_INFO_CACHE.clear()
+    monkeypatch.setitem(sys.modules, "huggingface_hub", SimpleNamespace(HfApi=FakeHfApi))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(load_hf_model_info, ["demo/model"] * 8))
+
+    assert results == [model_info] * 8
+    assert calls == ["demo/model"]

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -1,5 +1,11 @@
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
 import pytest
 
+import matheel.vectors as vectors_module
 from matheel.vectors import (
     available_pooling_methods,
     available_similarity_functions,
@@ -126,6 +132,38 @@ def test_detect_model_max_token_length_ignores_large_tokenizer_sentinel():
         config = DummyConfig()
 
     assert detect_model_max_token_length(model=DummyModel()) == 1024
+
+
+def test_model_name_token_length_cache_is_shared_across_concurrent_loads(monkeypatch):
+    calls = []
+
+    class FakeTokenizer:
+        model_max_length = 384
+
+    class FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(model_name):
+            calls.append(model_name)
+            time.sleep(0.01)
+            return FakeTokenizer()
+
+    class FakeAutoConfig:
+        @staticmethod
+        def from_pretrained(model_name):
+            raise AssertionError(f"config lookup should not run after tokenizer hit: {model_name}")
+
+    vectors_module._MODEL_NAME_TOKEN_LENGTH_CACHE.clear()
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(AutoConfig=FakeAutoConfig, AutoTokenizer=FakeAutoTokenizer),
+    )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: detect_model_max_token_length(model_name="demo-model"), range(8)))
+
+    assert results == [384] * 8
+    assert calls == ["demo-model"]
 
 
 def test_configure_model_max_token_length_clamps_to_detected_limit():


### PR DESCRIPTION
Summary:
- Adds locks around request-path module caches for model metadata, token-length detection, CodeBLEU keywords, tree-sitter parsers, and CodeBERTScore scorer and layer caches.
- Stores CodeBLEU keyword cache entries as immutable values and serializes parser and scorer use.
- Adds concurrent cache tests and documents cache-safety expectations.

Checks:
- python -m ruff check .
- python -m pytest
- python -m mkdocs build --strict
- git diff --check

Closes #51