### PR TITLE
Harden custom algorithm edge cases

### DIFF
--- a/docs/comparison_suite.md
+++ b/docs/comparison_suite.md
@@ -60,6 +60,7 @@ The suite normalizes a few convenience aliases:
 If no weights are supplied, the suite applies Matheel’s default feature blend.
 For custom runs, provide `algorithm_path` and optional `algorithm_options`; feature weights are not required for those runs.
 Relative `algorithm_path` values are resolved from the config file's directory.
+Custom runs reject unsupported option names so configuration typos fail early.
 
 ## Outputs
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -30,9 +30,13 @@ Options must be a mapping with non-empty string keys and JSON-serializable value
 Define `prepare_dataset` when the algorithm needs reusable dataset-level state:
 
 ```python
-def prepare_dataset(dataset, bias=0.0, **kwargs):
+def prepare_dataset(dataset, prepared_texts=None, bias=0.0, **kwargs):
     _ = kwargs
-    return {"bias": float(bias), "file_count": len(dataset.files)}
+    return {
+        "bias": float(bias),
+        "file_count": len(dataset.files),
+        "prepared_texts": dict(prepared_texts or {}),
+    }
 
 
 def score_pair(code_a, code_b, dataset_context=None, **kwargs):
@@ -41,7 +45,9 @@ def score_pair(code_a, code_b, dataset_context=None, **kwargs):
     return base + dataset_context["bias"]
 ```
 
-For normalized pair datasets, `dataset` is a `PairDataset`. For retrieval datasets, it is a `RetrievalDataset`. For `matheel compare` archive or directory runs, it is a small mapping with source file names, prepared code strings, and code count.
+For normalized pair datasets, `dataset` is a `PairDataset`. For retrieval datasets, it is a `RetrievalDataset`.
+For `matheel compare` archive or directory runs, it is a small mapping with source file names, prepared code strings, and code count.
+When accepted by the function, `prepared_texts` contains the exact file-id-to-text mapping that will be scored after preprocessing.
 
 ## CLI
 
