### PR TITLE
Add retrieval dataset evaluation foundation

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,8 +1,9 @@
 # Datasets and Evaluation
 
-Matheel supports local labeled pair datasets as the first step toward benchmark workflows.
+Matheel supports local labeled pair and retrieval datasets as the first step toward benchmark workflows.
 
 No external datasets are bundled or downloaded by default. Add public datasets only after checking licensing, provenance, access requirements, and expected task meaning.
+Use `task_type: plagiarism` for plagiarism-oriented datasets so they remain easy to separate from future dataset families.
 
 ## Dataset Registry
 
@@ -111,3 +112,89 @@ matheel evaluate-pairs tiny_pairs \
 ```
 
 The command defaults to `levenshtein=1.0` so small local evaluations are offline-friendly. Add semantic features explicitly when you want model-backed scoring.
+
+## Retrieval Dataset Format
+
+A retrieval dataset directory contains:
+
+```text
+metadata.json
+files.csv
+queries.csv
+corpus.csv
+qrels.csv
+files/
+```
+
+`metadata.json` should include:
+
+```json
+{
+  "task_type": "plagiarism",
+  "dataset_kind": "retrieval",
+  "name": "tiny_plagiarism_retrieval_fixture"
+}
+```
+
+`files.csv` uses the same columns as pair datasets. `queries.csv` maps query ids to files:
+
+| Column | Meaning |
+| --- | --- |
+| `query_id` | Stable query identifier with no path separators. |
+| `file_id` | File id from `files.csv`. |
+
+`corpus.csv` maps candidate document ids to files:
+
+| Column | Meaning |
+| --- | --- |
+| `document_id` | Stable document identifier with no path separators. |
+| `file_id` | File id from `files.csv`. |
+
+`qrels.csv` stores relevance judgments:
+
+| Column | Meaning |
+| --- | --- |
+| `query_id` | Query id from `queries.csv`. |
+| `document_id` | Candidate document id from `corpus.csv`. |
+| `relevance` | Non-negative relevance score. Values greater than `0` are treated as relevant. |
+
+You can write a small retrieval dataset programmatically:
+
+```python
+import pandas as pd
+from matheel.datasets import write_retrieval_dataset
+
+write_retrieval_dataset(
+    "tiny_retrieval",
+    files=pd.DataFrame(
+        [
+            {"file_id": "query_a", "text": "print(1)", "suffix": ".py"},
+            {"file_id": "doc_a", "text": "print(1)", "suffix": ".py"},
+            {"file_id": "doc_b", "text": "print(2)", "suffix": ".py"},
+        ]
+    ),
+    queries=pd.DataFrame([{"query_id": "q1", "file_id": "query_a"}]),
+    corpus=pd.DataFrame(
+        [
+            {"document_id": "d1", "file_id": "doc_a"},
+            {"document_id": "d2", "file_id": "doc_b"},
+        ]
+    ),
+    qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    metadata={"name": "tiny_plagiarism_retrieval_fixture"},
+)
+```
+
+## Retrieval Evaluation
+
+Use the CLI to score each query against every corpus document and write ranking metrics:
+
+```bash
+matheel evaluate-retrieval tiny_retrieval \
+  --feature-weight levenshtein=1.0 \
+  --k 10 \
+  --scores-out scored_retrieval.csv \
+  --metrics-out retrieval_metrics.json
+```
+
+The metrics include mean average precision, mean reciprocal rank, precision at `k`, recall at `k`, and nDCG at `k`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,5 +38,5 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 2. Read [Vectors and routing](vectors.md) to choose the embedding path.
 3. Add [Chunking](chunking.md) and [Preprocessing](preprocessing.md) if you need code-aware shaping before scoring.
 4. Add [Lexical metrics and baselines](lexical.md) and [Code metrics](code_metrics.md) if you want hybrid scoring.
-5. Use [Datasets and evaluation](datasets.md) for labeled pair datasets.
+5. Use [Datasets and evaluation](datasets.md) for labeled pair and retrieval datasets.
 6. Use [Comparison suite](comparison_suite.md) for repeatable multi-run experiments.

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -14,17 +14,28 @@ from .code_metrics import (
 )
 from .datasets import (
     PairDataset,
+    RetrievalDataset,
     available_dataset_kinds,
     available_dataset_task_types,
     get_dataset_entry,
     load_code_texts,
     load_pair_dataset,
+    load_retrieval_dataset,
     registered_datasets,
     register_dataset_entry,
     validate_pair_dataset,
+    validate_retrieval_dataset,
     write_pair_dataset,
+    write_retrieval_dataset,
 )
-from .evaluation import evaluate_pair_dataset, pair_classification_metrics, score_pair_dataset
+from .evaluation import (
+    evaluate_pair_dataset,
+    evaluate_retrieval_dataset,
+    pair_classification_metrics,
+    retrieval_ranking_metrics,
+    score_pair_dataset,
+    score_retrieval_dataset,
+)
 from .feature_weights import available_default_features, default_feature_weights, normalize_feature_weights
 from .model_routing import infer_model_backend, infer_model_capabilities, available_vector_backends
 from .preprocessing import preprocess_code
@@ -76,11 +87,18 @@ __all__ = [
     "preprocess_code",
     "registered_datasets",
     "register_dataset_entry",
+    "RetrievalDataset",
+    "retrieval_ranking_metrics",
     "run_comparison_suite",
     "score_pair_dataset",
+    "score_retrieval_dataset",
     "score_code_metric_pair",
     "detect_default_device",
     "similarity_function_score_range",
     "validate_pair_dataset",
+    "validate_retrieval_dataset",
     "write_pair_dataset",
+    "write_retrieval_dataset",
+    "evaluate_retrieval_dataset",
+    "load_retrieval_dataset",
 ]

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -7,7 +7,7 @@ import click
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
 from ._progress import should_show_progress
-from .evaluation import evaluate_pair_dataset
+from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
 from .similarity import DEFAULT_MODEL_NAME, available_runtime_devices, get_sim_list
 from .chunking import available_chunk_aggregations, available_chunking_methods
 from .model_routing import available_vector_backends
@@ -460,6 +460,109 @@ def evaluate_pairs(
         f"precision={metrics['precision']:.4f} "
         f"recall={metrics['recall']:.4f} "
         f"f1={metrics['f1']:.4f}"
+    )
+
+
+@main.command(name="evaluate-retrieval")
+@click.argument("dataset_path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.option("--scores-out", type=click.Path(), default="scored_retrieval.csv", show_default=True)
+@click.option("--metrics-out", type=click.Path(), default="retrieval_metrics.json", show_default=True)
+@click.option("--k", default=10, show_default=True, help="Ranking cutoff for top-k metrics.")
+@click.option(
+    "--feature-weight",
+    "feature_weights",
+    multiple=True,
+    help=(
+        "Normalized feature weights as name=value. "
+        "Defaults to levenshtein=1.0 for offline-friendly evaluation."
+    ),
+)
+@click.option("--model", default=DEFAULT_MODEL_NAME, show_default=True, help="Embedding model name.")
+@click.option(
+    "--preprocess-mode",
+    type=click.Choice(available_preprocess_modes()),
+    default="none",
+    show_default=True,
+)
+@click.option("--code-language", default="python", show_default=True)
+@click.option(
+    "--vector-backend",
+    type=click.Choice(available_vector_backends()),
+    default="auto",
+    show_default=True,
+)
+@click.option(
+    "--similarity-function",
+    type=click.Choice(available_similarity_functions()),
+    default="cosine",
+    show_default=True,
+)
+@click.option(
+    "--normalize-semantic-scores/--raw-semantic-scores",
+    default=False,
+    show_default=True,
+)
+@click.option("--max-token-length", default=0, show_default=True)
+@click.option(
+    "--pooling-method",
+    type=click.Choice(available_pooling_methods()),
+    default="mean",
+    show_default=True,
+)
+@click.option(
+    "--device",
+    type=click.Choice(("auto",) + available_runtime_devices()),
+    default="auto",
+    show_default=True,
+)
+def evaluate_retrieval(
+    dataset_path,
+    scores_out,
+    metrics_out,
+    k,
+    feature_weights,
+    model,
+    preprocess_mode,
+    code_language,
+    vector_backend,
+    similarity_function,
+    normalize_semantic_scores,
+    max_token_length,
+    pooling_method,
+    device,
+):
+    """Evaluate a local retrieval dataset."""
+    selected_weights = feature_weights or ("levenshtein=1.0",)
+    scored_results, metrics = evaluate_retrieval_dataset(
+        dataset_path,
+        k=k,
+        similarity_options={
+            "feature_weights": selected_weights,
+            "model_name": model,
+            "preprocess_mode": preprocess_mode,
+            "code_language": code_language,
+            "vector_backend": vector_backend,
+            "similarity_function": similarity_function,
+            "normalize_semantic_scores": normalize_semantic_scores,
+            "max_token_length": max_token_length,
+            "pooling_method": pooling_method,
+            "device": device,
+        },
+    )
+    scores_path = Path(scores_out)
+    metrics_path = Path(metrics_out)
+    scores_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    scored_results.to_csv(scores_path, index=False)
+    metrics_path.write_text(json.dumps(metrics, indent=2, sort_keys=True), encoding="utf-8")
+    click.echo(f"Wrote {len(scored_results)} scored retrieval result(s) to {scores_path}.")
+    click.echo(f"Wrote metrics to {metrics_path}.")
+    click.echo(
+        f"map={metrics['mean_average_precision']:.4f} "
+        f"mrr={metrics['mean_reciprocal_rank']:.4f} "
+        f"precision_at_{metrics['k']}={metrics['precision_at_k']:.4f} "
+        f"recall_at_{metrics['k']}={metrics['recall_at_k']:.4f} "
+        f"ndcg_at_{metrics['k']}={metrics['ndcg_at_k']:.4f}"
     )
 
 

--- a/matheel/datasets.py
+++ b/matheel/datasets.py
@@ -35,6 +35,16 @@ class PairDataset:
     metadata: dict
 
 
+@dataclass(frozen=True)
+class RetrievalDataset:
+    root: Path
+    files: pd.DataFrame
+    queries: pd.DataFrame
+    corpus: pd.DataFrame
+    qrels: pd.DataFrame
+    metadata: dict
+
+
 def available_dataset_task_types():
     return DATASET_TASK_TYPES
 
@@ -157,11 +167,179 @@ def validate_pair_dataset(dataset):
     return PairDataset(root=dataset.root, files=files, pairs=pairs, metadata=metadata)
 
 
+def load_retrieval_dataset(dataset_root):
+    root = _coerce_path(dataset_root)
+    metadata = _read_json(root / "metadata.json")
+    files = _load_files_manifest(root)
+
+    queries_path = root / "queries.csv"
+    corpus_path = root / "corpus.csv"
+    qrels_path = root / "qrels.csv"
+    for label, path in (
+        ("queries manifest", queries_path),
+        ("corpus manifest", corpus_path),
+        ("qrels manifest", qrels_path),
+    ):
+        if not path.exists():
+            raise ValueError(f"Missing {label}: {path}")
+
+    dataset = RetrievalDataset(
+        root=root,
+        files=files,
+        queries=pd.read_csv(queries_path),
+        corpus=pd.read_csv(corpus_path),
+        qrels=pd.read_csv(qrels_path),
+        metadata=metadata,
+    )
+    return validate_retrieval_dataset(dataset)
+
+
+def write_retrieval_dataset(dataset_root, files, queries, corpus, qrels, metadata=None):
+    root = _coerce_path(dataset_root)
+    root.mkdir(parents=True, exist_ok=True)
+    files_manifest = _write_files_manifest(root, files)
+
+    queries_frame = _coerce_frame(queries, required_columns=("query_id", "file_id"), frame_name="queries")
+    corpus_frame = _coerce_frame(corpus, required_columns=("document_id", "file_id"), frame_name="corpus")
+    qrels_frame = _coerce_frame(
+        qrels,
+        required_columns=("query_id", "document_id", "relevance"),
+        frame_name="qrels",
+    )
+
+    queries_frame["query_id"] = queries_frame["query_id"].map(lambda value: _normalize_id(value, "query_id"))
+    queries_frame["file_id"] = queries_frame["file_id"].map(lambda value: _normalize_id(value, "file_id"))
+    corpus_frame["document_id"] = corpus_frame["document_id"].map(
+        lambda value: _normalize_id(value, "document_id")
+    )
+    corpus_frame["file_id"] = corpus_frame["file_id"].map(lambda value: _normalize_id(value, "file_id"))
+    qrels_frame["query_id"] = qrels_frame["query_id"].map(lambda value: _normalize_id(value, "query_id"))
+    qrels_frame["document_id"] = qrels_frame["document_id"].map(
+        lambda value: _normalize_id(value, "document_id")
+    )
+    qrels_frame["relevance"] = qrels_frame["relevance"].map(_normalize_nonnegative_relevance)
+
+    queries_frame.to_csv(root / "queries.csv", index=False)
+    corpus_frame.to_csv(root / "corpus.csv", index=False)
+    qrels_frame.to_csv(root / "qrels.csv", index=False)
+
+    payload = _normalize_metadata(metadata, dataset_kind="retrieval")
+    _write_json(root / "metadata.json", payload)
+    return validate_retrieval_dataset(
+        RetrievalDataset(
+            root=root,
+            files=files_manifest,
+            queries=queries_frame,
+            corpus=corpus_frame,
+            qrels=qrels_frame,
+            metadata=payload,
+        )
+    )
+
+
+def validate_retrieval_dataset(dataset):
+    if isinstance(dataset, (str, os.PathLike)):
+        dataset = load_retrieval_dataset(dataset)
+    if not isinstance(dataset, RetrievalDataset):
+        raise ValueError("validate_retrieval_dataset expects a RetrievalDataset or dataset path.")
+
+    metadata = _normalize_metadata(dataset.metadata, dataset_kind="retrieval")
+    if metadata["dataset_kind"] != "retrieval":
+        raise ValueError("Retrieval datasets must use dataset_kind='retrieval'.")
+
+    files = _coerce_frame(dataset.files, required_columns=("file_id", "file_path"), frame_name="files")
+    queries = _coerce_frame(dataset.queries, required_columns=("query_id", "file_id"), frame_name="queries")
+    corpus = _coerce_frame(dataset.corpus, required_columns=("document_id", "file_id"), frame_name="corpus")
+    qrels = _coerce_frame(
+        dataset.qrels,
+        required_columns=("query_id", "document_id", "relevance"),
+        frame_name="qrels",
+    )
+
+    files["file_id"] = files["file_id"].map(lambda value: _normalize_id(value, "file_id"))
+    files["file_path"] = files["file_path"].map(_normalize_relative_file_path)
+    queries["query_id"] = queries["query_id"].map(lambda value: _normalize_id(value, "query_id"))
+    queries["file_id"] = queries["file_id"].map(lambda value: _normalize_id(value, "file_id"))
+    corpus["document_id"] = corpus["document_id"].map(lambda value: _normalize_id(value, "document_id"))
+    corpus["file_id"] = corpus["file_id"].map(lambda value: _normalize_id(value, "file_id"))
+    qrels["query_id"] = qrels["query_id"].map(lambda value: _normalize_id(value, "query_id"))
+    qrels["document_id"] = qrels["document_id"].map(lambda value: _normalize_id(value, "document_id"))
+    qrels["relevance"] = qrels["relevance"].map(_normalize_nonnegative_relevance)
+
+    duplicate_file_ids = files["file_id"][files["file_id"].duplicated()].tolist()
+    if duplicate_file_ids:
+        raise ValueError(
+            f"files.csv contains duplicate file_id values: {', '.join(sorted(set(duplicate_file_ids)))}"
+        )
+
+    duplicate_query_ids = queries["query_id"][queries["query_id"].duplicated()].tolist()
+    if duplicate_query_ids:
+        raise ValueError(
+            f"queries.csv contains duplicate query_id values: {', '.join(sorted(set(duplicate_query_ids)))}"
+        )
+
+    duplicate_document_ids = corpus["document_id"][corpus["document_id"].duplicated()].tolist()
+    if duplicate_document_ids:
+        raise ValueError(
+            "corpus.csv contains duplicate document_id values: "
+            f"{', '.join(sorted(set(duplicate_document_ids)))}"
+        )
+
+    duplicate_qrels = qrels[qrels.duplicated(subset=["query_id", "document_id"])]
+    if not duplicate_qrels.empty:
+        pairs = sorted(
+            f"{row['query_id']}->{row['document_id']}"
+            for row in duplicate_qrels.to_dict(orient="records")
+        )
+        raise ValueError(f"qrels.csv contains duplicate query/document judgments: {', '.join(pairs)}")
+
+    file_ids = set(files["file_id"].tolist())
+    missing_query_files = sorted(file_id for file_id in queries["file_id"].tolist() if file_id not in file_ids)
+    if missing_query_files:
+        raise ValueError(f"queries.csv references unknown file ids: {', '.join(missing_query_files)}")
+
+    missing_corpus_files = sorted(file_id for file_id in corpus["file_id"].tolist() if file_id not in file_ids)
+    if missing_corpus_files:
+        raise ValueError(f"corpus.csv references unknown file ids: {', '.join(missing_corpus_files)}")
+
+    query_ids = set(queries["query_id"].tolist())
+    document_ids = set(corpus["document_id"].tolist())
+    missing_queries = sorted(query_id for query_id in qrels["query_id"].tolist() if query_id not in query_ids)
+    if missing_queries:
+        raise ValueError(f"qrels.csv references unknown query ids: {', '.join(missing_queries)}")
+
+    missing_documents = sorted(
+        document_id for document_id in qrels["document_id"].tolist() if document_id not in document_ids
+    )
+    if missing_documents:
+        raise ValueError(f"qrels.csv references unknown document ids: {', '.join(missing_documents)}")
+
+    for file_path in files["file_path"].tolist():
+        target = dataset.root / file_path
+        if not target.exists():
+            raise ValueError(f"files.csv references missing file: {file_path}")
+
+    return RetrievalDataset(
+        root=dataset.root,
+        files=files,
+        queries=queries,
+        corpus=corpus,
+        qrels=qrels,
+        metadata=metadata,
+    )
+
+
 def load_code_texts(dataset):
     if isinstance(dataset, (str, os.PathLike)):
-        dataset = load_pair_dataset(dataset)
-    if not isinstance(dataset, PairDataset):
-        raise ValueError("load_code_texts expects a PairDataset or dataset path.")
+        root = _coerce_path(dataset)
+        metadata = _read_json(root / "metadata.json")
+        dataset_kind = str(metadata.get("dataset_kind") or "").strip().lower()
+        if dataset_kind == "retrieval":
+            dataset = load_retrieval_dataset(root)
+        else:
+            dataset = load_pair_dataset(root)
+    if not isinstance(dataset, (PairDataset, RetrievalDataset)):
+        raise ValueError("load_code_texts expects a PairDataset, RetrievalDataset, or dataset path.")
 
     texts = {}
     for row in dataset.files.to_dict(orient="records"):
@@ -257,6 +435,16 @@ def _normalize_binary_label(value):
     if not math.isfinite(numeric) or numeric not in (0.0, 1.0):
         raise ValueError(f"Binary labels must be 0 or 1. Got: {value}")
     return int(numeric)
+
+
+def _normalize_nonnegative_relevance(value):
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Relevance values must be finite and non-negative. Got: {value}") from exc
+    if not math.isfinite(numeric) or numeric < 0:
+        raise ValueError(f"Relevance values must be finite and non-negative. Got: {value}")
+    return numeric
 
 
 def _output_suffix(row):

--- a/matheel/evaluation.py
+++ b/matheel/evaluation.py
@@ -3,7 +3,7 @@ import math
 import pandas as pd
 
 from .calibration import evaluate_threshold
-from .datasets import PairDataset, load_code_texts, load_pair_dataset
+from .datasets import PairDataset, RetrievalDataset, load_code_texts, load_pair_dataset, load_retrieval_dataset
 from .similarity import calculate_similarity
 
 
@@ -75,3 +75,239 @@ def evaluate_pair_dataset(
         score_column=score_column,
     )
     return scored_pairs, metrics
+
+
+def score_retrieval_dataset(
+    dataset,
+    scorer=None,
+    similarity_options=None,
+    score_column="similarity_score",
+):
+    if not isinstance(dataset, RetrievalDataset):
+        dataset = load_retrieval_dataset(dataset)
+    texts = load_code_texts(dataset)
+    options = dict(similarity_options or {})
+    qrels_lookup = _qrels_lookup(dataset.qrels)
+    rows = []
+
+    query_rows = dataset.queries.to_dict(orient="records")
+    corpus_rows = dataset.corpus.to_dict(orient="records")
+    for query in query_rows:
+        query_id = str(query["query_id"])
+        query_file_id = str(query["file_id"])
+        query_text = texts[query_file_id]
+        for document in corpus_rows:
+            document_id = str(document["document_id"])
+            document_file_id = str(document["file_id"])
+            document_text = texts[document_file_id]
+            row = {
+                "query_id": query_id,
+                "document_id": document_id,
+                "query_file_id": query_file_id,
+                "document_file_id": document_file_id,
+                "relevance": float(qrels_lookup.get((query_id, document_id), 0.0)),
+            }
+            if scorer is None:
+                score = calculate_similarity(query_text, document_text, **options)
+            else:
+                score = scorer(query_text, document_text, row)
+            numeric_score = float(score)
+            if not math.isfinite(numeric_score):
+                raise ValueError(f"Retrieval score must be finite. Got: {score}")
+            row[score_column] = numeric_score
+            rows.append(row)
+
+    return pd.DataFrame(rows)
+
+
+def retrieval_ranking_metrics(
+    scored_results,
+    qrels=None,
+    k=10,
+    score_column="similarity_score",
+    query_column="query_id",
+    document_column="document_id",
+    relevance_column="relevance",
+):
+    if k <= 0:
+        raise ValueError("k must be greater than zero.")
+
+    frame = scored_results.copy() if isinstance(scored_results, pd.DataFrame) else pd.DataFrame(scored_results)
+    for column in (query_column, document_column, score_column):
+        if column not in frame.columns:
+            raise ValueError(f"scored_results is missing required column: {column}")
+
+    if qrels is None:
+        if relevance_column not in frame.columns:
+            raise ValueError(f"scored_results is missing required column: {relevance_column}")
+        qrels_frame = frame[[query_column, document_column, relevance_column]].copy()
+    else:
+        qrels_frame = qrels.copy() if isinstance(qrels, pd.DataFrame) else pd.DataFrame(qrels)
+        for column in (query_column, document_column, relevance_column):
+            if column not in qrels_frame.columns:
+                raise ValueError(f"qrels is missing required column: {column}")
+
+    frame = frame.copy()
+    frame[score_column] = frame[score_column].map(_normalize_finite_score)
+    qrels_lookup = _qrels_lookup(
+        qrels_frame,
+        query_column=query_column,
+        document_column=document_column,
+        relevance_column=relevance_column,
+    )
+    query_ids = sorted(set(frame[query_column].astype(str).tolist()) | {query for query, _ in qrels_lookup})
+
+    average_precisions = []
+    reciprocal_ranks = []
+    precision_at_k_values = []
+    recall_at_k_values = []
+    ndcg_at_k_values = []
+    relevant_count = 0
+
+    for query_id in query_ids:
+        relevant_by_document = {
+            document_id: relevance
+            for (judged_query_id, document_id), relevance in qrels_lookup.items()
+            if judged_query_id == query_id and relevance > 0
+        }
+        relevant_count += len(relevant_by_document)
+        ranked = _rank_query_results(
+            frame[frame[query_column].astype(str) == query_id],
+            document_column=document_column,
+            score_column=score_column,
+        )
+        ranked_documents = ranked[document_column].astype(str).tolist()
+
+        average_precisions.append(_average_precision(ranked_documents, relevant_by_document))
+        reciprocal_ranks.append(_reciprocal_rank(ranked_documents, relevant_by_document))
+        precision_at_k_values.append(_precision_at_k(ranked_documents, relevant_by_document, k))
+        recall_at_k_values.append(_recall_at_k(ranked_documents, relevant_by_document, k))
+        ndcg_at_k_values.append(_ndcg_at_k(ranked_documents, relevant_by_document, k))
+
+    return {
+        "query_count": int(len(query_ids)),
+        "result_count": int(len(frame)),
+        "relevant_count": int(relevant_count),
+        "k": int(k),
+        "mean_average_precision": _mean(average_precisions),
+        "mean_reciprocal_rank": _mean(reciprocal_ranks),
+        "precision_at_k": _mean(precision_at_k_values),
+        "recall_at_k": _mean(recall_at_k_values),
+        "ndcg_at_k": _mean(ndcg_at_k_values),
+    }
+
+
+def evaluate_retrieval_dataset(
+    dataset,
+    k=10,
+    scorer=None,
+    similarity_options=None,
+    score_column="similarity_score",
+):
+    if not isinstance(dataset, RetrievalDataset):
+        dataset = load_retrieval_dataset(dataset)
+    scored_results = score_retrieval_dataset(
+        dataset,
+        scorer=scorer,
+        similarity_options=similarity_options,
+        score_column=score_column,
+    )
+    metrics = retrieval_ranking_metrics(
+        scored_results,
+        qrels=dataset.qrels,
+        k=k,
+        score_column=score_column,
+    )
+    return scored_results, metrics
+
+
+def _qrels_lookup(
+    qrels,
+    query_column="query_id",
+    document_column="document_id",
+    relevance_column="relevance",
+):
+    frame = qrels.copy() if isinstance(qrels, pd.DataFrame) else pd.DataFrame(qrels)
+    lookup = {}
+    for row in frame.to_dict(orient="records"):
+        query_id = str(row[query_column])
+        document_id = str(row[document_column])
+        relevance = _normalize_nonnegative_relevance(row[relevance_column])
+        lookup[(query_id, document_id)] = max(lookup.get((query_id, document_id), 0.0), relevance)
+    return lookup
+
+
+def _rank_query_results(frame, document_column, score_column):
+    if frame.empty:
+        return frame.copy()
+    return frame.sort_values(
+        by=[score_column, document_column],
+        ascending=[False, True],
+        kind="mergesort",
+    )
+
+
+def _average_precision(ranked_documents, relevant_by_document):
+    if not relevant_by_document:
+        return 0.0
+    hits = 0
+    precision_sum = 0.0
+    for rank, document_id in enumerate(ranked_documents, start=1):
+        if document_id in relevant_by_document:
+            hits += 1
+            precision_sum += hits / rank
+    return precision_sum / len(relevant_by_document)
+
+
+def _reciprocal_rank(ranked_documents, relevant_by_document):
+    for rank, document_id in enumerate(ranked_documents, start=1):
+        if document_id in relevant_by_document:
+            return 1.0 / rank
+    return 0.0
+
+
+def _precision_at_k(ranked_documents, relevant_by_document, k):
+    top_documents = ranked_documents[:k]
+    hits = sum(1 for document_id in top_documents if document_id in relevant_by_document)
+    return hits / k
+
+
+def _recall_at_k(ranked_documents, relevant_by_document, k):
+    if not relevant_by_document:
+        return 0.0
+    top_documents = ranked_documents[:k]
+    hits = sum(1 for document_id in top_documents if document_id in relevant_by_document)
+    return hits / len(relevant_by_document)
+
+
+def _ndcg_at_k(ranked_documents, relevant_by_document, k):
+    ideal_relevances = sorted(relevant_by_document.values(), reverse=True)[:k]
+    ideal_dcg = _discounted_cumulative_gain(ideal_relevances)
+    if ideal_dcg == 0.0:
+        return 0.0
+    ranked_relevances = [relevant_by_document.get(document_id, 0.0) for document_id in ranked_documents[:k]]
+    return _discounted_cumulative_gain(ranked_relevances) / ideal_dcg
+
+
+def _discounted_cumulative_gain(relevances):
+    return sum(relevance / math.log2(rank + 1) for rank, relevance in enumerate(relevances, start=1))
+
+
+def _mean(values):
+    if not values:
+        return 0.0
+    return float(sum(values) / len(values))
+
+
+def _normalize_finite_score(value):
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"Scores must be finite. Got: {value}")
+    return numeric
+
+
+def _normalize_nonnegative_relevance(value):
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0:
+        raise ValueError(f"Relevance values must be finite and non-negative. Got: {value}")
+    return numeric

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 import pandas as pd
 
 from matheel.cli import main
-from matheel.datasets import write_pair_dataset
+from matheel.datasets import write_pair_dataset, write_retrieval_dataset
 
 
 def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
@@ -301,6 +301,53 @@ def test_evaluate_pairs_command_writes_scores_and_metrics(tmp_path):
     metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
     assert metrics["pair_count"] == 2
     assert "accuracy=" in result.output
+
+
+def test_evaluate_retrieval_command_writes_scores_and_metrics(tmp_path):
+    dataset_root = tmp_path / "retrieval"
+    write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "query_a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "doc_a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "doc_b", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "query_a"}]),
+        corpus=pd.DataFrame(
+            [
+                {"document_id": "d1", "file_id": "doc_a"},
+                {"document_id": "d2", "file_id": "doc_b"},
+            ]
+        ),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    )
+    scores_path = tmp_path / "retrieval_scores.csv"
+    metrics_path = tmp_path / "retrieval_metrics.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "evaluate-retrieval",
+            str(dataset_root),
+            "--k",
+            "1",
+            "--scores-out",
+            str(scores_path),
+            "--metrics-out",
+            str(metrics_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert scores_path.exists()
+    assert metrics_path.exists()
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["query_count"] == 1
+    assert metrics["result_count"] == 2
+    assert "map=" in result.output
 
 
 def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -7,8 +7,10 @@ from matheel.datasets import (
     get_dataset_entry,
     load_code_texts,
     load_pair_dataset,
+    load_retrieval_dataset,
     registered_datasets,
     register_dataset_entry,
+    write_retrieval_dataset,
     write_pair_dataset,
 )
 
@@ -84,3 +86,60 @@ def test_pair_dataset_rejects_path_separator_file_ids(tmp_path):
             files=pd.DataFrame([{"file_id": "../a", "text": "print(1)"}]),
             pairs=pd.DataFrame([{"left_id": "../a", "right_id": "../a", "label": 1}]),
         )
+
+
+def test_retrieval_dataset_roundtrip_writes_manifests(tmp_path):
+    dataset_root = tmp_path / "retrieval"
+
+    written = write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "query_a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "doc_a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "doc_b", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "query_a"}]),
+        corpus=pd.DataFrame(
+            [
+                {"document_id": "d1", "file_id": "doc_a"},
+                {"document_id": "d2", "file_id": "doc_b"},
+            ]
+        ),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+        metadata={"name": "tiny_retrieval_fixture", "task_type": "plagiarism"},
+    )
+    loaded = load_retrieval_dataset(dataset_root)
+    texts = load_code_texts(loaded)
+
+    assert written.metadata["dataset_kind"] == "retrieval"
+    assert loaded.metadata["task_type"] == "plagiarism"
+    assert loaded.queries["query_id"].tolist() == ["q1"]
+    assert loaded.corpus["document_id"].tolist() == ["d1", "d2"]
+    assert loaded.qrels["relevance"].tolist() == [1.0]
+    assert texts["query_a"] == "print(1)"
+    assert (dataset_root / "queries.csv").exists()
+    assert (dataset_root / "corpus.csv").exists()
+    assert (dataset_root / "qrels.csv").exists()
+
+
+def test_retrieval_dataset_rejects_unknown_qrels_reference(tmp_path):
+    dataset_root = tmp_path / "retrieval"
+    write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "query_a", "text": "print(1)"},
+                {"file_id": "doc_a", "text": "print(1)"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "query_a"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "doc_a"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    )
+    qrels_path = dataset_root / "qrels.csv"
+    qrels_path.write_text("query_id,document_id,relevance\nq1,missing,1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown document ids: missing"):
+        load_retrieval_dataset(dataset_root)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,11 +1,14 @@
 import pandas as pd
 import pytest
 
-from matheel.datasets import write_pair_dataset
+from matheel.datasets import write_pair_dataset, write_retrieval_dataset
 from matheel.evaluation import (
     evaluate_pair_dataset,
+    evaluate_retrieval_dataset,
     pair_classification_metrics,
+    retrieval_ranking_metrics,
     score_pair_dataset,
+    score_retrieval_dataset,
 )
 
 
@@ -23,6 +26,40 @@ def _write_tiny_pair_dataset(path):
             [
                 {"left_id": "a", "right_id": "b", "label": 1},
                 {"left_id": "a", "right_id": "c", "label": 0},
+            ]
+        ),
+    )
+
+
+def _write_tiny_retrieval_dataset(path):
+    return write_retrieval_dataset(
+        path,
+        files=pd.DataFrame(
+            [
+                {"file_id": "query_one", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "query_two", "text": "print(2)", "suffix": ".py"},
+                {"file_id": "doc_one", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "doc_two", "text": "print(2)", "suffix": ".py"},
+                {"file_id": "doc_three", "text": "print(3)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame(
+            [
+                {"query_id": "q1", "file_id": "query_one"},
+                {"query_id": "q2", "file_id": "query_two"},
+            ]
+        ),
+        corpus=pd.DataFrame(
+            [
+                {"document_id": "d1", "file_id": "doc_one"},
+                {"document_id": "d2", "file_id": "doc_two"},
+                {"document_id": "d3", "file_id": "doc_three"},
+            ]
+        ),
+        qrels=pd.DataFrame(
+            [
+                {"query_id": "q1", "document_id": "d1", "relevance": 1},
+                {"query_id": "q2", "document_id": "d2", "relevance": 1},
             ]
         ),
     )
@@ -59,3 +96,60 @@ def test_evaluate_pair_dataset_returns_scored_pairs_and_metrics(tmp_path):
 def test_pair_classification_metrics_requires_score_column():
     with pytest.raises(ValueError, match="similarity_score"):
         pair_classification_metrics([{"label": 1}], threshold=0.5)
+
+
+def test_score_retrieval_dataset_uses_custom_scorer(tmp_path):
+    dataset = _write_tiny_retrieval_dataset(tmp_path / "retrieval")
+
+    scored = score_retrieval_dataset(
+        dataset,
+        scorer=lambda query, document, row: 1.0 if query == document else 0.0,
+    )
+
+    assert len(scored) == 6
+    assert scored.loc[scored["query_id"] == "q1", "similarity_score"].tolist() == [1.0, 0.0, 0.0]
+    assert scored["relevance"].sum() == 2.0
+
+
+def test_evaluate_retrieval_dataset_returns_ranking_metrics(tmp_path):
+    dataset = _write_tiny_retrieval_dataset(tmp_path / "retrieval")
+
+    scored, metrics = evaluate_retrieval_dataset(
+        dataset,
+        k=1,
+        scorer=lambda query, document, row: 1.0 if query == document else 0.0,
+    )
+
+    assert len(scored) == 6
+    assert metrics["query_count"] == 2
+    assert metrics["result_count"] == 6
+    assert metrics["relevant_count"] == 2
+    assert metrics["mean_average_precision"] == 1.0
+    assert metrics["mean_reciprocal_rank"] == 1.0
+    assert metrics["precision_at_k"] == 1.0
+    assert metrics["recall_at_k"] == 1.0
+    assert metrics["ndcg_at_k"] == 1.0
+
+
+def test_retrieval_ranking_metrics_handles_queries_without_relevant_documents():
+    metrics = retrieval_ranking_metrics(
+        pd.DataFrame(
+            [
+                {"query_id": "q1", "document_id": "d1", "similarity_score": 1.0, "relevance": 0},
+                {"query_id": "q1", "document_id": "d2", "similarity_score": 0.5, "relevance": 0},
+            ]
+        ),
+        k=2,
+    )
+
+    assert metrics["query_count"] == 1
+    assert metrics["relevant_count"] == 0
+    assert metrics["mean_average_precision"] == 0.0
+    assert metrics["mean_reciprocal_rank"] == 0.0
+    assert metrics["recall_at_k"] == 0.0
+    assert metrics["ndcg_at_k"] == 0.0
+
+
+def test_retrieval_ranking_metrics_requires_score_column():
+    with pytest.raises(ValueError, match="similarity_score"):
+        retrieval_ranking_metrics([{"query_id": "q1", "document_id": "d1", "relevance": 1}])


### PR DESCRIPTION
Refs #39.

Summary:
- Adds local retrieval dataset manifests for queries, corpus, and qrels.
- Adds retrieval scoring plus MAP, MRR, precision/recall, and nDCG at k.
- Adds the evaluate-retrieval CLI, docs, and deterministic tests.

Notes:
- No external datasets, dataset names, downloaders, or bundled data are added.

Validation:
- python -m pytest tests/test_datasets.py tests/test_evaluation.py tests/test_cli.py
- python -m ruff check .
- python -m pytest
- python -m mkdocs build --strict
- git diff --check