### PR TITLE
Clarify inactive semantic backend metadata

### DIFF
--- a/matheel/_run_metadata.py
+++ b/matheel/_run_metadata.py
@@ -2,6 +2,7 @@ from time import perf_counter
 
 
 _METADATA_DECIMALS = 4
+INACTIVE_SEMANTIC_BACKEND = "inactive"
 
 
 def active_feature_names(feature_weights):
@@ -15,6 +16,16 @@ def active_feature_names(feature_weights):
 
 def format_feature_set(feature_weights):
     return ",".join(active_feature_names(feature_weights))
+
+
+def semantic_is_active(feature_weights):
+    return float((feature_weights or {}).get("semantic", 0.0)) > 0.0
+
+
+def semantic_vector_backend_metadata(feature_weights, vector_backend):
+    if semantic_is_active(feature_weights):
+        return vector_backend
+    return INACTIVE_SEMANTIC_BACKEND
 
 
 def elapsed_seconds_since(start_time):
@@ -36,7 +47,7 @@ def attach_run_metadata(
 ):
     frame.attrs["elapsed_seconds"] = round(float(elapsed_seconds), _METADATA_DECIMALS)
     frame.attrs["feature_set"] = format_feature_set(feature_weights)
-    frame.attrs["vector_backend"] = vector_backend
+    frame.attrs["vector_backend"] = semantic_vector_backend_metadata(feature_weights, vector_backend)
     frame.attrs["code_metric"] = code_metric
     frame.attrs["chunking_method"] = chunking_method
     return frame

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -6,7 +6,12 @@ import pandas as pd
 
 from .feature_weights import default_feature_weights, parse_feature_weights
 from ._progress import progress_iter
-from ._run_metadata import elapsed_seconds_between, format_feature_set, perf_counter
+from ._run_metadata import (
+    elapsed_seconds_between,
+    format_feature_set,
+    perf_counter,
+    semantic_vector_backend_metadata,
+)
 from .similarity import DEFAULT_MODEL_NAME, get_sim_list
 
 
@@ -233,10 +238,14 @@ def _resolved_elapsed_seconds(results, elapsed_seconds):
 def _summary_metadata(options, results, elapsed_seconds):
     attrs = getattr(results, "attrs", {}) if results is not None else {}
     feature_weights = options.get("feature_weights")
