### PR TITLE
Add labeled pair evaluation foundation

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,0 +1,113 @@
+# Datasets and Evaluation
+
+Matheel supports local labeled pair datasets as the first step toward benchmark workflows.
+
+No external datasets are bundled or downloaded by default. Add public datasets only after checking licensing, provenance, access requirements, and expected task meaning.
+
+## Dataset Registry
+
+Dataset tracking uses these fields:
+
+| Field | Meaning |
+| --- | --- |
+| `name` | Stable dataset identifier. |
+| `task_type` | High-level task label. Use `plagiarism` for plagiarism-oriented datasets. |
+| `dataset_kind` | Dataset layout, such as `pair_classification` or `retrieval`. |
+| `languages` | Languages covered by the dataset. |
+| `license` | Dataset license or `unknown`. |
+| `source_url` | Public source page. |
+| `access` | `bundled`, `download`, `manual`, or `external`. |
+| `citation` | Citation text or DOI when available. |
+| `notes` | Short caveats about labels, splits, or preprocessing. |
+
+The built-in registry starts empty. Register datasets in code only after deciding they should be tracked by Matheel:
+
+```python
+from matheel.datasets import register_dataset_entry
+
+register_dataset_entry(
+    "example_plagiarism_dataset",
+    task_type="plagiarism",
+    dataset_kind="pair_classification",
+    languages=("python",),
+    license="unknown",
+    source_url="https://example.org/dataset",
+    access="manual",
+    notes="Example registry entry only.",
+)
+```
+
+## Pair Dataset Format
+
+A pair-classification dataset directory contains:
+
+```text
+metadata.json
+files.csv
+pairs.csv
+files/
+```
+
+`metadata.json` should include:
+
+```json
+{
+  "task_type": "plagiarism",
+  "dataset_kind": "pair_classification",
+  "name": "tiny_plagiarism_fixture"
+}
+```
+
+`files.csv` must include:
+
+| Column | Meaning |
+| --- | --- |
+| `file_id` | Stable file identifier with no path separators. |
+| `file_path` | Relative path under the dataset directory. |
+
+`pairs.csv` must include:
+
+| Column | Meaning |
+| --- | --- |
+| `left_id` | File id for the first submission. |
+| `right_id` | File id for the second submission. |
+| `label` | Binary label, where `1` means positive/plagiarism match and `0` means negative. |
+
+You can write a small dataset programmatically:
+
+```python
+import pandas as pd
+from matheel.datasets import write_pair_dataset
+
+write_pair_dataset(
+    "tiny_pairs",
+    files=pd.DataFrame(
+        [
+            {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+            {"file_id": "b", "text": "print(1)", "suffix": ".py"},
+            {"file_id": "c", "text": "print(2)", "suffix": ".py"},
+        ]
+    ),
+    pairs=pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "label": 1},
+            {"left_id": "a", "right_id": "c", "label": 0},
+        ]
+    ),
+    metadata={"name": "tiny_plagiarism_fixture"},
+)
+```
+
+## Pair Evaluation
+
+Use the CLI to score local pair datasets and write both scored rows and metrics:
+
+```bash
+matheel evaluate-pairs tiny_pairs \
+  --feature-weight levenshtein=1.0 \
+  --threshold 0.8 \
+  --scores-out scored_pairs.csv \
+  --metrics-out pair_metrics.json
+```
+
+The command defaults to `levenshtein=1.0` so small local evaluations are offline-friendly. Add semantic features explicitly when you want model-backed scoring.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 - [Vectors and routing](vectors.md)
 - [Lexical metrics and baselines](lexical.md)
 - [Code metrics](code_metrics.md)
+- [Datasets and evaluation](datasets.md)
 - [Comparison suite](comparison_suite.md)
 - [Development](development.md)
 - [Release checklist](release_checklist.md)
@@ -37,4 +38,5 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 2. Read [Vectors and routing](vectors.md) to choose the embedding path.
 3. Add [Chunking](chunking.md) and [Preprocessing](preprocessing.md) if you need code-aware shaping before scoring.
 4. Add [Lexical metrics and baselines](lexical.md) and [Code metrics](code_metrics.md) if you want hybrid scoring.
