### PR TITLE
Update workflows for Node 24 actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,16 +33,16 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ inputs.python-version }}
           cache: pip
 
       - name: Cache Hugging Face models
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/huggingface
           key: hf-models-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('tests/test_real_models.py') }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,17 +29,17 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: docs/requirements.txt
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6.0.0
 
       - name: Install docs dependencies
         run: python -m pip install -r docs/requirements.txt
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site
 
@@ -68,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -62,4 +62,4 @@ jobs:
         run: python -m twine check dist/*
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0

--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -47,13 +47,26 @@ jobs:
         timeout-minutes: 12
         run: python scripts/check_pinned_matheel_release.py
 
+      - name: Set up uv
+        if: steps.pinned-release.outputs.should_sync_space == 'true'
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
       - name: Sync Gradio app to Hugging Face Space
         if: steps.pinned-release.outputs.should_sync_space == 'true'
-        uses: huggingface/hub-sync@v0.1.0
-        with:
-          github_repo_id: ${{ github.repository }}
-          huggingface_repo_id: ${{ vars.HF_SPACE_REPO || 'buelfhood/matheel-framework' }}
-          hf_token: ${{ secrets.HF_TOKEN }}
-          repo_type: space
-          space_sdk: gradio
-          subdirectory: gradio_app
+        env:
+          HF_REPO_ID: ${{ vars.HF_SPACE_REPO || 'buelfhood/matheel-framework' }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          uvx hf repo create "${HF_REPO_ID}" --repo-type space --space-sdk gradio --exist-ok
+          uvx hf upload \
+            "${HF_REPO_ID}" \
+            gradio_app \
+            --repo-type space \
+            --exclude=".git*" \
+            --exclude=".github*" \
+            --delete="*" \
+            --commit-message="Sync from GitHub Actions"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip


### PR DESCRIPTION
## Summary
- update GitHub-owned workflow actions to Node 24-compatible releases
- pin the PyPI publish action to the current release tag
- replace the Space sync composite action with direct `setup-uv@v8.1.0` plus `hf` CLI commands to avoid its older transitive action runtime

## Verification
- .venv/bin/python -m pytest tests/test_space_sync_release_check.py tests/test_gradio_version_sync.py
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- git diff --check
- parsed all `.github/workflows/*.yml` with PyYAML

Closes #122