+    vector_backend = attrs.get("vector_backend") or semantic_vector_backend_metadata(
+        feature_weights,
+        options.get("vector_backend", "auto"),
+    )
     return {
         "elapsed_seconds": round(float(elapsed_seconds), _SCORE_DECIMALS),
         "feature_set": attrs.get("feature_set") or format_feature_set(feature_weights),
-        "vector_backend": attrs.get("vector_backend") or options.get("vector_backend", "auto"),
+        "vector_backend": vector_backend,
         "code_metric": attrs.get("code_metric") or options.get("code_metric", "none"),
         "chunking_method": attrs.get("chunking_method") or options.get("chunking_method", "none"),
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,51 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     assert "features=code_metric,semantic" in result.stderr
 
 
+def test_compare_command_marks_backend_inactive_without_semantic_feature(tmp_path, monkeypatch):
+    archive_path = tmp_path / "codes.zip"
+    archive_path.write_bytes(b"placeholder")
+
+    def fake_get_sim_list(*args, **kwargs):
+        _ = (args, kwargs)
+        frame = pd.DataFrame(
+            [
+                {
+                    "file_name_1": "a.py",
+                    "file_name_2": "b.py",
+                    "similarity_score": 1.0,
+                }
+            ]
+        )
+        frame.attrs.update(
+            {
+                "elapsed_seconds": 0.5,
+                "feature_set": "levenshtein",
+                "vector_backend": "inactive",
+                "code_metric": "none",
+                "chunking_method": "none",
+            }
+        )
+        return frame
+
+    monkeypatch.setattr("matheel.cli.get_sim_list", fake_get_sim_list)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "compare",
+            str(archive_path),
+            "--feature-weight",
+            "levenshtein=1.0",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "features=levenshtein" in result.stderr
+    assert "backend=inactive" in result.stderr
+    assert "backend=auto" not in result.stderr
+
+
 def test_compare_command_accepts_directory_source(tmp_path, monkeypatch):
     source_dir = tmp_path / "codes"
     source_dir.mkdir()

--- a/tests/test_comparison_suite.py
+++ b/tests/test_comparison_suite.py
@@ -149,6 +149,63 @@ def test_run_comparison_suite_writes_summary_and_details(tmp_path, monkeypatch):
     assert "0.9877" in strong_details_text
 
 
+def test_run_comparison_suite_marks_backend_inactive_without_semantic_feature(monkeypatch):
+    def fake_get_sim_list(zipped_file, **kwargs):
+        _ = (zipped_file, kwargs)
+        return pd.DataFrame(
+            [
+                {"file_name_1": "a.py", "file_name_2": "b.py", "similarity_score": 1.0},
+            ]
+        )
+
+    monkeypatch.setattr("matheel.comparison_suite.get_sim_list", fake_get_sim_list)
+    times = iter([10.0, 10.25])
+    monkeypatch.setattr("matheel.comparison_suite.perf_counter", lambda: next(times))
+
+    summary, _ = run_comparison_suite(
+        "codes.zip",
+        [
+            {
+                "run_name": "lexical",
+                "feature_weights": {"levenshtein": 1.0},
+                "number_results": 10,
+            },
+        ],
+    )
+
+    assert summary.loc[0, "feature_set"] == "levenshtein"
+    assert summary.loc[0, "vector_backend"] == "inactive"
+
+
+def test_run_comparison_suite_keeps_backend_when_semantic_feature_is_active(monkeypatch):
+    def fake_get_sim_list(zipped_file, **kwargs):
+        _ = (zipped_file, kwargs)
+        return pd.DataFrame(
+            [
+                {"file_name_1": "a.py", "file_name_2": "b.py", "similarity_score": 1.0},
+            ]
+        )
+
+    monkeypatch.setattr("matheel.comparison_suite.get_sim_list", fake_get_sim_list)
+    times = iter([10.0, 10.25])
+    monkeypatch.setattr("matheel.comparison_suite.perf_counter", lambda: next(times))
+
+    summary, _ = run_comparison_suite(
+        "codes.zip",
+        [
+            {
+                "run_name": "semantic",
+                "feature_weights": {"semantic": 1.0},
+                "vector_backend": "sentence_transformers",
+                "number_results": 10,
+            },
+        ],
+    )
+
+    assert summary.loc[0, "feature_set"] == "semantic"
+    assert summary.loc[0, "vector_backend"] == "sentence_transformers"
+
+
 def test_run_comparison_suite_accepts_already_normalized_configs(monkeypatch):
     captured_options = []
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -475,9 +475,34 @@ def test_get_sim_list_reports_progress_events(tmp_path):
     assert pair_events[-1]["current"] == 3
     assert results.attrs["elapsed_seconds"] >= 0.0
     assert results.attrs["feature_set"] == "levenshtein"
-    assert results.attrs["vector_backend"] == "sentence_transformers"
+    assert results.attrs["vector_backend"] == "inactive"
     assert results.attrs["code_metric"] == "none"
     assert results.attrs["chunking_method"] == "none"
+
+
+def test_get_sim_list_keeps_vector_backend_metadata_when_semantic_is_active(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        similarity,
+        "load_backend_model",
+        lambda model_name, vector_backend="auto", device="auto", similarity_function="cosine", pooling_method="mean", max_token_length=None: FakeModel(),
+    )
+
+    source_dir = tmp_path / "codes"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("alpha beta", encoding="utf-8")
+    (source_dir / "b.py").write_text("alpha gamma", encoding="utf-8")
+
+    results = similarity.get_sim_list(
+        source_dir,
+        model_name="fake",
+        threshold=0.0,
+        number_results=5,
+        feature_weights={"semantic": 1.0},
+        vector_backend="sentence_transformers",
+    )
+
+    assert results.attrs["feature_set"] == "semantic"
+    assert results.attrs["vector_backend"] == "sentence_transformers"
 
 
 def test_calculate_similarity_reports_progress_events():


### PR DESCRIPTION
## Summary
- mark semantic backend metadata as `inactive` when semantic scoring is not active
- use the same inactive-backend fallback in comparison-suite summaries
- add CLI, comparison-suite, and similarity tests for lexical-only and semantic-active metadata

## Verification
- .venv/bin/python -m pytest tests/test_cli.py tests/test_comparison_suite.py tests/test_similarity.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- git diff --check
- .venv/bin/matheel compare sample_pairs.zip --feature-weight levenshtein=1.0 --num 3

Closes #124