### PR TITLE
Add dataset source loading to CLI

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -236,6 +236,21 @@ matheel evaluate-pairs tiny_pairs \
 
 The command defaults to `levenshtein=1.0` so small local evaluations are offline-friendly. Add semantic features explicitly when you want model-backed scoring.
 
+You can also adapt a raw custom pair table directly from the CLI:
+
+```bash
+matheel evaluate-pairs ./data/raw_pairs \
+  --adapter auto_pair_tabular \
+  --adapter-option pair_table=pairs.csv \
+  --adapter-option left_text_column=code_a \
+  --adapter-option right_text_column=code_b \
+  --adapter-option label_column=label \
+  --scores-out scored_pairs.csv \
+  --metrics-out pair_metrics.json
+```
+
+Use `--preset NAME` for registered presets, or combine `--source`, `--identifier`, `--destination`, `--revision`, `--split`, and `--path-in-archive` when a resolver needs an explicit source spec. Matheel does not require or store credentials in these commands.
+
 ## Retrieval Dataset Format
 
 A retrieval dataset directory contains:
@@ -321,6 +336,20 @@ matheel evaluate-retrieval tiny_retrieval \
 ```
 
 The metrics include mean average precision, mean reciprocal rank, precision at `k`, recall at `k`, and nDCG at `k`.
+
+Raw custom retrieval tables can be adapted the same way:
+
+```bash
+matheel evaluate-retrieval ./data/raw_retrieval \
+  --adapter auto_retrieval_tabular \
+  --adapter-option retrieval_table=retrieval.csv \
+  --adapter-option query_text_column=query_code \
+  --adapter-option document_text_column=candidate_code \
+  --adapter-option relevance_column=relevance \
+  --k 10 \
+  --scores-out scored_retrieval.csv \
+  --metrics-out retrieval_metrics.json
+```
 
 ## Resampling and Uncertainty
 

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -7,6 +7,7 @@ import click
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
 from ._progress import should_show_progress
+from .datasets import load_pair_datasets, load_retrieval_datasets
 from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
 from .similarity import DEFAULT_MODEL_NAME, available_runtime_devices, get_sim_list
 from .chunking import available_chunk_aggregations, available_chunking_methods
@@ -21,6 +22,73 @@ from .vectors import (
 def main():
     """Matheel CLI - Compute Code Similarity"""
     pass
+
+
+def _parse_dataset_adapter_options(entries):
+    options = {}
+    for entry in entries or ():
+        key, separator, value = str(entry).partition("=")
+        key = key.strip()
+        if not separator or not key:
+            raise click.UsageError("--adapter-option values must use name=value.")
+        options[key] = value
+    return options
+
+
+def _dataset_spec_from_cli(
+    dataset_spec,
+    *,
+    task_family,
+    preset,
+    source,
+    identifier,
+    dataset_name,
+    adapter,
+    adapter_options,
+    destination,
+    adapted_destination,
+    revision,
+    split,
+    path_in_archive,
+):
+    parsed_adapter_options = _parse_dataset_adapter_options(adapter_options)
+    if preset and dataset_spec:
+        raise click.UsageError("Use either DATASET_SPEC or --preset, not both.")
+    if dataset_spec and identifier:
+        raise click.UsageError("Use either DATASET_SPEC or --identifier, not both.")
+    if parsed_adapter_options and adapter is None and preset is None:
+        raise click.UsageError("--adapter-option requires --adapter or --preset.")
+
+    adapter_key = "adapter" if task_family == "pair" else "retrieval_adapter"
+    optional_values = {
+        "source": source,
+        "identifier": identifier,
+        "name": dataset_name,
+        adapter_key: adapter,
+        "adapter_options": parsed_adapter_options or None,
+        "destination": destination,
+        "adapted_destination": adapted_destination,
+        "revision": revision,
+        "split": split,
+        "path_in_archive": path_in_archive,
+    }
+
+    if preset:
+        payload = {"preset": preset}
+        payload.update({key: value for key, value in optional_values.items() if value is not None})
+        return payload
+
+    if dataset_spec is None and identifier is None:
+        raise click.UsageError("Provide DATASET_SPEC, --identifier, or --preset.")
+
+    resolved_identifier = identifier if identifier is not None else dataset_spec
+    has_dataset_controls = any(value is not None for value in optional_values.values())
+    if not has_dataset_controls:
+        return resolved_identifier
+
+    payload = {"identifier": resolved_identifier}
+    payload.update({key: value for key, value in optional_values.items() if value is not None})
+    return payload
 
 
 @main.command()
@@ -362,7 +430,31 @@ def compare_suite(source_path, config_file, summary_out, details_dir, output_for
 
 
 @main.command(name="evaluate-pairs")
-@click.argument("dataset_path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.argument("dataset_spec", required=False, metavar="DATASET_SPEC")
+@click.option("--preset", help="Registered dataset preset to load.")
+@click.option("--source", help="Dataset source resolver to use with DATASET_SPEC or --identifier.")
+@click.option("--identifier", help="Dataset source identifier. Use this instead of DATASET_SPEC when clearer.")
+@click.option("--dataset-name", help="Name to assign to the loaded or adapted dataset.")
+@click.option("--adapter", help="Dataset adapter to apply before evaluation.")
+@click.option(
+    "--adapter-option",
+    "adapter_options",
+    multiple=True,
+    help="Adapter option as name=value. Repeat to pass multiple options.",
+)
+@click.option(
+    "--destination",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory where a source resolver should place raw data.",
+)
+@click.option(
+    "--adapted-destination",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory where an adapter should write the normalized dataset.",
+)
+@click.option("--revision", help="Source revision, branch, tag, or version when the resolver supports it.")
+@click.option("--split", help="Dataset split name forwarded to the resolver or adapter.")
+@click.option("--path-in-archive", help="Relative nested path inside the resolved source root.")
 @click.option("--scores-out", type=click.Path(), default="scored_pairs.csv", show_default=True)
 @click.option("--metrics-out", type=click.Path(), default="pair_metrics.json", show_default=True)
 @click.option("--threshold", default=0.5, show_default=True, help="Classification threshold.")
@@ -414,7 +506,18 @@ def compare_suite(source_path, config_file, summary_out, details_dir, output_for
     show_default=True,
 )
 def evaluate_pairs(
-    dataset_path,
+    dataset_spec,
+    preset,
+    source,
+    identifier,
+    dataset_name,
+    adapter,
+    adapter_options,
+    destination,
+    adapted_destination,
+    revision,
+    split,
+    path_in_archive,
     scores_out,
     metrics_out,
     threshold,
@@ -429,10 +532,27 @@ def evaluate_pairs(
     pooling_method,
     device,
 ):
-    """Evaluate a local pair-classification dataset."""
+    """Evaluate a pair-classification dataset from a path, source spec, or preset."""
+    resolved_dataset = load_pair_datasets(
+        _dataset_spec_from_cli(
+            dataset_spec,
+            task_family="pair",
+            preset=preset,
+            source=source,
+            identifier=identifier,
+            dataset_name=dataset_name,
+            adapter=adapter,
+            adapter_options=adapter_options,
+            destination=destination,
+            adapted_destination=adapted_destination,
+            revision=revision,
+            split=split,
+            path_in_archive=path_in_archive,
+        )
+    )
     selected_weights = feature_weights or ("levenshtein=1.0",)
     scored_pairs, metrics = evaluate_pair_dataset(
-        dataset_path,
+        resolved_dataset,
         threshold=threshold,
         similarity_options={
             "feature_weights": selected_weights,
@@ -464,7 +584,31 @@ def evaluate_pairs(
 
 
 @main.command(name="evaluate-retrieval")
-@click.argument("dataset_path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.argument("dataset_spec", required=False, metavar="DATASET_SPEC")
+@click.option("--preset", help="Registered dataset preset to load.")
+@click.option("--source", help="Dataset source resolver to use with DATASET_SPEC or --identifier.")
+@click.option("--identifier", help="Dataset source identifier. Use this instead of DATASET_SPEC when clearer.")
+@click.option("--dataset-name", help="Name to assign to the loaded or adapted dataset.")
+@click.option("--adapter", help="Dataset adapter to apply before evaluation.")
+@click.option(
+    "--adapter-option",
+    "adapter_options",
+    multiple=True,
+    help="Adapter option as name=value. Repeat to pass multiple options.",
+)
+@click.option(
+    "--destination",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory where a source resolver should place raw data.",
+)
+@click.option(
+    "--adapted-destination",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory where an adapter should write the normalized dataset.",
+)
+@click.option("--revision", help="Source revision, branch, tag, or version when the resolver supports it.")
+@click.option("--split", help="Dataset split name forwarded to the resolver or adapter.")
+@click.option("--path-in-archive", help="Relative nested path inside the resolved source root.")
 @click.option("--scores-out", type=click.Path(), default="scored_retrieval.csv", show_default=True)
 @click.option("--metrics-out", type=click.Path(), default="retrieval_metrics.json", show_default=True)
 @click.option("--k", default=10, show_default=True, help="Ranking cutoff for top-k metrics.")
@@ -516,7 +660,18 @@ def evaluate_pairs(
     show_default=True,
 )
 def evaluate_retrieval(
-    dataset_path,
+    dataset_spec,
+    preset,
+    source,
+    identifier,
+    dataset_name,
+    adapter,
+    adapter_options,
+    destination,
+    adapted_destination,
+    revision,
+    split,
+    path_in_archive,
     scores_out,
     metrics_out,
     k,
@@ -531,10 +686,27 @@ def evaluate_retrieval(
     pooling_method,
     device,
 ):
-    """Evaluate a local retrieval dataset."""
+    """Evaluate a retrieval dataset from a path, source spec, or preset."""
+    resolved_dataset = load_retrieval_datasets(
+        _dataset_spec_from_cli(
+            dataset_spec,
+            task_family="retrieval",
+            preset=preset,
+            source=source,
+            identifier=identifier,
+            dataset_name=dataset_name,
+            adapter=adapter,
+            adapter_options=adapter_options,
+            destination=destination,
+            adapted_destination=adapted_destination,
+            revision=revision,
+            split=split,
+            path_in_archive=path_in_archive,
+        )
+    )
     selected_weights = feature_weights or ("levenshtein=1.0",)
     scored_results, metrics = evaluate_retrieval_dataset(
-        dataset_path,
+        resolved_dataset,
         k=k,
         similarity_options={
             "feature_weights": selected_weights,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,15 @@
 import json
+import os
+from pathlib import Path
+import subprocess
+import sys
 
 from click.testing import CliRunner
 import pandas as pd
 
+import matheel.datasets as datasets_module
 from matheel.cli import main
-from matheel.datasets import write_pair_dataset, write_retrieval_dataset
+from matheel.datasets import register_dataset_preset, write_pair_dataset, write_retrieval_dataset
 
 
 def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
@@ -303,6 +308,90 @@ def test_evaluate_pairs_command_writes_scores_and_metrics(tmp_path):
     assert "accuracy=" in result.output
 
 
+def test_evaluate_pairs_command_loads_tabular_adapter_spec(tmp_path):
+    raw_root = tmp_path / "raw_pairs"
+    raw_root.mkdir()
+    pd.DataFrame(
+        [
+            {"left_code": "print(1)", "right_code": "print(1)", "target": 1},
+            {"left_code": "print(1)", "right_code": "print(2)", "target": 0},
+        ]
+    ).to_csv(raw_root / "pairs.csv", index=False)
+    scores_path = tmp_path / "adapter_scores.csv"
+    metrics_path = tmp_path / "adapter_metrics.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "evaluate-pairs",
+            str(raw_root),
+            "--adapter",
+            "auto_pair_tabular",
+            "--adapter-option",
+            "left_text_column=left_code",
+            "--adapter-option",
+            "right_text_column=right_code",
+            "--adapter-option",
+            "label_column=target",
+            "--scores-out",
+            str(scores_path),
+            "--metrics-out",
+            str(metrics_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["pair_count"] == 2
+    assert pd.read_csv(scores_path)["label"].tolist() == [1, 0]
+
+
+def test_evaluate_pairs_command_loads_registered_preset(tmp_path, monkeypatch):
+    monkeypatch.setattr(datasets_module, "_DATASET_PRESETS", dict(datasets_module._DATASET_PRESETS))
+    dataset_root = tmp_path / "preset_pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "return 1", "suffix": ".py"},
+                {"file_id": "b", "text": "return 1", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+    )
+    register_dataset_preset(
+        "unit_cli_pair_preset",
+        {
+            "source": "local",
+            "identifier": dataset_root,
+            "task_families": ("pair",),
+        },
+        overwrite=True,
+    )
+    scores_path = tmp_path / "preset_scores.csv"
+    metrics_path = tmp_path / "preset_metrics.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "evaluate-pairs",
+            "--preset",
+            "unit_cli_pair_preset",
+            "--scores-out",
+            str(scores_path),
+            "--metrics-out",
+            str(metrics_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert pd.read_csv(scores_path)["label"].tolist() == [1]
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["pair_count"] == 1
+
+
 def test_evaluate_retrieval_command_writes_scores_and_metrics(tmp_path):
     dataset_root = tmp_path / "retrieval"
     write_retrieval_dataset(
@@ -348,6 +437,82 @@ def test_evaluate_retrieval_command_writes_scores_and_metrics(tmp_path):
     assert metrics["query_count"] == 1
     assert metrics["result_count"] == 2
     assert "map=" in result.output
+
+
+def test_evaluate_retrieval_command_loads_tabular_adapter_spec(tmp_path):
+    raw_root = tmp_path / "raw_retrieval"
+    raw_root.mkdir()
+    pd.DataFrame(
+        [
+            {
+                "query_id": "q1",
+                "document_id": "d1",
+                "query_code": "print(1)",
+                "candidate_code": "print(1)",
+                "relevance": 1,
+            },
+            {
+                "query_id": "q1",
+                "document_id": "d2",
+                "query_code": "print(1)",
+                "candidate_code": "print(2)",
+                "relevance": 0,
+            },
+        ]
+    ).to_csv(raw_root / "retrieval.csv", index=False)
+    scores_path = tmp_path / "adapter_retrieval_scores.csv"
+    metrics_path = tmp_path / "adapter_retrieval_metrics.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "evaluate-retrieval",
+            str(raw_root),
+            "--adapter",
+            "auto_retrieval_tabular",
+            "--adapter-option",
+            "retrieval_table=retrieval.csv",
+            "--adapter-option",
+            "query_text_column=query_code",
+            "--adapter-option",
+            "document_text_column=candidate_code",
+            "--adapter-option",
+            "relevance_column=relevance",
+            "--k",
+            "1",
+            "--scores-out",
+            str(scores_path),
+            "--metrics-out",
+            str(metrics_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics["query_count"] == 1
+    assert metrics["result_count"] == 2
+    assert set(pd.read_csv(scores_path)["document_id"]) == {"d1", "d2"}
+
+
+def test_dataset_example_script_runs():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(repo_root), env.get("PYTHONPATH", "")) if part
+    )
+
+    result = subprocess.run(
+        [sys.executable, "examples/datasets_demo.py"],
+        cwd=repo_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Generic tabular retrieval adapter" in result.stdout
+    assert "Custom source and preset" in result.stdout
 
 
 def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- route pair and retrieval evaluation CLI commands through dataset source/preset/adapter loading
- add options for presets, sources, identifiers, adapter options, destinations, revisions, splits, and nested source paths
- cover local tabular adapters, registered preset loading, and the dataset examples script with tests
- document CLI usage for custom pair and retrieval tables

## Tests
- .venv/bin/python examples/datasets_demo.py
- .venv/bin/python -m pytest tests/test_cli.py
- .venv/bin/python -m pytest tests/test_cli.py tests/test_datasets.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- git diff --check

Closes #111