### PR TITLE
Add dataset utility CLI commands

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -128,6 +128,49 @@ register_dataset_preset(
 )
 ```
 
+## Dataset CLI Utilities
+
+Use `matheel datasets list` to inspect registered sources, adapters, and presets:
+
+```bash
+matheel datasets list
+matheel datasets list --task retrieval --format json
+```
+
+Use `matheel datasets validate` to check a normalized dataset and print stable counts:
+
+```bash
+matheel datasets validate tiny_pairs --format json
+matheel datasets validate tiny_retrieval --kind retrieval
+```
+
+Use `matheel datasets adapt` to convert a raw local tabular dataset into normalized Matheel manifests. Always provide an explicit output directory so repeated runs write to the same location:
+
+```bash
+matheel datasets adapt ./data/raw_pairs \
+  --kind pair \
+  --output ./data/normalized_pairs \
+  --dataset-name custom_pairs \
+  --adapter-option pair_table=pairs.csv \
+  --adapter-option left_text_column=code_a \
+  --adapter-option right_text_column=code_b \
+  --adapter-option label_column=label \
+  --format json
+```
+
+For retrieval tables:
+
+```bash
+matheel datasets adapt ./data/raw_retrieval \
+  --kind retrieval \
+  --output ./data/normalized_retrieval \
+  --adapter-option retrieval_table=retrieval.csv \
+  --adapter-option query_text_column=query_code \
+  --adapter-option document_text_column=candidate_code \
+  --adapter-option relevance_column=relevance \
+  --format json
+```
+
 ## Dataset Registry
 
 Dataset tracking uses these fields:

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -7,7 +7,19 @@ import click
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
 from ._progress import should_show_progress
-from .datasets import load_pair_datasets, load_retrieval_datasets
+from .datasets import (
+    adapt_pair_dataset,
+    adapt_retrieval_dataset,
+    available_dataset_adapters,
+    available_dataset_presets,
+    available_dataset_presets_by_task,
+    available_dataset_sources,
+    dataset_preset_task_families,
+    load_pair_dataset,
+    load_pair_datasets,
+    load_retrieval_dataset,
+    load_retrieval_datasets,
+)
 from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
 from .similarity import DEFAULT_MODEL_NAME, available_runtime_devices, get_sim_list
 from .chunking import available_chunk_aggregations, available_chunking_methods
@@ -89,6 +101,208 @@ def _dataset_spec_from_cli(
     payload = {"identifier": resolved_identifier}
     payload.update({key: value for key, value in optional_values.items() if value is not None})
     return payload
+
+
+def _echo_json(payload):
+    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _dataset_list_payload(task):
+    if task is None:
+        preset_names = available_dataset_presets()
+    else:
+        preset_names = available_dataset_presets_by_task(task)
+    return {
+        "sources": list(available_dataset_sources()),
+        "adapters": list(available_dataset_adapters()),
+        "presets": [
+            {
+                "name": name,
+                "task_families": list(dataset_preset_task_families(name)),
+            }
+            for name in preset_names
+        ],
+    }
+
+
+def _dataset_kind_from_path(dataset_path, requested_kind):
+    if requested_kind != "auto":
+        return requested_kind
+
+    root = Path(dataset_path)
+    if all((root / name).exists() for name in ("files.csv", "queries.csv", "corpus.csv", "qrels.csv")):
+        return "retrieval"
+    if (root / "files.csv").exists() and (root / "pairs.csv").exists():
+        return "pair"
+    raise click.UsageError("Could not detect dataset kind. Use --kind pair or --kind retrieval.")
+
+
+def _pair_dataset_summary(dataset):
+    positive_count = int(dataset.pairs["label"].sum()) if "label" in dataset.pairs else 0
+    pair_count = int(len(dataset.pairs))
+    return {
+        "dataset_kind": "pair_classification",
+        "name": str(dataset.metadata.get("name") or dataset.root.name),
+        "counts": {
+            "files": int(len(dataset.files)),
+            "pairs": pair_count,
+            "positive_pairs": positive_count,
+            "negative_pairs": pair_count - positive_count,
+        },
+        "metadata": dataset.metadata,
+    }
+
+
+def _retrieval_dataset_summary(dataset):
+    return {
+        "dataset_kind": "retrieval",
+        "name": str(dataset.metadata.get("name") or dataset.root.name),
+        "counts": {
+            "files": int(len(dataset.files)),
+            "queries": int(len(dataset.queries)),
+            "documents": int(len(dataset.corpus)),
+            "qrels": int(len(dataset.qrels)),
+        },
+        "metadata": dataset.metadata,
+    }
+
+
+def _echo_dataset_summary(summary, output_format):
+    if output_format == "json":
+        _echo_json(summary)
+        return
+
+    click.echo(f"name={summary['name']}")
+    click.echo(f"dataset_kind={summary['dataset_kind']}")
+    for key, value in summary["counts"].items():
+        click.echo(f"{key}={value}")
+    task_type = summary["metadata"].get("task_type")
+    if task_type:
+        click.echo(f"task_type={task_type}")
+
+
+@main.group(name="datasets")
+def datasets_cli():
+    """Inspect, validate, and adapt Matheel datasets."""
+    pass
+
+
+@datasets_cli.command(name="list")
+@click.option("--task", type=click.Choice(("pair", "retrieval")), help="Filter presets by task.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def datasets_list(task, output_format):
+    """List registered dataset sources, adapters, and presets."""
+    payload = _dataset_list_payload(task)
+    if output_format == "json":
+        _echo_json(payload)
+        return
+
+    click.echo("Sources:")
+    for source in payload["sources"]:
+        click.echo(f"- {source}")
+    click.echo("Adapters:")
+    for adapter in payload["adapters"]:
+        click.echo(f"- {adapter}")
+    click.echo("Presets:")
+    for preset in payload["presets"]:
+        tasks = ", ".join(preset["task_families"])
+        click.echo(f"- {preset['name']} ({tasks})")
+
+
+@datasets_cli.command(name="validate")
+@click.argument("dataset_path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.option(
+    "--kind",
+    type=click.Choice(("auto", "pair", "retrieval")),
+    default="auto",
+    show_default=True,
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def datasets_validate(dataset_path, kind, output_format):
+    """Validate a normalized pair or retrieval dataset."""
+    dataset_kind = _dataset_kind_from_path(dataset_path, kind)
+    if dataset_kind == "pair":
+        summary = _pair_dataset_summary(load_pair_dataset(dataset_path))
+    else:
+        summary = _retrieval_dataset_summary(load_retrieval_dataset(dataset_path))
+    _echo_dataset_summary(summary, output_format)
+
+
+@datasets_cli.command(name="adapt")
+@click.argument("source_path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.option("--kind", type=click.Choice(("pair", "retrieval")), required=True)
+@click.option("--adapter", help="Dataset adapter name. Defaults to the generic tabular adapter.")
+@click.option(
+    "--adapter-option",
+    "adapter_options",
+    multiple=True,
+    help="Adapter option as name=value. Repeat to pass multiple options.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=True,
+    help="Directory where the normalized dataset will be written.",
+)
+@click.option("--dataset-name", help="Name to write into normalized dataset metadata.")
+@click.option("--split", help="Dataset split name forwarded to the adapter.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def datasets_adapt(
+    source_path,
+    kind,
+    adapter,
+    adapter_options,
+    output_path,
+    dataset_name,
+    split,
+    output_format,
+):
+    """Adapt a local raw dataset into Matheel's normalized manifests."""
+    parsed_options = _parse_dataset_adapter_options(adapter_options)
+    if split is not None and "split" not in parsed_options:
+        parsed_options["split"] = split
+
+    if kind == "pair":
+        adapter_name = adapter or "auto_pair_tabular"
+        adapted_root = adapt_pair_dataset(
+            source_path,
+            adapter=adapter_name,
+            destination=output_path,
+            dataset_name=dataset_name,
+            adapter_options=parsed_options,
+        )
+        summary = _pair_dataset_summary(load_pair_dataset(adapted_root))
+    else:
+        adapter_name = adapter or "auto_retrieval_tabular"
+        adapted_root = adapt_retrieval_dataset(
+            source_path,
+            adapter=adapter_name,
+            destination=output_path,
+            dataset_name=dataset_name,
+            adapter_options=parsed_options,
+        )
+        summary = _retrieval_dataset_summary(load_retrieval_dataset(adapted_root))
+    summary["adapter"] = adapter_name
+    _echo_dataset_summary(summary, output_format)
 
 
 @main.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,6 +264,152 @@ def test_compare_command_rejects_inactive_code_metric_weight(tmp_path):
     assert "code_metric_weight requires an active code_metric" in str(result.exception)
 
 
+def test_datasets_list_command_outputs_reproducible_json():
+    runner = CliRunner()
+    result = runner.invoke(main, ["datasets", "list", "--task", "retrieval", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["sources"] == sorted(payload["sources"])
+    assert "local" in payload["sources"]
+    assert "auto_retrieval_tabular" in payload["adapters"]
+    assert payload["presets"]
+    assert all("retrieval" in preset["task_families"] for preset in payload["presets"])
+
+
+def test_datasets_validate_command_reports_pair_summary(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "c", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame(
+            [
+                {"left_id": "a", "right_id": "b", "label": 1},
+                {"left_id": "a", "right_id": "c", "label": 0},
+            ]
+        ),
+        metadata={"name": "unit_pairs"},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["datasets", "validate", str(dataset_root), "--format", "json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["name"] == "unit_pairs"
+    assert payload["dataset_kind"] == "pair_classification"
+    assert payload["counts"] == {
+        "files": 3,
+        "negative_pairs": 1,
+        "pairs": 2,
+        "positive_pairs": 1,
+    }
+
+
+def test_datasets_adapt_command_writes_pair_dataset(tmp_path):
+    source_root = tmp_path / "raw_pairs"
+    source_root.mkdir()
+    pd.DataFrame(
+        [
+            {"left_code": "return a", "right_code": "return a", "label": 1},
+            {"left_code": "return a", "right_code": "return b", "label": 0},
+        ]
+    ).to_csv(source_root / "pairs.csv", index=False)
+    output_root = tmp_path / "normalized_pairs"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "datasets",
+            "adapt",
+            str(source_root),
+            "--kind",
+            "pair",
+            "--output",
+            str(output_root),
+            "--dataset-name",
+            "custom_pairs",
+            "--adapter-option",
+            "left_text_column=left_code",
+            "--adapter-option",
+            "right_text_column=right_code",
+            "--adapter-option",
+            "label_column=label",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["adapter"] == "auto_pair_tabular"
+    assert payload["counts"]["pairs"] == 2
+    assert (output_root / "files.csv").exists()
+    assert (output_root / "pairs.csv").exists()
+
+
+def test_datasets_adapt_command_writes_retrieval_dataset(tmp_path):
+    source_root = tmp_path / "raw_retrieval"
+    source_root.mkdir()
+    pd.DataFrame(
+        [
+            {
+                "query_id": "q1",
+                "document_id": "d1",
+                "query_code": "print(1)",
+                "candidate_code": "print(1)",
+                "relevance": 1,
+            },
+            {
+                "query_id": "q1",
+                "document_id": "d2",
+                "query_code": "print(1)",
+                "candidate_code": "print(2)",
+                "relevance": 0,
+            },
+        ]
+    ).to_csv(source_root / "retrieval.csv", index=False)
+    output_root = tmp_path / "normalized_retrieval"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "datasets",
+            "adapt",
+            str(source_root),
+            "--kind",
+            "retrieval",
+            "--output",
+            str(output_root),
+            "--adapter-option",
+            "retrieval_table=retrieval.csv",
+            "--adapter-option",
+            "query_text_column=query_code",
+            "--adapter-option",
+            "document_text_column=candidate_code",
+            "--adapter-option",
+            "relevance_column=relevance",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["adapter"] == "auto_retrieval_tabular"
+    assert payload["counts"]["queries"] == 1
+    assert payload["counts"]["documents"] == 2
+    assert (output_root / "qrels.csv").exists()
+
+
 def test_evaluate_pairs_command_writes_scores_and_metrics(tmp_path):
     dataset_root = tmp_path / "pairs"
     write_pair_dataset(


### PR DESCRIPTION
## Summary
- add dataset utility commands for listing registry entries, validating normalized datasets, and adapting local tabular datasets
- support deterministic JSON output for scripting and reproducible workflows
- document local custom dataset adaptation commands
- add synthetic CLI tests for list, validate, pair adaptation, and retrieval adaptation

## Tests
- .venv/bin/python -m pytest tests/test_cli.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- git diff --check

Closes #113