### PR TITLE
Harden Space sync for release-prep pins

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -42,42 +42,13 @@ jobs:
       - name: Verify Gradio app version references
         run: python scripts/sync_gradio_app_version.py --check
 
-      - name: Wait for pinned Matheel release on PyPI
+      - name: Check pinned Matheel release on PyPI
+        id: pinned-release
         timeout-minutes: 12
-        run: |
-          python - <<'PY'
-          import re
-          import time
-          import urllib.error
-          import urllib.request
-          from pathlib import Path
-
-          requirements = Path("gradio_app/requirements.txt").read_text(encoding="utf-8")
-          match = re.search(r"^matheel(?:\[[^\]]+\])?==([^\s;]+)", requirements, re.MULTILINE)
-          if not match:
-              raise SystemExit("No pinned matheel requirement found in gradio_app/requirements.txt.")
-
-          version = match.group(1)
-          url = f"https://pypi.org/pypi/matheel/{version}/json"
-          deadline = time.monotonic() + 10 * 60
-          delay = 30
-
-          while True:
-              try:
-                  with urllib.request.urlopen(url, timeout=10) as response:
-                      if response.status == 200:
-                          print(f"matheel {version} is available on PyPI.")
-                          break
-              except (TimeoutError, urllib.error.HTTPError, urllib.error.URLError) as exc:
-                  print(f"matheel {version} is not available on PyPI yet: {exc}")
-
-              if time.monotonic() >= deadline:
-                  raise SystemExit(f"Timed out waiting for matheel {version} on PyPI.")
-
-              time.sleep(delay)
-          PY
+        run: python scripts/check_pinned_matheel_release.py
 
       - name: Sync Gradio app to Hugging Face Space
+        if: steps.pinned-release.outputs.should_sync_space == 'true'
         uses: huggingface/hub-sync@v0.1.0
         with:
           github_repo_id: ${{ github.repository }}