@@ -77,6 +83,7 @@ matheel evaluate-retrieval ./data/retrieval \
 ```
 
 `--algorithm-option` accepts JSON-like scalar values such as `0.2`, `true`, `false`, `null`, quoted strings, lists, and objects.
+Path-loaded algorithm files can import helper modules placed beside the algorithm file.
 
 ## Comparison Suite
 

--- a/matheel/algorithms.py
+++ b/matheel/algorithms.py
@@ -38,7 +38,7 @@ class PairAlgorithm:
     source_fingerprint: dict | None = None
 
 
-_PREPARE_RESERVED_KEYS = frozenset({"dataset", "algorithm_options"})
+_PREPARE_RESERVED_KEYS = frozenset({"dataset", "prepared_texts", "algorithm_options"})
 _SCORE_RESERVED_KEYS = frozenset(
     {"code_a", "code_b", "dataset_context", "row", "algorithm_options"}
 )
@@ -111,8 +111,19 @@ def _load_module_from_path(module_path):
     if spec is None or spec.loader is None:
         raise ValueError(f"Unable to load algorithm module from: {target.name}")
     module = importlib.util.module_from_spec(spec)
+    algorithm_dir = str(target.parent)
+    sys.path.insert(0, algorithm_dir)
     sys.modules[module_name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
+    finally:
+        try:
+            sys.path.remove(algorithm_dir)
+        except ValueError:
+            pass
     module.__matheel_algorithm_name__ = target.stem
     module.__matheel_algorithm_module__ = target.stem
     module.__matheel_algorithm_package__ = None
@@ -211,11 +222,14 @@ def _build_call_values(base_values, algorithm_options, reserved_keys):
     }
 
 
-def prepare_algorithm_dataset(algorithm, dataset, algorithm_options=None):
+def prepare_algorithm_dataset(algorithm, dataset, algorithm_options=None, prepared_texts=None):
     resolved = resolve_pair_algorithm(algorithm)
     if resolved.prepare_dataset is None:
         return None
-    values = _build_call_values({"dataset": dataset}, algorithm_options, _PREPARE_RESERVED_KEYS)
+    base_values = {"dataset": dataset}
+    if prepared_texts is not None:
+        base_values["prepared_texts"] = dict(prepared_texts)
+    values = _build_call_values(base_values, algorithm_options, _PREPARE_RESERVED_KEYS)
     return _call_supported(resolved.prepare_dataset, values)
 
 
@@ -233,7 +247,7 @@ def score_pair_with_algorithm(
             "code_a": code_a,
             "code_b": code_b,
             "dataset_context": dataset_context,
-            "row": dict(row or {}),
+            "row": {} if row is None else dict(row),
         },
         algorithm_options,
         _SCORE_RESERVED_KEYS,
@@ -327,6 +341,7 @@ def score_source_pairs_with_algorithm(
         resolved_algorithm,
         source_context,
         algorithm_options=options,
+        prepared_texts=dict(zip(file_names, codes, strict=True)),
     )
 
     rows = []

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -29,6 +29,19 @@ _SCORE_FIELDS = (
     "similarity_score",
 )
 _RUNTIME_FIELDS = ("elapsed_seconds",)
+_CUSTOM_ALGORITHM_OPTION_NAMES = frozenset(
+    {
+        "algorithm",
+        "algorithm_path",
+        "algorithm_options",
+        "preprocess_mode",
+        "code_language",
+        "threshold",
+        "number_results",
+        "progress",
+        "progress_callback",
+    }
+)
 
 
 def load_run_configs(config_path):
@@ -69,7 +82,9 @@ def normalize_run_config(config, index=1):
     if "algorithm_options" in options:
         options["algorithm_options"] = normalize_algorithm_options(options["algorithm_options"])
 
-    if not _run_uses_custom_algorithm(options):
+    if _run_uses_custom_algorithm(options):
+        _validate_custom_algorithm_options(options)
+    else:
         _normalize_run_feature_weights(options)
         options.setdefault("model_name", DEFAULT_MODEL_NAME)
     options.setdefault("threshold", 0.0)
@@ -80,6 +95,17 @@ def normalize_run_config(config, index=1):
 
 def _run_uses_custom_algorithm(options):
     return options.get("algorithm") is not None or options.get("algorithm_path") is not None
+
+
+def _validate_custom_algorithm_options(options):
+    unknown = sorted(set(options).difference(_CUSTOM_ALGORITHM_OPTION_NAMES))
+    if unknown:
+        names = ", ".join(unknown)
+        supported = ", ".join(sorted(_CUSTOM_ALGORITHM_OPTION_NAMES - {"algorithm", "progress_callback"}))
+        raise ValueError(
+            f"Unsupported custom algorithm option(s): {names}. "
+            f"Supported custom options are: {supported}."
+        )
 
 
 def _resolve_run_paths(run, base_dir):

--- a/matheel/evaluation.py
+++ b/matheel/evaluation.py
@@ -38,6 +38,7 @@ def score_pair_dataset(
             resolved_algorithm,
             dataset,
             algorithm_options=algorithm_options,
+            prepared_texts=texts,
         )
         if resolved_algorithm is not None
         else None
@@ -143,6 +144,7 @@ def score_retrieval_dataset(
             resolved_algorithm,
             dataset,
             algorithm_options=algorithm_options,
+            prepared_texts=texts,
         )
         if resolved_algorithm is not None
         else None

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1,5 +1,7 @@
+import sys
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from matheel.algorithms import (
@@ -41,6 +43,16 @@ def test_score_pair_with_algorithm_passes_options_context_and_row():
     )
 
     assert score == pytest.approx(2.75)
+
+
+def test_score_pair_with_algorithm_accepts_series_row():
+    def score_pair(code_a, code_b, row=None):
+        _ = (code_a, code_b)
+        return float(row["bonus"])
+
+    score = score_pair_with_algorithm("a", "b", score_pair, row=pd.Series({"bonus": 0.25}))
+
+    assert score == pytest.approx(0.25)
 
 
 def test_algorithm_options_are_validated():
@@ -88,6 +100,24 @@ def test_resolve_pair_algorithm_from_module_path_with_prepare_hook(tmp_path):
     assert metadata["algorithm_source_fingerprint"]["file_name"] == "custom_algorithm.py"
     assert len(metadata["algorithm_source_fingerprint"]["sha256"]) == 64
     assert metadata["algorithm_options"] == {"bonus": 0.2}
+
+
+def test_resolve_pair_algorithm_from_module_path_imports_sibling_helper(tmp_path):
+    module_path = tmp_path / "custom_algorithm.py"
+    helper_path = tmp_path / "helper.py"
+    helper_path.write_text("BIAS = 0.25\n", encoding="utf-8")
+    module_path.write_text(
+        "from helper import BIAS\n\n"
+        "def score_pair(code_a, code_b):\n"
+        "    _ = (code_a, code_b)\n"
+        "    return BIAS\n",
+        encoding="utf-8",
+    )
+
+    algorithm = resolve_pair_algorithm(module_path)
+
+    assert score_pair_with_algorithm("a", "b", algorithm) == pytest.approx(0.25)
+    assert str(tmp_path) not in sys.path
 
 
 def test_score_source_pairs_with_algorithm_attaches_reproducibility_metadata(tmp_path):

--- a/tests/test_comparison_suite.py
+++ b/tests/test_comparison_suite.py
@@ -110,6 +110,13 @@ def test_parse_run_configs_rejects_legacy_weight_keys():
         )
 
 
+def test_parse_run_configs_rejects_unknown_custom_algorithm_options():
+    with pytest.raises(ValueError, match="Unsupported custom algorithm option.*threshhold"):
+        parse_run_configs(
+            '[{"run_name":"custom","algorithm_path":"algo.py","threshhold":0.5}]'
+        )
+
+
 def test_slugify_run_name_removes_path_separators():
     assert slugify_run_name("../baseline/strong") == "baseline_strong"
     assert slugify_run_name("...") == "run"

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -150,6 +150,48 @@ def test_evaluate_pair_dataset_preprocesses_custom_algorithm_inputs(tmp_path):
     assert metrics["accuracy"] == 1.0
 
 
+def test_evaluate_pair_dataset_prepare_hook_receives_prepared_texts(tmp_path):
+    dataset = write_pair_dataset(
+        tmp_path / "prepared_pairs",
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)  # comment", "suffix": ".py"},
+                {"file_id": "b", "text": "print(1)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+    )
+    module_path = tmp_path / "prepared_algo.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "def prepare_dataset(dataset, prepared_texts):",
+                "    return {",
+                "        'same': prepared_texts['a'] == prepared_texts['b'],",
+                "        'files': len(dataset.files),",
+                "    }",
+                "",
+                "def score_pair(code_a, code_b, dataset_context=None):",
+                "    _ = (code_a, code_b)",
+                "    return 1.0 if (",
+                "        dataset_context['same'] and dataset_context['files'] == 2",
+                "    ) else 0.0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    scored, metrics = evaluate_pair_dataset(
+        dataset,
+        threshold=0.5,
+        algorithm=module_path,
+        similarity_options={"preprocess_mode": "basic", "code_language": "python"},
+    )
+
+    assert scored["similarity_score"].tolist() == [1.0]
+    assert metrics["accuracy"] == 1.0
+
+
 def test_pair_classification_metrics_requires_score_column():
     with pytest.raises(ValueError, match="similarity_score"):
         pair_classification_metrics([{"label": 1}], threshold=0.5)
@@ -234,6 +276,50 @@ def test_evaluate_retrieval_dataset_preprocesses_custom_algorithm_inputs(tmp_pat
         dataset,
         k=1,
         algorithm=score_pair,
+        similarity_options={"preprocess_mode": "basic", "code_language": "python"},
+    )
+
+    assert scored["similarity_score"].tolist() == [1.0]
+    assert metrics["mean_average_precision"] == 1.0
+
+
+def test_evaluate_retrieval_dataset_prepare_hook_receives_prepared_texts(tmp_path):
+    dataset = write_retrieval_dataset(
+        tmp_path / "prepared_retrieval",
+        files=pd.DataFrame(
+            [
+                {"file_id": "query_a", "text": "print(1)  # comment", "suffix": ".py"},
+                {"file_id": "doc_a", "text": "print(1)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "query_a"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "doc_a"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    )
+    module_path = tmp_path / "prepared_retrieval_algo.py"
+    module_path.write_text(
+        "\n".join(
+            [
+                "def prepare_dataset(dataset, prepared_texts):",
+                "    return {",
+                "        'same': prepared_texts['query_a'] == prepared_texts['doc_a'],",
+                "        'queries': len(dataset.queries),",
+                "    }",
+                "",
+                "def score_pair(code_a, code_b, dataset_context=None):",
+                "    _ = (code_a, code_b)",
+                "    return 1.0 if (",
+                "        dataset_context['same'] and dataset_context['queries'] == 1",
+                "    ) else 0.0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    scored, metrics = evaluate_retrieval_dataset(
+        dataset,
+        k=1,
+        algorithm=module_path,
         similarity_options={"preprocess_mode": "basic", "code_language": "python"},
     )
 


### PR DESCRIPTION
## Summary
- allow path-loaded custom algorithms to import sibling helper modules during module load
- make custom row forwarding handle mapping-like row objects and pass prepared text maps into dataset preparation hooks
- reject unsupported custom comparison-suite options so typos fail early
- document the updated custom algorithm behavior

## Tests
- `python -m pytest tests/test_algorithms.py tests/test_evaluation.py tests/test_comparison_suite.py`
- `python -m ruff check .`
- `python -m pytest`
- `python -m mkdocs build --strict`
- `git diff --check`

Closes #134
