### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/examples/matheel_gradio_colab_demo.ipynb
+++ b/examples/matheel_gradio_colab_demo.ipynb
@@ -25,9 +25,9 @@
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",
     "cd /content/matheel\n",
-    "git checkout v0.3.7\n",
+    "git checkout v0.4.0\n",
     "pip install -e \".[all]\"\n",
-    "echo \"Matheel v0.3.7 is installed. Colab dependency alignment can take a few minutes. If Colab asks, restart the runtime once before launching the app.\"\n"
+    "echo \"Matheel v0.4.0 is installed. Colab dependency alignment can take a few minutes. If Colab asks, restart the runtime once before launching the app.\"\n"
    ]
   },
   {

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.3.7` and includes:
+This Space is aligned with `matheel==0.4.0` and includes:
 
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.3.7
+matheel[all]==0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.3.7"
+version = "0.4.0"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
## Summary
- bump the package version to 0.4.0
- sync Gradio Space dependency and README version references
- update the Gradio Colab example to check out the v0.4.0 tag

## Verification
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- .venv/bin/python -m build
- .venv/bin/python -m twine check dist/*
- git diff --check

Closes #119