### PR TITLE
Prepare v0.4.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ Matheel is a Python package and CLI for source-code similarity. It combines sema
 
 Matheel supports Python `3.10` to `3.13`.
 
+Recommended install:
+
+```bash
+pip install "matheel[all]"
+```
+
+For a lightweight install without optional semantic, chunking, metrics, and Gradio dependencies:
+
 ```bash
 pip install matheel
 ```
 
-Optional semantic, chunking, metrics, and Gradio extras are covered in the [usage guide](https://fahadebrahim.github.io/matheel/usage/#installation).
+Installation options are covered in the [usage guide](https://fahadebrahim.github.io/matheel/usage/#installation).
 
 ## Quick Start
 

--- a/examples/notebooks/01_core_workflows.ipynb
+++ b/examples/notebooks/01_core_workflows.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"main\"\n",
+    "MATHEEL_REF = \"v0.4.2\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/02_datasets_and_reproducibility.ipynb
+++ b/examples/notebooks/02_datasets_and_reproducibility.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"main\"\n",
+    "MATHEEL_REF = \"v0.4.2\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/03_custom_algorithms.ipynb
+++ b/examples/notebooks/03_custom_algorithms.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"main\"\n",
+    "MATHEEL_REF = \"v0.4.2\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/04_gradio_app.ipynb
+++ b/examples/notebooks/04_gradio_app.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%%bash\n",
     "set -euo pipefail\n",
-    "MATHEEL_REF=\"main\"\n",
+    "MATHEEL_REF=\"v0.4.2\"\n",
     "pip uninstall -y torchvision || true\n",
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.4.1` and includes:
+This Space is aligned with `matheel==0.4.2` and includes:
 
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.4.1
+matheel[all]==0.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
Summary:
- bump package and Gradio app pins to 0.4.2
- pin ordered Colab notebooks to the v0.4.2 release tag
- update README to recommend matheel[all] as the default install

Validation:
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- git diff --check
- python -m build
- python -m twine check

Closes #143