--- a/scripts/check_pinned_matheel_release.py
+++ b/scripts/check_pinned_matheel_release.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Check whether the Gradio Space Matheel pin is available on PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+MATHEEL_REQUIREMENT_RE = re.compile(r"^matheel(?:\[[^\]]+\])?==([^\s;]+)", re.MULTILINE)
+
+
+def pinned_matheel_version(requirements_text):
+    match = MATHEEL_REQUIREMENT_RE.search(requirements_text)
+    if not match:
+        raise ValueError("No pinned matheel requirement found in gradio_app/requirements.txt.")
+    return match.group(1)
+
+
+def pinned_matheel_version_from_root(root):
+    requirements_path = Path(root) / "gradio_app" / "requirements.txt"
+    return pinned_matheel_version(requirements_path.read_text(encoding="utf-8"))
+
+
+def pypi_release_url(version):
+    return f"https://pypi.org/pypi/matheel/{version}/json"
+
+
+def release_is_available(version, urlopen=urllib.request.urlopen, timeout=10):
+    try:
+        with urlopen(pypi_release_url(version), timeout=timeout) as response:
+            return response.status == 200
+    except (TimeoutError, urllib.error.HTTPError, urllib.error.URLError):
+        return False
+
+
+def write_github_output(path, *, should_sync_space, matheel_version):
+    if not path:
+        return
+    target = Path(path)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(f"should_sync_space={str(bool(should_sync_space)).lower()}\n")
+        handle.write(f"matheel_version={matheel_version}\n")
+
+
+def check_pinned_release(
+    root,
+    *,
+    event_name,
+    timeout_seconds=600,
+    delay_seconds=30,
+    availability_check=release_is_available,
+    sleep=time.sleep,
+    github_output=None,
+):
+    version = pinned_matheel_version_from_root(root)
+    event = str(event_name or "").strip()
+
+    if event == "push":
+        if availability_check(version):
+            print(f"matheel {version} is available on PyPI.")
+            write_github_output(github_output, should_sync_space=True, matheel_version=version)
+            return 0
+        print(
+            f"matheel {version} is not available on PyPI yet. "
+            "Skipping this push-triggered Space sync; the publish-triggered workflow will sync after release."
+        )
+        write_github_output(github_output, should_sync_space=False, matheel_version=version)
+        return 0
+
+    deadline = time.monotonic() + max(0.0, float(timeout_seconds))
+    delay = max(0.0, float(delay_seconds))
+    while True:
+        if availability_check(version):
+            print(f"matheel {version} is available on PyPI.")
+            write_github_output(github_output, should_sync_space=True, matheel_version=version)
+            return 0
+
+        print(f"matheel {version} is not available on PyPI yet.")
+        if time.monotonic() >= deadline:
+            write_github_output(github_output, should_sync_space=False, matheel_version=version)
+            print(f"Timed out waiting for matheel {version} on PyPI.", file=sys.stderr)
+            return 1
+
+        sleep(delay)
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description="Check whether gradio_app/requirements.txt pins an available Matheel release."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of the scripts directory.",
+    )
+    parser.add_argument(
+        "--event-name",
+        default=os.environ.get("GITHUB_EVENT_NAME", ""),
+        help="GitHub event name. Push events skip successfully when the pin is not published yet.",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=600.0)
+    parser.add_argument("--delay-seconds", type=float, default=30.0)
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        default=Path(os.environ["GITHUB_OUTPUT"]) if os.environ.get("GITHUB_OUTPUT") else None,
+        help="GitHub output file. Defaults to GITHUB_OUTPUT when present.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    return check_pinned_release(
+        args.root.resolve(),
+        event_name=args.event_name,
+        timeout_seconds=args.timeout_seconds,
+        delay_seconds=args.delay_seconds,
+        github_output=args.github_output,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_space_sync_release_check.py
+++ b/tests/test_space_sync_release_check.py
@@ -1,0 +1,103 @@
+import pytest
+
+from scripts.check_pinned_matheel_release import check_pinned_release, pinned_matheel_version
+
+
+def write_sample_repo(root, version="1.2.3"):
+    (root / "gradio_app").mkdir()
+    (root / "gradio_app" / "requirements.txt").write_text(
+        f"matheel[all]=={version}\n",
+        encoding="utf-8",
+    )
+
+
+def read_outputs(path):
+    values = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+def test_pinned_matheel_version_parses_extra_requirement():
+    assert pinned_matheel_version("numpy\nmatheel[all]==0.5.0\n") == "0.5.0"
+
+
+def test_pinned_matheel_version_rejects_missing_pin():
+    with pytest.raises(ValueError, match="No pinned matheel requirement"):
+        pinned_matheel_version("matheel>=0.5\n")
+
+
+def test_push_event_skips_successfully_when_pin_is_not_published(tmp_path):
+    write_sample_repo(tmp_path, version="9.9.9")
+    output_path = tmp_path / "github_output.txt"
+
+    result = check_pinned_release(
+        tmp_path,
+        event_name="push",
+        availability_check=lambda version: False,
+        github_output=output_path,
+    )
+
+    assert result == 0
+    assert read_outputs(output_path) == {
+        "should_sync_space": "false",
+        "matheel_version": "9.9.9",
+    }
+
+
+def test_push_event_syncs_when_pin_is_already_published(tmp_path):
+    write_sample_repo(tmp_path, version="0.5.0")
+    output_path = tmp_path / "github_output.txt"
+
+    result = check_pinned_release(
+        tmp_path,
+        event_name="push",
+        availability_check=lambda version: True,
+        github_output=output_path,
+    )
+
+    assert result == 0
+    assert read_outputs(output_path) == {
+        "should_sync_space": "true",
+        "matheel_version": "0.5.0",
+    }
+
+
+def test_publish_event_waits_for_pin_to_be_available(tmp_path):
+    write_sample_repo(tmp_path, version="0.5.0")
+    output_path = tmp_path / "github_output.txt"
+    attempts = iter([False, True])
+    sleeps = []
+
+    result = check_pinned_release(
+        tmp_path,
+        event_name="workflow_run",
+        timeout_seconds=30,
+        delay_seconds=5,
+        availability_check=lambda version: next(attempts),
+        sleep=sleeps.append,
+        github_output=output_path,
+    )
+
+    assert result == 0
+    assert sleeps == [5.0]
+    assert read_outputs(output_path)["should_sync_space"] == "true"
+
+
+def test_publish_event_fails_when_pin_never_appears(tmp_path):
+    write_sample_repo(tmp_path, version="0.5.0")
+    output_path = tmp_path / "github_output.txt"
+
+    result = check_pinned_release(
+        tmp_path,
+        event_name="workflow_run",
+        timeout_seconds=0,
+        delay_seconds=0,
+        availability_check=lambda version: False,
+        sleep=lambda seconds: None,
+        github_output=output_path,
+    )
+
+    assert result == 1
+    assert read_outputs(output_path)["should_sync_space"] == "false"


### PR DESCRIPTION
## Summary
- move pinned Matheel PyPI availability checks into a tested script
- let push-triggered Space syncs skip successfully when a release-prep pin is not on PyPI yet
- keep publish-triggered and manual checks strict so post-release Space sync still waits for PyPI

## Verification
- .venv/bin/python -m pytest tests/test_space_sync_release_check.py tests/test_gradio_version_sync.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- git diff --check

Closes #121