### PR TITLE
Prepare v0.3.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See the [usage guide](https://fahadebrahim.github.io/matheel/usage/) for semanti
 
 - Documentation: [fahadebrahim.github.io/matheel](https://fahadebrahim.github.io/matheel/)
 - Hugging Face Space demo: [buelfhood/matheel-framework](https://huggingface.co/spaces/buelfhood/matheel-framework)
-- Gradio Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/gradio_app/matheel_gradio_colab_demo.ipynb)
+- Gradio Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_gradio_colab_demo.ipynb)
 - Examples Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_examples_colab.ipynb)
 - Examples folder: [examples/](https://github.com/FahadEbrahim/matheel/tree/main/examples)
 - Development: [development docs](https://fahadebrahim.github.io/matheel/development/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 ## Demos and Examples
 
 - [Hugging Face Space demo](https://huggingface.co/spaces/buelfhood/matheel-framework)
-- [Gradio Colab notebook](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/gradio_app/matheel_gradio_colab_demo.ipynb)
+- [Gradio Colab notebook](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_gradio_colab_demo.ipynb)
 - [Examples Colab notebook](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_examples_colab.ipynb)
 - [Examples folder](https://github.com/FahadEbrahim/matheel/tree/main/examples)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -94,7 +94,7 @@ print(results.head())
 ## Demos and Examples
 
 - Hugging Face Space demo: [buelfhood/matheel-framework](https://huggingface.co/spaces/buelfhood/matheel-framework)
-- Gradio Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/gradio_app/matheel_gradio_colab_demo.ipynb)
+- Gradio Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_gradio_colab_demo.ipynb)
 - Examples Colab notebook: [Open in Colab](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/matheel_examples_colab.ipynb)
 - Examples folder: [github.com/FahadEbrahim/matheel/tree/main/examples](https://github.com/FahadEbrahim/matheel/tree/main/examples)
 

--- a/examples/matheel_gradio_colab_demo.ipynb
+++ b/examples/matheel_gradio_colab_demo.ipynb
@@ -25,9 +25,9 @@
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",
     "cd /content/matheel\n",
-    "git checkout v0.3.4\n",
+    "git checkout v0.3.7\n",
     "pip install -e \".[all]\"\n",
-    "echo \"Matheel v0.3.4 is installed. Colab dependency alignment can take a few minutes. If Colab asks, restart the runtime once before launching the app.\"\n"
+    "echo \"Matheel v0.3.7 is installed. Colab dependency alignment can take a few minutes. If Colab asks, restart the runtime once before launching the app.\"\n"
    ]
   },
   {
@@ -74,7 +74,7 @@
    "source": [
     "If the launch cell shows a public Gradio link, open that link. If the first model interaction feels slow, that is usually the initial Hugging Face download.\n",
     "\n",
-    "To tune code metrics, open the **Features** accordion, enable **Code Metric**, select your metric, then adjust the metric-specific fields."
+    "To tune code metrics, open the **Metrics** accordion, enable **Code Metric**, select your metric, then adjust the metric-specific fields."
    ]
   }
  ],

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.3.6` and includes:
+This Space is aligned with `matheel==0.3.7` and includes:
 
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.3.6
+matheel[all]==0.3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.3.6"
+version = "0.3.7"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
Summary:
- Bumps Matheel to 0.3.7 and syncs the Gradio Space package pin.
- Moves the Gradio Colab notebook out of the synced Space directory and updates public links.
- Updates the moved notebook to use the v0.3.7 tag and current UI labels.

Checks:
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- python -m build
- python -m twine check dist/*
- git diff --check

Closes #100