### PR TITLE
Harden custom similarity extension behavior

### DIFF
--- a/docs/comparison_suite.md
+++ b/docs/comparison_suite.md
@@ -59,6 +59,7 @@ The suite normalizes a few convenience aliases:
 
 If no weights are supplied, the suite applies Matheel’s default feature blend.
 For custom runs, provide `algorithm_path` and optional `algorithm_options`; feature weights are not required for those runs.
+Relative `algorithm_path` values are resolved from the config file's directory.
 
 ## Outputs
 

--- a/matheel/algorithms.py
+++ b/matheel/algorithms.py
@@ -14,6 +14,7 @@ from collections.abc import Mapping
 
 import pandas as pd
 
+from ._progress import progress_iter
 from ._run_metadata import attach_run_metadata, elapsed_seconds_since, perf_counter
 from .preprocessing import preprocess_code
 from .similarity import RESULT_COLUMNS, calculate_similarity, extract_and_read_source
@@ -112,6 +113,9 @@ def _load_module_from_path(module_path):
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
+    module.__matheel_algorithm_name__ = target.stem
+    module.__matheel_algorithm_module__ = target.stem
+    module.__matheel_algorithm_package__ = None
     return module
 
 
@@ -148,10 +152,18 @@ def resolve_pair_algorithm(
         prepare_dataset = getattr(module, prepare_name, None)
         if prepare_dataset is not None and not callable(prepare_dataset):
             raise ValueError(f"'{prepare_name}' must be callable when provided.")
-        module_name = getattr(module, "__name__", None)
-        package_name = _package_name_from_module(module_name)
+        module_name = getattr(module, "__matheel_algorithm_module__", None) or getattr(module, "__name__", None)
+        package_name = (
+            getattr(module, "__matheel_algorithm_package__")
+            if hasattr(module, "__matheel_algorithm_package__")
+            else _package_name_from_module(module_name)
+        )
         return PairAlgorithm(
-            name=str(name or getattr(module, "__name__", "custom_algorithm")),
+            name=str(
+                name
+                or getattr(module, "__matheel_algorithm_name__", None)
+                or getattr(module, "__name__", "custom_algorithm")
+            ),
             score_pair=score_pair,
             prepare_dataset=prepare_dataset,
             module_name=module_name,
@@ -295,7 +307,15 @@ def score_source_pairs_with_algorithm(
     file_names, raw_codes = extract_and_read_source(source_path)
     codes = [
         preprocess_code(code, mode=preprocess_mode, language=code_language)
-        for code in raw_codes
+        for code in progress_iter(
+            raw_codes,
+            total=len(raw_codes),
+            desc="Prepare files",
+            unit="file",
+            progress=progress,
+            progress_callback=progress_callback,
+            stage="prepare_files",
+        )
     ]
     source_context = {
         "source_kind": "source_pairs",
@@ -310,7 +330,17 @@ def score_source_pairs_with_algorithm(
     )
 
     rows = []
-    for i, j in combinations(range(len(codes)), 2):
+    pair_count = max(0, len(codes) * (len(codes) - 1) // 2)
+    pair_iter = progress_iter(
+        combinations(range(len(codes)), 2),
+        total=pair_count,
+        desc="Score custom pairs",
+        unit="pair",
+        progress=progress,
+        progress_callback=progress_callback,
+        stage="score_pairs",
+    )
+    for i, j in pair_iter:
         row = {"file_name_1": file_names[i], "file_name_2": file_names[j]}
         score = score_pair_with_algorithm(
             codes[i],

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -957,6 +957,10 @@ def evaluate_pairs(
             threshold=threshold,
             algorithm=algorithm_path,
             algorithm_options=parsed_algorithm_options,
+            similarity_options={
+                "preprocess_mode": preprocess_mode,
+                "code_language": code_language,
+            },
         )
     else:
         if parsed_algorithm_options:
@@ -1178,6 +1182,10 @@ def evaluate_retrieval(
             k=k,
             algorithm=algorithm_path,
             algorithm_options=parsed_algorithm_options,
+            similarity_options={
+                "preprocess_mode": preprocess_mode,
+                "code_language": code_language,
+            },
         )
     else:
         if parsed_algorithm_options:

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -32,8 +32,10 @@ _RUNTIME_FIELDS = ("elapsed_seconds",)
 
 
 def load_run_configs(config_path):
-    raw_data = Path(config_path).read_text(encoding="utf-8")
-    return parse_run_configs(raw_data)
+    path = Path(config_path)
+    raw_data = path.read_text(encoding="utf-8")
+    runs = parse_run_configs(raw_data)
+    return [_resolve_run_paths(run, base_dir=path.parent) for run in runs]
 
 
 def parse_run_configs(raw_data):
@@ -78,6 +80,32 @@ def normalize_run_config(config, index=1):
 
 def _run_uses_custom_algorithm(options):
     return options.get("algorithm") is not None or options.get("algorithm_path") is not None
+
+
+def _resolve_run_paths(run, base_dir):
+    options = dict(run["options"])
+    if "algorithm_path" in options:
+        options["algorithm_path"] = _resolve_config_relative_path(options["algorithm_path"], base_dir)
+    return {"run_name": run["run_name"], "options": options}
+
+
+def _resolve_config_relative_path(value, base_dir):
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text or Path(text).expanduser().is_absolute() or not _looks_like_path(text):
+        return value
+    return str((Path(base_dir) / text).resolve())
+
+
+def _looks_like_path(value):
+    text = str(value)
+    return (
+        text.startswith(".")
+        or text.endswith(".py")
+        or "/" in text
+        or "\\" in text
+    )
 
 
 def _normalize_run_feature_weights(options):

--- a/matheel/evaluation.py
+++ b/matheel/evaluation.py
@@ -10,6 +10,7 @@ from .algorithms import (
 )
 from .calibration import evaluate_threshold
 from .datasets import PairDataset, RetrievalDataset, load_code_texts, load_pair_dataset, load_retrieval_dataset
+from .preprocessing import preprocess_code
 from .resampling import summarize_metric_samples
 from .similarity import calculate_similarity
 
@@ -30,6 +31,8 @@ def score_pair_dataset(
     texts = load_code_texts(dataset)
     options = dict(similarity_options or {})
     resolved_algorithm = resolve_pair_algorithm(algorithm) if algorithm is not None else None
+    if resolved_algorithm is not None:
+        texts = _preprocess_algorithm_texts(texts, options)
     dataset_context = (
         prepare_algorithm_dataset(
             resolved_algorithm,
@@ -133,6 +136,8 @@ def score_retrieval_dataset(
     options = dict(similarity_options or {})
     qrels_lookup = _qrels_lookup(dataset.qrels)
     resolved_algorithm = resolve_pair_algorithm(algorithm) if algorithm is not None else None
+    if resolved_algorithm is not None:
+        texts = _preprocess_algorithm_texts(texts, options)
     dataset_context = (
         prepare_algorithm_dataset(
             resolved_algorithm,
@@ -402,6 +407,15 @@ def _qrels_lookup(
         relevance = _normalize_nonnegative_relevance(row[relevance_column])
         lookup[(query_id, document_id)] = max(lookup.get((query_id, document_id), 0.0), relevance)
     return lookup
+
+
+def _preprocess_algorithm_texts(texts, similarity_options):
+    preprocess_mode = (similarity_options or {}).get("preprocess_mode", "none")
+    code_language = (similarity_options or {}).get("code_language")
+    return {
+        file_id: preprocess_code(text, mode=preprocess_mode, language=code_language)
+        for file_id, text in texts.items()
+    }
 
 
 def _rank_query_results(frame, document_column, score_column):

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -80,6 +80,11 @@ def test_resolve_pair_algorithm_from_module_path_with_prepare_hook(tmp_path):
 
     assert context["n"] == 3
     assert score == pytest.approx(1.2)
+    assert metadata["algorithm_name"] == "custom_algorithm"
+    assert metadata["algorithm_module"] == "custom_algorithm"
+    assert metadata["algorithm_package"] is None
+    assert "matheel_user_algorithm" not in metadata["algorithm_name"]
+    assert "matheel_user_algorithm" not in metadata["algorithm_module"]
     assert metadata["algorithm_source_fingerprint"]["file_name"] == "custom_algorithm.py"
     assert len(metadata["algorithm_source_fingerprint"]["sha256"]) == 64
     assert metadata["algorithm_options"] == {"bonus": 0.2}
@@ -119,3 +124,29 @@ def test_score_source_pairs_with_algorithm_attaches_reproducibility_metadata(tmp
     assert results.attrs["vector_backend"] == "inactive"
     assert results.attrs["algorithm"]["algorithm_options"] == {"bias": 0.1}
     assert len(results.attrs["algorithm"]["algorithm_source_fingerprint"]["sha256"]) == 64
+
+
+def test_score_source_pairs_with_algorithm_reports_progress(tmp_path):
+    source_root = tmp_path / "codes"
+    source_root.mkdir()
+    (source_root / "a.py").write_text("print(1)\n", encoding="utf-8")
+    (source_root / "b.py").write_text("print(1)\n", encoding="utf-8")
+
+    def score_pair(code_a, code_b):
+        return 1.0 if code_a == code_b else 0.0
+
+    events = []
+    score_source_pairs_with_algorithm(
+        source_root,
+        algorithm=score_pair,
+        progress_callback=events.append,
+    )
+
+    prepare_events = [event for event in events if event["stage"] == "prepare_files"]
+    score_events = [event for event in events if event["stage"] == "score_pairs"]
+    assert prepare_events[0]["current"] == 0
+    assert prepare_events[-1]["current"] == 2
+    assert prepare_events[-1]["total"] == 2
+    assert score_events[0]["current"] == 0
+    assert score_events[-1]["current"] == 1
+    assert score_events[-1]["total"] == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -630,7 +630,7 @@ def test_evaluate_pairs_command_uses_custom_algorithm(tmp_path):
         dataset_root,
         files=pd.DataFrame(
             [
-                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "a", "text": "print(1)  # comment", "suffix": ".py"},
                 {"file_id": "b", "text": "print(1)", "suffix": ".py"},
                 {"file_id": "c", "text": "print(2)", "suffix": ".py"},
             ]
@@ -666,6 +666,8 @@ def test_evaluate_pairs_command_uses_custom_algorithm(tmp_path):
             str(algorithm_path),
             "--algorithm-option",
             "bias=0.1",
+            "--preprocess-mode",
+            "basic",
             "--scores-out",
             str(scores_path),
             "--metrics-out",
@@ -898,7 +900,7 @@ def test_evaluate_retrieval_command_uses_custom_algorithm(tmp_path):
         dataset_root,
         files=pd.DataFrame(
             [
-                {"file_id": "query_a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "query_a", "text": "print(1)  # comment", "suffix": ".py"},
                 {"file_id": "doc_a", "text": "print(1)", "suffix": ".py"},
                 {"file_id": "doc_b", "text": "print(2)", "suffix": ".py"},
             ]
@@ -936,6 +938,8 @@ def test_evaluate_retrieval_command_uses_custom_algorithm(tmp_path):
             str(algorithm_path),
             "--algorithm-option",
             "bias=0.1",
+            "--preprocess-mode",
+            "basic",
             "--k",
             "1",
             "--scores-out",

--- a/tests/test_comparison_suite.py
+++ b/tests/test_comparison_suite.py
@@ -55,6 +55,29 @@ def test_load_run_configs_supports_feature_weights_dict(tmp_path):
     }
 
 
+def test_load_run_configs_resolves_algorithm_path_relative_to_config(tmp_path):
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    algorithm_path = config_dir / "algo.py"
+    algorithm_path.write_text("def score_pair(code_a, code_b):\n    return 1.0\n", encoding="utf-8")
+    config_path = config_dir / "runs.json"
+    config_path.write_text(
+        json.dumps(
+            [
+                {
+                    "run_name": "custom",
+                    "algorithm_path": "algo.py",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    runs = load_run_configs(config_path)
+
+    assert runs[0]["options"]["algorithm_path"] == str(algorithm_path.resolve())
+
+
 def test_parse_run_configs_accepts_json_text():
     runs = parse_run_configs(
         '[{"run_name":"baseline","model":"demo-model","feature_weights":"semantic=0.2,code_metric=0.8"}]'
@@ -273,6 +296,32 @@ def test_run_comparison_suite_supports_custom_algorithm(tmp_path):
     payload = json.loads(reproducibility_path.read_text(encoding="utf-8"))
     assert payload["source"]["source_type"] == "directory"
     assert payload["run_metadata"]["runs"]["custom_exact"]["algorithm"]["algorithm_options"] == {"bias": 0.1}
+
+
+def test_run_comparison_suite_uses_config_relative_custom_algorithm(tmp_path, monkeypatch):
+    source_dir = tmp_path / "codes"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("return 1\n", encoding="utf-8")
+    (source_dir / "b.py").write_text("return 1\n", encoding="utf-8")
+
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    (config_dir / "algo.py").write_text(
+        "def score_pair(code_a, code_b):\n    return 1.0 if code_a == code_b else 0.0\n",
+        encoding="utf-8",
+    )
+    config_path = config_dir / "runs.json"
+    config_path.write_text(
+        json.dumps([{"run_name": "custom", "algorithm_path": "algo.py"}]),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    runs = load_run_configs(config_path)
+    summary, _ = run_comparison_suite(source_dir, runs)
+
+    assert summary.loc[0, "run_name"] == "custom"
+    assert summary.loc[0, "top_score"] == pytest.approx(1.0)
 
 
 def test_run_comparison_suite_reports_progress_events(monkeypatch):

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -124,6 +124,32 @@ def test_evaluate_pair_dataset_supports_custom_algorithm_module(tmp_path):
     assert scored.attrs["algorithm"]["algorithm_options"] == {"bias": 0.1}
 
 
+def test_evaluate_pair_dataset_preprocesses_custom_algorithm_inputs(tmp_path):
+    dataset = write_pair_dataset(
+        tmp_path / "commented_pairs",
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)  # comment", "suffix": ".py"},
+                {"file_id": "b", "text": "print(1)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+    )
+
+    def score_pair(code_a, code_b):
+        return 1.0 if code_a == code_b else 0.0
+
+    scored, metrics = evaluate_pair_dataset(
+        dataset,
+        threshold=0.5,
+        algorithm=score_pair,
+        similarity_options={"preprocess_mode": "basic", "code_language": "python"},
+    )
+
+    assert scored["similarity_score"].tolist() == [1.0]
+    assert metrics["accuracy"] == 1.0
+
+
 def test_pair_classification_metrics_requires_score_column():
     with pytest.raises(ValueError, match="similarity_score"):
         pair_classification_metrics([{"label": 1}], threshold=0.5)
@@ -184,6 +210,34 @@ def test_evaluate_retrieval_dataset_supports_custom_algorithm_module(tmp_path):
 
     assert len(scored) == 6
     assert scored.attrs["algorithm"]["algorithm_options"] == {"boost": 0.1}
+    assert metrics["mean_average_precision"] == 1.0
+
+
+def test_evaluate_retrieval_dataset_preprocesses_custom_algorithm_inputs(tmp_path):
+    dataset = write_retrieval_dataset(
+        tmp_path / "commented_retrieval",
+        files=pd.DataFrame(
+            [
+                {"file_id": "query_a", "text": "print(1)  # comment", "suffix": ".py"},
+                {"file_id": "doc_a", "text": "print(1)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "query_a"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "doc_a"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    )
+
+    def score_pair(code_a, code_b):
+        return 1.0 if code_a == code_b else 0.0
+
+    scored, metrics = evaluate_retrieval_dataset(
+        dataset,
+        k=1,
+        algorithm=score_pair,
+        similarity_options={"preprocess_mode": "basic", "code_language": "python"},
+    )
+
+    assert scored["similarity_score"].tolist() == [1.0]
     assert metrics["mean_average_precision"] == 1.0
 
 


### PR DESCRIPTION
## Summary

- apply preprocessing options to dataset custom algorithms for pair and retrieval evaluation
- use portable file-stem metadata for path-loaded custom algorithms while keeping source SHA-256 fingerprints
- resolve comparison-suite `algorithm_path` values relative to the config file directory
- emit progress events/bars for custom archive preparation and pair scoring

## Tests

- `.venv/bin/python -m pytest tests/test_algorithms.py tests/test_evaluation.py tests/test_comparison_suite.py tests/test_cli.py`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m mkdocs build --strict`
- `git diff --check`

Closes #132
