### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.4.0` and includes:
+This Space is aligned with `matheel==0.4.1` and includes:
 
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.4.0
+matheel[all]==0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
## Summary
- bump Matheel package version to `0.4.1`
- sync Gradio app README and requirements pins to `0.4.1`

## Release validation
- `python scripts/sync_gradio_app_version.py --check`
- `python -m pytest`
- `python -m ruff check .`
- `python -m mkdocs build --strict`
- `git diff --check`
- `python -m build`
- `python -m twine check` on the built artifacts

Closes #125