-5. Use [Comparison suite](comparison_suite.md) for repeatable multi-run experiments.
+5. Use [Datasets and evaluation](datasets.md) for labeled pair datasets.
+6. Use [Comparison suite](comparison_suite.md) for repeatable multi-run experiments.

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -12,6 +12,19 @@ from .code_metrics import (
     codebleu_components,
     score_code_metric_pair,
 )
+from .datasets import (
+    PairDataset,
+    available_dataset_kinds,
+    available_dataset_task_types,
+    get_dataset_entry,
+    load_code_texts,
+    load_pair_dataset,
+    registered_datasets,
+    register_dataset_entry,
+    validate_pair_dataset,
+    write_pair_dataset,
+)
+from .evaluation import evaluate_pair_dataset, pair_classification_metrics, score_pair_dataset
 from .feature_weights import available_default_features, default_feature_weights, normalize_feature_weights
 from .model_routing import infer_model_backend, infer_model_capabilities, available_vector_backends
 from .preprocessing import preprocess_code
@@ -32,6 +45,8 @@ __all__ = [
     "available_code_metrics",
     "available_code_metric_languages",
     "available_default_features",
+    "available_dataset_kinds",
+    "available_dataset_task_types",
     "available_pooling_methods",
     "available_runtime_devices",
     "available_similarity_functions",
@@ -43,18 +58,29 @@ __all__ = [
     "chunker_parameter_names",
     "codebleu_components",
     "evaluate_threshold",
+    "evaluate_pair_dataset",
     "feature_score_range",
     "get_sim_list",
+    "get_dataset_entry",
     "infer_model_backend",
     "infer_model_capabilities",
     "inspect_model_settings",
+    "load_code_texts",
+    "load_pair_dataset",
     "load_run_configs",
     "default_feature_weights",
     "normalize_feature_weights",
+    "PairDataset",
+    "pair_classification_metrics",
     "parse_run_configs",
     "preprocess_code",
+    "registered_datasets",
+    "register_dataset_entry",
     "run_comparison_suite",
+    "score_pair_dataset",
     "score_code_metric_pair",
     "detect_default_device",
     "similarity_function_score_range",
+    "validate_pair_dataset",
+    "write_pair_dataset",
 ]

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -1,10 +1,13 @@
+import json
 import sys
+from pathlib import Path
 
 import click
 
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
 from ._progress import should_show_progress
+from .evaluation import evaluate_pair_dataset
 from .similarity import DEFAULT_MODEL_NAME, available_runtime_devices, get_sim_list
 from .chunking import available_chunk_aggregations, available_chunking_methods
 from .model_routing import available_vector_backends
@@ -356,6 +359,108 @@ def compare_suite(source_path, config_file, summary_out, details_dir, output_for
         click.echo("No runs were executed.")
         return
     click.echo(summary.to_string(index=False))
+
+
+@main.command(name="evaluate-pairs")
+@click.argument("dataset_path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.option("--scores-out", type=click.Path(), default="scored_pairs.csv", show_default=True)
+@click.option("--metrics-out", type=click.Path(), default="pair_metrics.json", show_default=True)
+@click.option("--threshold", default=0.5, show_default=True, help="Classification threshold.")
+@click.option(
+    "--feature-weight",
+    "feature_weights",
+    multiple=True,
+    help=(
+        "Normalized feature weights as name=value. "
+        "Defaults to levenshtein=1.0 for offline-friendly evaluation."
+    ),
+)
+@click.option("--model", default=DEFAULT_MODEL_NAME, show_default=True, help="Embedding model name.")
+@click.option(
+    "--preprocess-mode",
+    type=click.Choice(available_preprocess_modes()),
+    default="none",
+    show_default=True,
+)
+@click.option("--code-language", default="python", show_default=True)
+@click.option(
+    "--vector-backend",
+    type=click.Choice(available_vector_backends()),
+    default="auto",
+    show_default=True,
+)
+@click.option(
+    "--similarity-function",
+    type=click.Choice(available_similarity_functions()),
+    default="cosine",
+    show_default=True,
+)
+@click.option(
+    "--normalize-semantic-scores/--raw-semantic-scores",
+    default=False,
+    show_default=True,
+)
+@click.option("--max-token-length", default=0, show_default=True)
+@click.option(
+    "--pooling-method",
+    type=click.Choice(available_pooling_methods()),
+    default="mean",
+    show_default=True,
+)
+@click.option(
+    "--device",
+    type=click.Choice(("auto",) + available_runtime_devices()),
+    default="auto",
+    show_default=True,
+)
+def evaluate_pairs(
+    dataset_path,
+    scores_out,
+    metrics_out,
+    threshold,
+    feature_weights,
+    model,
+    preprocess_mode,
+    code_language,
+    vector_backend,
+    similarity_function,
+    normalize_semantic_scores,
+    max_token_length,
+    pooling_method,
+    device,
+):
+    """Evaluate a local pair-classification dataset."""
+    selected_weights = feature_weights or ("levenshtein=1.0",)
+    scored_pairs, metrics = evaluate_pair_dataset(
+        dataset_path,
+        threshold=threshold,
+        similarity_options={
+            "feature_weights": selected_weights,
+            "model_name": model,
+            "preprocess_mode": preprocess_mode,
+            "code_language": code_language,
+            "vector_backend": vector_backend,
+            "similarity_function": similarity_function,
+            "normalize_semantic_scores": normalize_semantic_scores,
+            "max_token_length": max_token_length,
+            "pooling_method": pooling_method,
+            "device": device,
+        },
+    )
+    scores_path = Path(scores_out)
+    metrics_path = Path(metrics_out)
+    scores_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    scored_pairs.to_csv(scores_path, index=False)
+    metrics_path.write_text(json.dumps(metrics, indent=2, sort_keys=True), encoding="utf-8")
+    click.echo(f"Wrote {len(scored_pairs)} scored pair(s) to {scores_path}.")
+    click.echo(f"Wrote metrics to {metrics_path}.")
+    click.echo(
+        f"accuracy={metrics['accuracy']:.4f} "
+        f"precision={metrics['precision']:.4f} "
+        f"recall={metrics['recall']:.4f} "
+        f"f1={metrics['f1']:.4f}"
+    )
 
 
 def _elapsed_summary_text(results):

--- a/matheel/datasets.py
+++ b/matheel/datasets.py
@@ -1,0 +1,318 @@
+import json
+import math
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+
+DATASET_TASK_TYPES = ("plagiarism",)
+DATASET_KINDS = ("pair_classification", "retrieval")
+DATASET_ACCESS_TYPES = ("bundled", "download", "manual", "external")
+_DATASET_REGISTRY = {}
+
+
+@dataclass(frozen=True)
+class DatasetRegistryEntry:
+    name: str
+    task_type: str
+    dataset_kind: str
+    languages: tuple[str, ...]
+    license: str
+    source_url: str
+    access: str
+    citation: str = ""
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class PairDataset:
+    root: Path
+    files: pd.DataFrame
+    pairs: pd.DataFrame
+    metadata: dict
+
+
+def available_dataset_task_types():
+    return DATASET_TASK_TYPES
+
+
+def available_dataset_kinds():
+    return DATASET_KINDS
+
+
+def registered_datasets(task_type=None, dataset_kind=None):
+    entries = tuple(_DATASET_REGISTRY[name] for name in sorted(_DATASET_REGISTRY))
+    if task_type is not None:
+        requested_task = _normalize_choice(task_type, DATASET_TASK_TYPES, "task_type")
+        entries = tuple(entry for entry in entries if entry.task_type == requested_task)
+    if dataset_kind is not None:
+        requested_kind = _normalize_choice(dataset_kind, DATASET_KINDS, "dataset_kind")
+        entries = tuple(entry for entry in entries if entry.dataset_kind == requested_kind)
+    return entries
+
+
+def get_dataset_entry(name):
+    key = _normalize_name(name)
+    try:
+        return _DATASET_REGISTRY[key]
+    except KeyError as exc:
+        raise KeyError(f"Unknown registered dataset: {name}") from exc
+
+
+def register_dataset_entry(
+    name,
+    task_type,
+    dataset_kind,
+    languages=(),
+    license="unknown",
+    source_url="",
+    access="manual",
+    citation="",
+    notes="",
+    overwrite=False,
+):
+    key = _normalize_name(name)
+    if key in _DATASET_REGISTRY and not overwrite:
+        raise ValueError(f"Dataset registry entry already exists: {key}")
+    entry = DatasetRegistryEntry(
+        name=key,
+        task_type=_normalize_choice(task_type, DATASET_TASK_TYPES, "task_type"),
+        dataset_kind=_normalize_choice(dataset_kind, DATASET_KINDS, "dataset_kind"),
+        languages=tuple(str(language).strip().lower() for language in (languages or ()) if str(language).strip()),
+        license=str(license or "unknown").strip() or "unknown",
+        source_url=str(source_url or "").strip(),
+        access=_normalize_choice(access, DATASET_ACCESS_TYPES, "access"),
+        citation=str(citation or "").strip(),
+        notes=str(notes or "").strip(),
+    )
+    _DATASET_REGISTRY[key] = entry
+    return entry
+
+
+def load_pair_dataset(dataset_root):
+    root = _coerce_path(dataset_root)
+    metadata = _read_json(root / "metadata.json")
+    files = _load_files_manifest(root)
+    pairs_path = root / "pairs.csv"
+    if not pairs_path.exists():
+        raise ValueError(f"Missing pairs manifest: {pairs_path}")
+    pairs = pd.read_csv(pairs_path)
+    dataset = PairDataset(root=root, files=files, pairs=pairs, metadata=metadata)
+    return validate_pair_dataset(dataset)
+
+
+def write_pair_dataset(dataset_root, files, pairs, metadata=None):
+    root = _coerce_path(dataset_root)
+    root.mkdir(parents=True, exist_ok=True)
+    files_manifest = _write_files_manifest(root, files)
+    pairs_frame = _coerce_frame(pairs, required_columns=("left_id", "right_id", "label"), frame_name="pairs")
+    pairs_frame["left_id"] = pairs_frame["left_id"].map(lambda value: _normalize_id(value, "left_id"))
+    pairs_frame["right_id"] = pairs_frame["right_id"].map(lambda value: _normalize_id(value, "right_id"))
+    pairs_frame["label"] = pairs_frame["label"].map(_normalize_binary_label)
+    pairs_frame.to_csv(root / "pairs.csv", index=False)
+    payload = _normalize_metadata(metadata, dataset_kind="pair_classification")
+    _write_json(root / "metadata.json", payload)
+    return validate_pair_dataset(
+        PairDataset(root=root, files=files_manifest, pairs=pairs_frame, metadata=payload)
+    )
+
+
+def validate_pair_dataset(dataset):
+    if isinstance(dataset, (str, os.PathLike)):
+        dataset = load_pair_dataset(dataset)
+    if not isinstance(dataset, PairDataset):
+        raise ValueError("validate_pair_dataset expects a PairDataset or dataset path.")
+
+    metadata = _normalize_metadata(dataset.metadata, dataset_kind="pair_classification")
+    if metadata["dataset_kind"] != "pair_classification":
+        raise ValueError("Pair datasets must use dataset_kind='pair_classification'.")
+
+    files = _coerce_frame(dataset.files, required_columns=("file_id", "file_path"), frame_name="files")
+    pairs = _coerce_frame(dataset.pairs, required_columns=("left_id", "right_id", "label"), frame_name="pairs")
+    files["file_id"] = files["file_id"].map(lambda value: _normalize_id(value, "file_id"))
+    files["file_path"] = files["file_path"].map(_normalize_relative_file_path)
+    pairs["left_id"] = pairs["left_id"].map(lambda value: _normalize_id(value, "left_id"))
+    pairs["right_id"] = pairs["right_id"].map(lambda value: _normalize_id(value, "right_id"))
+    pairs["label"] = pairs["label"].map(_normalize_binary_label)
+
+    duplicate_ids = files["file_id"][files["file_id"].duplicated()].tolist()
+    if duplicate_ids:
+        raise ValueError(f"files.csv contains duplicate file_id values: {', '.join(sorted(set(duplicate_ids)))}")
+
+    file_ids = set(files["file_id"].tolist())
+    missing = sorted(
+        {file_id for file_id in pairs["left_id"].tolist() + pairs["right_id"].tolist() if file_id not in file_ids}
+    )
+    if missing:
+        raise ValueError(f"pairs.csv references unknown file ids: {', '.join(missing)}")
+
+    for file_path in files["file_path"].tolist():
+        target = dataset.root / file_path
+        if not target.exists():
+            raise ValueError(f"files.csv references missing file: {file_path}")
+
+    return PairDataset(root=dataset.root, files=files, pairs=pairs, metadata=metadata)
+
+
+def load_code_texts(dataset):
+    if isinstance(dataset, (str, os.PathLike)):
+        dataset = load_pair_dataset(dataset)
+    if not isinstance(dataset, PairDataset):
+        raise ValueError("load_code_texts expects a PairDataset or dataset path.")
+
+    texts = {}
+    for row in dataset.files.to_dict(orient="records"):
+        file_id = _normalize_id(row["file_id"], "file_id")
+        file_path = _normalize_relative_file_path(row["file_path"])
+        texts[file_id] = (dataset.root / file_path).read_text(encoding="utf-8", errors="ignore")
+    return texts
+
+
+def _normalize_name(value):
+    name = str(value or "").strip().lower()
+    if not name:
+        raise ValueError("Dataset registry names must be non-empty.")
+    if any(separator in name for separator in ("/", "\\")):
+        raise ValueError(f"Dataset registry names must not contain path separators. Got: {value}")
+    return name
+
+
+def _normalize_choice(value, choices, label):
+    key = str(value or "").strip().lower()
+    if key not in choices:
+        supported = ", ".join(choices)
+        raise ValueError(f"{label} must be one of: {supported}. Got: {value}")
+    return key
+
+
+def _normalize_metadata(metadata, dataset_kind):
+    payload = dict(metadata or {})
+    payload["task_type"] = _normalize_choice(payload.get("task_type") or "plagiarism", DATASET_TASK_TYPES, "task_type")
+    payload["dataset_kind"] = _normalize_choice(
+        payload.get("dataset_kind") or dataset_kind,
+        DATASET_KINDS,
+        "dataset_kind",
+    )
+    return payload
+
+
+def _coerce_path(path):
+    return Path(path).expanduser().resolve()
+
+
+def _read_json(path):
+    target = Path(path)
+    if not target.exists():
+        return {}
+    return json.loads(target.read_text(encoding="utf-8"))
+
+
+def _write_json(path, payload):
+    Path(path).write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _coerce_frame(records, required_columns, frame_name):
+    frame = records.copy() if isinstance(records, pd.DataFrame) else pd.DataFrame(records)
+    missing = [column for column in required_columns if column not in frame.columns]
+    if missing:
+        raise ValueError(f"{frame_name} is missing required columns: {', '.join(missing)}")
+    return frame.copy()
+
+
+def _normalize_id(value, label):
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} must be non-empty.")
+    if "/" in text or "\\" in text:
+        raise ValueError(f"{label} must not contain path separators. Got: {value}")
+    return text
+
+
+def _normalize_relative_file_path(value):
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("file_path must be non-empty.")
+    path = Path(text)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"file_path must be relative to the dataset root. Got: {value}")
+    return path.as_posix()
+
+
+def _normalize_binary_label(value):
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str):
+        key = value.strip().lower()
+        if key in {"1", "true", "yes", "y", "positive", "plagiarized", "plagiarism", "match"}:
+            return 1
+        if key in {"0", "false", "no", "n", "negative", "original", "non_plagiarism", "non-match"}:
+            return 0
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Binary labels must be 0 or 1. Got: {value}") from exc
+    if not math.isfinite(numeric) or numeric not in (0.0, 1.0):
+        raise ValueError(f"Binary labels must be 0 or 1. Got: {value}")
+    return int(numeric)
+
+
+def _output_suffix(row):
+    for column in ("suffix", "extension"):
+        value = row.get(column)
+        if pd.notna(value) and str(value).strip():
+            suffix = str(value).strip()
+            return suffix if suffix.startswith(".") else f".{suffix}"
+    source_path = row.get("source_path")
+    if pd.notna(source_path) and str(source_path).strip():
+        return Path(str(source_path)).suffix or ".txt"
+    return ".txt"
+
+
+def _write_files_manifest(dataset_root, files):
+    files_frame = _coerce_frame(files, required_columns=("file_id",), frame_name="files")
+    if "text" not in files_frame.columns and "source_path" not in files_frame.columns:
+        raise ValueError("files must include either a text column or a source_path column.")
+
+    files_dir = dataset_root / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    rows = []
+    seen_ids = set()
+    for row in files_frame.to_dict(orient="records"):
+        file_id = _normalize_id(row.get("file_id"), "file_id")
+        if file_id in seen_ids:
+            raise ValueError(f"Duplicate file_id in files manifest: {file_id}")
+        seen_ids.add(file_id)
+
+        relative_path = Path("files") / f"{file_id}{_output_suffix(row)}"
+        output_path = dataset_root / relative_path
+        text = row.get("text")
+        source_path = row.get("source_path")
+        if pd.notna(text):
+            output_path.write_text(str(text), encoding="utf-8")
+        elif pd.notna(source_path):
+            shutil.copyfile(os.fspath(source_path), output_path)
+        else:
+            raise ValueError(f"File entry for {file_id} must include text or source_path.")
+
+        manifest = {
+            key: value
+            for key, value in row.items()
+            if key not in {"text", "source_path", "suffix", "extension"}
+        }
+        manifest["file_id"] = file_id
+        manifest["file_path"] = relative_path.as_posix()
+        rows.append(manifest)
+
+    manifest_frame = pd.DataFrame(rows).sort_values(by="file_id", ignore_index=True)
+    manifest_frame.to_csv(dataset_root / "files.csv", index=False)
+    return manifest_frame
+
+
+def _load_files_manifest(dataset_root):
+    files_path = Path(dataset_root) / "files.csv"
+    if not files_path.exists():
+        raise ValueError(f"Missing files manifest: {files_path}")
+    return pd.read_csv(files_path)

