### PR TITLE
Organize docs and add reproducible benchmark demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 dist/
 site/
 docs/releases/
+benchmark_outputs/

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -524,3 +524,5 @@ comparison = compare_metric_samples(
 ```
 
 The comparison report includes mean difference, interval bounds, win/loss/tie counts, and a two-sided sign-test p-value.
+
+For a complete tiny workflow that writes a manifest, scored rows, metrics, resampling summaries, and reproducibility metadata, see the [reproducible benchmark demo](reproducible_benchmark.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,9 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 - [Vectors and routing](vectors.md)
 - [Lexical metrics and baselines](lexical.md)
 - [Code metrics](code_metrics.md)
+- [Scoring and calibration](scoring.md)
 - [Datasets and evaluation](datasets.md)
+- [Reproducible benchmark demo](reproducible_benchmark.md)
 - [Custom algorithms](customization.md)
 - [Comparison suite](comparison_suite.md)
 - [Development](development.md)
@@ -39,5 +41,6 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 3. Add [Chunking](chunking.md) and [Preprocessing](preprocessing.md) if you need code-aware shaping before scoring.
 4. Add [Lexical metrics and baselines](lexical.md) and [Code metrics](code_metrics.md) if you want hybrid scoring.
 5. Use [Datasets and evaluation](datasets.md) for labeled pair and retrieval datasets.
-6. Use [Custom algorithms](customization.md) for project-specific scorers.
-7. Use [Comparison suite](comparison_suite.md) for repeatable multi-run experiments.
+6. Run the [reproducible benchmark demo](reproducible_benchmark.md) for a small auditable workflow.
+7. Use [Custom algorithms](customization.md) for project-specific scorers.
+8. Use [Comparison suite](comparison_suite.md) for repeatable multi-run experiments.

--- a/docs/reproducible_benchmark.md
+++ b/docs/reproducible_benchmark.md
@@ -1,0 +1,78 @@
+# Reproducible Benchmark Demo
+
+This demo creates a tiny synthetic pair-classification dataset, adapts it through the dataset manifest workflow, scores it with an offline lexical baseline, and writes auditable outputs.
+
+It is a workflow example, not a benchmark claim. Real datasets are not bundled with Matheel, and users should provide or download datasets according to each source's terms.
+
+## Run the Demo
+
+From the repository root:
+
+```bash
+python examples/reproducible_benchmark_demo.py \
+  --output-dir benchmark_outputs/synthetic_pair_benchmark \
+  --overwrite
+```
+
+The command writes:
+
+```text
+benchmark_outputs/synthetic_pair_benchmark/
+  raw/pairs.csv
+  dataset_manifest.json
+  benchmark_config.json
+  dataset/
+  results/
+    scored_pairs.csv
+    pair_metrics.json
+    resample_metrics.csv
+    resample_summary.csv
+    reproducibility.json
+```
+
+The generated files capture:
+
+- synthetic raw inputs and the normalized Matheel dataset
+- source, adapter, and destination choices in `dataset_manifest.json`
+- threshold, feature weights, preprocessing, language, and resampling seed in `benchmark_config.json`
+- scored rows and aggregate pair-classification metrics
+- fold-level metrics and interval summaries
+- package versions, Python metadata, platform metadata, source fingerprint, and run metadata
+
+## CLI Equivalent
+
+After generating the synthetic inputs, you can rerun the scoring step through the CLI:
+
+```bash
+matheel evaluate-pairs \
+  --manifest benchmark_outputs/synthetic_pair_benchmark/dataset_manifest.json \
+  --feature-weight levenshtein=1.0 \
+  --preprocess-mode basic \
+  --code-language python \
+  --threshold 0.65 \
+  --scores-out benchmark_outputs/synthetic_pair_benchmark/results/scored_pairs_cli.csv \
+  --metrics-out benchmark_outputs/synthetic_pair_benchmark/results/pair_metrics_cli.json \
+  --reproducibility-out benchmark_outputs/synthetic_pair_benchmark/results/reproducibility_cli.json
+```
+
+The example uses `levenshtein=1.0`, so it runs offline and does not download embedding models.
+
+## Adapt the Workflow
+
+For a custom pair dataset:
+
+1. Replace `raw/pairs.csv` with your own table.
+2. Update `dataset_manifest.json` so `adapter_options` point to your column names.
+3. Keep `benchmark_config.json` with the run settings you want to audit.
+4. Keep a fixed resampling seed while comparing configurations.
+5. Store generated outputs outside source control unless the files are deliberately tiny examples.
+
+For retrieval datasets, use `auto_retrieval_tabular` and the ranking metrics described in [Datasets and evaluation](datasets.md).
+
+## Reproducibility Checklist
+
+- Record the Matheel version and optional backend package versions.
+- Record the dataset source, adapter, and normalized source fingerprint.
+- Record scorer settings, preprocessing, language, threshold, and feature weights.
+- Record split method, number of folds or rounds, confidence level, and random seed.
+- Keep scored rows alongside summary metrics so threshold decisions can be audited.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,6 +90,7 @@ print(results.head())
 - Add `--chunking-method` when large files should be split before embedding.
 - Use `matheel compare-suite` with a JSON config for repeatable multi-run comparisons.
 - Use `--algorithm-path` when you need a custom `score_pair` implementation.
+- Run the reproducible benchmark demo when you need a small auditable evaluation workflow.
 - Run the Gradio app or notebooks when you want an interactive workflow.
 
 ## Demos and Examples
@@ -108,6 +109,7 @@ print(results.head())
 - [Lexical metrics and baselines](lexical.md)
 - [Code metrics](code_metrics.md)
 - [Scoring and calibration](scoring.md)
+- [Reproducible benchmark demo](reproducible_benchmark.md)
 - [Custom algorithms](customization.md)
 - [Comparison suite](comparison_suite.md)
 - [Development](development.md)

--- a/examples/reproducible_benchmark_demo.py
+++ b/examples/reproducible_benchmark_demo.py
@@ -1,0 +1,274 @@
+"""Run a tiny reproducible Matheel pair-classification benchmark."""
+
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+from tempfile import gettempdir
+
+import pandas as pd
+
+# Configure Matplotlib before importing Matheel's evaluation stack.
+_MPLCONFIGDIR = Path(gettempdir()) / "matheel_matplotlib"
+_MPLCONFIGDIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", os.fspath(_MPLCONFIGDIR))
+
+from matheel.datasets import load_pair_datasets_from_manifest  # noqa: E402
+from matheel.evaluation import evaluate_pair_dataset, evaluate_pair_resamples  # noqa: E402
+from matheel.reproducibility import (  # noqa: E402
+    collect_reproducibility_snapshot,
+    write_reproducibility_snapshot,
+)
+from matheel.resampling import kfold_splits  # noqa: E402
+
+
+DEFAULT_OUTPUT_DIR = Path("benchmark_outputs") / "synthetic_pair_benchmark"
+THRESHOLD = 0.65
+RESAMPLING_SEED = 7
+RESAMPLING_FOLDS = 4
+CONFIDENCE = 0.95
+SIMILARITY_OPTIONS = {
+    "feature_weights": {"levenshtein": 1.0},
+    "preprocess_mode": "basic",
+    "code_language": "python",
+    "vector_backend": "auto",
+}
+
+
+SYNTHETIC_PAIRS = [
+    {
+        "left_id": "sum_original",
+        "right_id": "sum_renamed",
+        "left_code": "def total(values):\n    return sum(values)\n",
+        "right_code": "def total(items):\n    return sum(items)\n",
+        "label": 1,
+    },
+    {
+        "left_id": "max_original",
+        "right_id": "max_renamed",
+        "left_code": "def largest(values):\n    return max(values)\n",
+        "right_code": "def largest(numbers):\n    return max(numbers)\n",
+        "label": 1,
+    },
+    {
+        "left_id": "tax_original",
+        "right_id": "tax_reformatted",
+        "left_code": "def total_with_tax(price, tax):\n    return price + tax\n",
+        "right_code": "def total_with_tax(price,tax):\n    result = price + tax\n    return result\n",
+        "label": 1,
+    },
+    {
+        "left_id": "filter_original",
+        "right_id": "filter_loop",
+        "left_code": "def positives(values):\n    return [value for value in values if value > 0]\n",
+        "right_code": (
+            "def positives(values):\n"
+            "    output = []\n"
+            "    for value in values:\n"
+            "        if value > 0:\n"
+            "            output.append(value)\n"
+            "    return output\n"
+        ),
+        "label": 1,
+    },
+    {
+        "left_id": "sum_original",
+        "right_id": "multiply_different",
+        "left_code": "def total(values):\n    return sum(values)\n",
+        "right_code": "def product(values):\n    result = 1\n    for value in values:\n        result *= value\n    return result\n",
+        "label": 0,
+    },
+    {
+        "left_id": "max_original",
+        "right_id": "duplicates_different",
+        "left_code": "def largest(values):\n    return max(values)\n",
+        "right_code": (
+            "def has_duplicates(values):\n"
+            "    seen = set()\n"
+            "    for value in values:\n"
+            "        if value in seen:\n"
+            "            return True\n"
+            "        seen.add(value)\n"
+            "    return False\n"
+        ),
+        "label": 0,
+    },
+    {
+        "left_id": "tax_original",
+        "right_id": "discount_different",
+        "left_code": "def total_with_tax(price, tax):\n    return price + tax\n",
+        "right_code": "def total_after_discount(price, discount):\n    return price - discount\n",
+        "label": 0,
+    },
+    {
+        "left_id": "filter_original",
+        "right_id": "sort_different",
+        "left_code": "def positives(values):\n    return [value for value in values if value > 0]\n",
+        "right_code": "def ordered(values):\n    return sorted(values)\n",
+        "label": 0,
+    },
+]
+
+
+def main():
+    args = _parse_args()
+    output_dir = Path(args.output_dir)
+    if output_dir.exists() and args.overwrite:
+        _replace_output_dir(output_dir)
+    elif output_dir.exists() and any(output_dir.iterdir()):
+        raise SystemExit(f"{output_dir} already exists and is not empty. Pass --overwrite to replace it.")
+
+    artifacts = run_benchmark(output_dir)
+    print("Reproducible synthetic pair benchmark")
+    for name, path in artifacts.items():
+        print(f"{name}: {path}")
+
+
+def run_benchmark(output_dir):
+    output_dir.mkdir(parents=True, exist_ok=True)
+    raw_dir = output_dir / "raw"
+    results_dir = output_dir / "results"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    raw_pairs_path = raw_dir / "pairs.csv"
+    pd.DataFrame(SYNTHETIC_PAIRS).to_csv(raw_pairs_path, index=False)
+
+    manifest_path = output_dir / "dataset_manifest.json"
+    manifest = _dataset_manifest()
+    _write_json(manifest_path, manifest)
+
+    config_path = output_dir / "benchmark_config.json"
+    config = _benchmark_config(manifest_path.name)
+    _write_json(config_path, config)
+
+    dataset = load_pair_datasets_from_manifest(manifest_path)
+    scored_pairs, metrics = evaluate_pair_dataset(
+        dataset,
+        threshold=THRESHOLD,
+        similarity_options=SIMILARITY_OPTIONS,
+    )
+
+    scores_path = results_dir / "scored_pairs.csv"
+    metrics_path = results_dir / "pair_metrics.json"
+    scored_pairs.to_csv(scores_path, index=False)
+    _write_json(metrics_path, metrics)
+
+    splits = kfold_splits(
+        len(scored_pairs),
+        n_splits=RESAMPLING_FOLDS,
+        shuffle=True,
+        seed=RESAMPLING_SEED,
+        labels=scored_pairs["label"].tolist(),
+    )
+    fold_metrics, fold_summary = evaluate_pair_resamples(
+        scored_pairs,
+        splits,
+        threshold=THRESHOLD,
+        confidence=CONFIDENCE,
+    )
+    resample_metrics_path = results_dir / "resample_metrics.csv"
+    resample_summary_path = results_dir / "resample_summary.csv"
+    fold_metrics.to_csv(resample_metrics_path, index=False)
+    fold_summary.to_csv(resample_summary_path, index=False)
+
+    reproducibility_path = results_dir / "reproducibility.json"
+    snapshot = collect_reproducibility_snapshot(
+        source_path=dataset.root,
+        run_configs=[config],
+        result_attrs={
+            "metrics": metrics,
+            "resampling": {
+                "method": "kfold",
+                "n_splits": RESAMPLING_FOLDS,
+                "seed": RESAMPLING_SEED,
+                "confidence": CONFIDENCE,
+            },
+        },
+    )
+    write_reproducibility_snapshot(snapshot, reproducibility_path)
+
+    return {
+        "raw_pairs": raw_pairs_path,
+        "dataset_manifest": manifest_path,
+        "benchmark_config": config_path,
+        "scores": scores_path,
+        "metrics": metrics_path,
+        "resample_metrics": resample_metrics_path,
+        "resample_summary": resample_summary_path,
+        "reproducibility": reproducibility_path,
+    }
+
+
+def _replace_output_dir(output_dir):
+    resolved = Path(output_dir).expanduser().resolve()
+    protected = {Path.cwd().resolve(), Path.home().resolve()}
+    if resolved.parent == resolved or resolved in protected:
+        raise SystemExit(f"Refusing to overwrite protected output directory: {output_dir}")
+    shutil.rmtree(resolved)
+
+
+def _dataset_manifest():
+    return {
+        "version": 1,
+        "task": "pair",
+        "datasets": [
+            {
+                "name": "synthetic_pair_benchmark",
+                "source": "local",
+                "identifier": "./raw",
+                "adapter": "auto_pair_tabular",
+                "adapted_destination": "./dataset",
+                "adapter_options": {
+                    "pair_table": "pairs.csv",
+                    "left_id_column": "left_id",
+                    "right_id_column": "right_id",
+                    "left_text_column": "left_code",
+                    "right_text_column": "right_code",
+                    "label_column": "label",
+                    "suffix": ".py",
+                },
+            }
+        ],
+    }
+
+
+def _benchmark_config(manifest_name):
+    return {
+        "dataset_manifest": manifest_name,
+        "scoring": {
+            "threshold": THRESHOLD,
+            "similarity_options": SIMILARITY_OPTIONS,
+        },
+        "resampling": {
+            "method": "kfold",
+            "n_splits": RESAMPLING_FOLDS,
+            "seed": RESAMPLING_SEED,
+            "confidence": CONFIDENCE,
+        },
+    }
+
+
+def _write_json(path, payload):
+    Path(path).write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        default=DEFAULT_OUTPUT_DIR,
+        type=Path,
+        help="Directory where synthetic inputs and benchmark outputs are written.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace an existing non-empty output directory.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,19 +15,24 @@ theme:
   highlightjs: true
 
 nav:
-  - Home: index.md
-  - Usage: usage.md
-  - Preprocessing: preprocessing.md
-  - Tokenization and limits: tokenization.md
-  - Chunking: chunking.md
-  - Vectors and routing: vectors.md
-  - Lexical metrics and baselines: lexical.md
-  - Code metrics: code_metrics.md
-  - Scoring and calibration: scoring.md
-  - Datasets and evaluation: datasets.md
-  - Custom algorithms: customization.md
-  - Comparison suite: comparison_suite.md
-  - Development: development.md
+  - Getting Started:
+      - Home: index.md
+      - Usage: usage.md
+  - Scoring:
+      - Preprocessing: preprocessing.md
+      - Tokenization and limits: tokenization.md
+      - Chunking: chunking.md
+      - Vectors and routing: vectors.md
+      - Lexical metrics and baselines: lexical.md
+      - Code metrics: code_metrics.md
+  - Evaluation:
+      - Scoring and calibration: scoring.md
+      - Datasets and evaluation: datasets.md
+      - Reproducible benchmark demo: reproducible_benchmark.md
+      - Custom algorithms: customization.md
+      - Comparison suite: comparison_suite.md
+  - Project:
+      - Development: development.md
 
 exclude_docs: |
   README.md

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1104,6 +1104,43 @@ def test_dataset_example_script_runs():
     assert "Custom source and preset" in result.stdout
 
 
+def test_reproducible_benchmark_example_script_runs(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(repo_root), env.get("PYTHONPATH", "")) if part
+    )
+    output_dir = tmp_path / "benchmark"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "examples/reproducible_benchmark_demo.py",
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=repo_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "Reproducible synthetic pair benchmark" in result.stdout
+    assert (output_dir / "dataset_manifest.json").exists()
+    assert (output_dir / "benchmark_config.json").exists()
+    assert (output_dir / "results" / "scored_pairs.csv").exists()
+    assert (output_dir / "results" / "resample_summary.csv").exists()
+
+    metrics = json.loads((output_dir / "results" / "pair_metrics.json").read_text(encoding="utf-8"))
+    assert metrics["pair_count"] == 8
+    reproducibility = json.loads(
+        (output_dir / "results" / "reproducibility.json").read_text(encoding="utf-8")
+    )
+    assert reproducibility["schema_version"] == 1
+    assert reproducibility["source"]["source_type"] == "directory"
+
+
 def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
     archive_path = tmp_path / "codes.zip"
     archive_path.write_bytes(b"placeholder")


### PR DESCRIPTION
Summary:
- group the MkDocs navigation by workflow area
- add a synthetic reproducible benchmark example that writes raw data, manifest, config, scores, metrics, resampling summaries, and reproducibility metadata
- document the benchmark workflow and add a regression test for the example script

Validation:
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- git diff --check

Closes #43
Closes #138