--- a/matheel/evaluation.py
+++ b/matheel/evaluation.py
@@ -1,0 +1,77 @@
+import math
+
+import pandas as pd
+
+from .calibration import evaluate_threshold
+from .datasets import PairDataset, load_code_texts, load_pair_dataset
+from .similarity import calculate_similarity
+
+
+def score_pair_dataset(
+    dataset,
+    scorer=None,
+    similarity_options=None,
+    score_column="similarity_score",
+):
+    if not isinstance(dataset, PairDataset):
+        dataset = load_pair_dataset(dataset)
+    texts = load_code_texts(dataset)
+    options = dict(similarity_options or {})
+    rows = []
+    for pair in dataset.pairs.to_dict(orient="records"):
+        left_id = str(pair["left_id"])
+        right_id = str(pair["right_id"])
+        left_text = texts[left_id]
+        right_text = texts[right_id]
+        if scorer is None:
+            score = calculate_similarity(left_text, right_text, **options)
+        else:
+            score = scorer(left_text, right_text, pair)
+        numeric_score = float(score)
+        if not math.isfinite(numeric_score):
+            raise ValueError(f"Pair score must be finite. Got: {score}")
+        row = dict(pair)
+        row[score_column] = numeric_score
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def pair_classification_metrics(
+    scored_pairs,
+    threshold=0.5,
+    score_column="similarity_score",
+    label_column="label",
+):
+    frame = scored_pairs.copy() if isinstance(scored_pairs, pd.DataFrame) else pd.DataFrame(scored_pairs)
+    for column in (score_column, label_column):
+        if column not in frame.columns:
+            raise ValueError(f"scored_pairs is missing required column: {column}")
+    metrics = evaluate_threshold(
+        frame.to_dict(orient="records"),
+        threshold=threshold,
+        score_key=score_column,
+        label_key=label_column,
+    )
+    metrics["pair_count"] = int(len(frame))
+    return metrics
+
+
+def evaluate_pair_dataset(
+    dataset,
+    threshold=0.5,
+    scorer=None,
+    similarity_options=None,
+    score_column="similarity_score",
+):
+    scored_pairs = score_pair_dataset(
+        dataset,
+        scorer=scorer,
+        similarity_options=similarity_options,
+        score_column=score_column,
+    )
+    metrics = pair_classification_metrics(
+        scored_pairs,
+        threshold=threshold,
+        score_column=score_column,
+    )
+    return scored_pairs, metrics

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Lexical metrics and baselines: lexical.md
   - Code metrics: code_metrics.md
   - Scoring and calibration: scoring.md
+  - Datasets and evaluation: datasets.md
   - Comparison suite: comparison_suite.md
   - Development: development.md
   - Release checklist: release_checklist.md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
+import json
+
 from click.testing import CliRunner
 import pandas as pd
 
 from matheel.cli import main
+from matheel.datasets import write_pair_dataset
 
 
 def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
@@ -254,6 +257,50 @@ def test_compare_command_rejects_inactive_code_metric_weight(tmp_path):
     assert result.exit_code != 0
     assert isinstance(result.exception, ValueError)
     assert "code_metric_weight requires an active code_metric" in str(result.exception)
+
+
+def test_evaluate_pairs_command_writes_scores_and_metrics(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "c", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame(
+            [
+                {"left_id": "a", "right_id": "b", "label": 1},
+                {"left_id": "a", "right_id": "c", "label": 0},
+            ]
+        ),
+    )
+    scores_path = tmp_path / "scores.csv"
+    metrics_path = tmp_path / "metrics.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "evaluate-pairs",
+            str(dataset_root),
+            "--threshold",
+            "0.8",
+            "--scores-out",
+            str(scores_path),
+            "--metrics-out",
+            str(metrics_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert scores_path.exists()
+    assert metrics_path.exists()
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["pair_count"] == 2
+    assert "accuracy=" in result.output
 
 
 def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import pytest
+
+from matheel.datasets import (
+    available_dataset_kinds,
+    available_dataset_task_types,
+    get_dataset_entry,
+    load_code_texts,
+    load_pair_dataset,
+    registered_datasets,
+    register_dataset_entry,
+    write_pair_dataset,
+)
+
+
+def test_dataset_registry_tracks_plagiarism_entries():
+    entry = register_dataset_entry(
+        "unit_plagiarism_pairs",
+        task_type="plagiarism",
+        dataset_kind="pair_classification",
+        languages=("python", "java"),
+        license="unknown",
+        source_url="https://example.invalid/unit",
+        access="manual",
+        overwrite=True,
+    )
+
+    assert available_dataset_task_types() == ("plagiarism",)
+    assert "pair_classification" in available_dataset_kinds()
+    assert get_dataset_entry("unit_plagiarism_pairs") == entry
+    assert entry in registered_datasets(task_type="plagiarism", dataset_kind="pair_classification")
+
+
+def test_pair_dataset_roundtrip_writes_manifest_files(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    files = pd.DataFrame(
+        [
+            {"file_id": "a", "text": "print(1)", "suffix": ".py", "language": "python"},
+            {"file_id": "b", "text": "print(1)", "suffix": ".py", "language": "python"},
+            {"file_id": "c", "text": "print(2)", "suffix": ".py", "language": "python"},
+        ]
+    )
+    pairs = pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "label": "plagiarism"},
+            {"left_id": "a", "right_id": "c", "label": "negative"},
+        ]
+    )
+
+    written = write_pair_dataset(
+        dataset_root,
+        files=files,
+        pairs=pairs,
+        metadata={"name": "tiny", "task_type": "plagiarism"},
+    )
+    loaded = load_pair_dataset(dataset_root)
+    texts = load_code_texts(loaded)
+
+    assert written.metadata["task_type"] == "plagiarism"
+    assert loaded.metadata["dataset_kind"] == "pair_classification"
+    assert loaded.pairs["label"].tolist() == [1, 0]
+    assert texts == {"a": "print(1)", "b": "print(1)", "c": "print(2)"}
+    assert (dataset_root / "files" / "a.py").exists()
+
+
+def test_pair_dataset_rejects_unknown_file_reference(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame([{"file_id": "a", "text": "print(1)"}]),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "a", "label": 1}]),
+    )
+    pairs_path = dataset_root / "pairs.csv"
+    pairs_path.write_text("left_id,right_id,label\na,missing,1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown file ids: missing"):
+        load_pair_dataset(dataset_root)
+
+
+def test_pair_dataset_rejects_path_separator_file_ids(tmp_path):
+    with pytest.raises(ValueError, match="path separators"):
+        write_pair_dataset(
+            tmp_path / "pairs",
+            files=pd.DataFrame([{"file_id": "../a", "text": "print(1)"}]),
+            pairs=pd.DataFrame([{"left_id": "../a", "right_id": "../a", "label": 1}]),
+        )

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import pytest
+
+from matheel.datasets import write_pair_dataset
+from matheel.evaluation import (
+    evaluate_pair_dataset,
+    pair_classification_metrics,
+    score_pair_dataset,
+)
+
+
+def _write_tiny_pair_dataset(path):
+    return write_pair_dataset(
+        path,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "c", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame(
+            [
+                {"left_id": "a", "right_id": "b", "label": 1},
+                {"left_id": "a", "right_id": "c", "label": 0},
+            ]
+        ),
+    )
+
+
+def test_score_pair_dataset_uses_custom_scorer(tmp_path):
+    dataset = _write_tiny_pair_dataset(tmp_path / "pairs")
+
+    scored = score_pair_dataset(
+        dataset,
+        scorer=lambda left, right, pair: 1.0 if left == right else 0.0,
+    )
+
+    assert scored["similarity_score"].tolist() == [1.0, 0.0]
+    assert scored["label"].tolist() == [1, 0]
+
+
+def test_evaluate_pair_dataset_returns_scored_pairs_and_metrics(tmp_path):
+    dataset = _write_tiny_pair_dataset(tmp_path / "pairs")
+
+    scored, metrics = evaluate_pair_dataset(
+        dataset,
+        threshold=0.5,
+        scorer=lambda left, right, pair: 1.0 if left == right else 0.0,
+    )
+
+    assert len(scored) == 2
+    assert metrics["accuracy"] == 1.0
+    assert metrics["precision"] == 1.0
+    assert metrics["recall"] == 1.0
+    assert metrics["f1"] == 1.0
+
+
+def test_pair_classification_metrics_requires_score_column():
+    with pytest.raises(ValueError, match="similarity_score"):
+        pair_classification_metrics([{"label": 1}], threshold=0.5)


### PR DESCRIPTION
Summary:
- Adds local pair-classification dataset manifests, validation, text loading, and writer helpers.
- Adds a dataset registry schema with task_type set up for plagiarism tracking, without adding external datasets.
- Adds pair scoring, classification metrics, and an offline-friendly evaluate-pairs CLI command that writes scored rows and metrics.
- Documents the dataset format, registry fields, and current policy that no external datasets are bundled or downloaded by default.

Checks:
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- git diff --check

Refs #39