### PR TITLE
Add parser-derived lexical tokenization

### DIFF
--- a/docs/lexical.md
+++ b/docs/lexical.md
@@ -13,7 +13,7 @@ Matheel can blend lexical similarity with semantic and code-aware scores.
 - `gst`
   Greedy String Tiling over token sequences.
 
-Winnowing and GST use Matheel's shared code-token regex after preprocessing. They are deterministic lexical baselines, not parser-derived token streams. See [Tokenization and preprocessing limits](tokenization.md) for details.
+Winnowing and GST use Matheel's shared code-token regex after preprocessing by default. Set `lexical_tokenizer="parser"` or CLI `--lexical-tokenizer parser` to use tree-sitter leaf node types for supported languages. Parser-derived token streams are more structural and less sensitive to identifier renaming.
 
 These are most useful when:
 
@@ -30,6 +30,7 @@ These are most useful when:
 - `winnowing_kgram`
 - `winnowing_window`
 - `gst_min_match_length`
+- `lexical_tokenizer`
 
 ## Canonical Weight Format
 
@@ -88,12 +89,15 @@ python examples/sample_data.py --output sample_pairs.zip --overwrite
 matheel compare sample_pairs.zip \
   --feature-weight winnowing=1.0 \
   --winnowing-kgram 5 \
-  --winnowing-window 4
+  --winnowing-window 4 \
+  --lexical-tokenizer raw
 ```
 
 ```bash
 python examples/sample_data.py --output sample_pairs.zip --overwrite
 matheel compare sample_pairs.zip \
   --feature-weight gst=1.0 \
-  --gst-min-match-length 5
+  --gst-min-match-length 5 \
+  --code-language python \
+  --lexical-tokenizer parser
 ```

--- a/docs/tokenization.md
+++ b/docs/tokenization.md
@@ -10,7 +10,7 @@ For `calculate_similarity(...)` and `get_sim_list(...)`, the main order is:
 2. Apply `preprocess_mode`.
 3. Build embeddings when the semantic feature is active.
 4. Tokenize for lexical baselines and token-based code metrics.
-5. Parse code for parser-backed code metrics when those metrics are active and their optional runtimes are available.
+5. Parse code for parser-derived lexical tokens or parser-backed code metrics when those modes are active and their runtimes are available.
 6. Blend active feature scores with normalized feature weights.
 
 Preprocessing happens before lexical, semantic, and code-aware scoring. If you enable `advanced`, identifiers and literals may already be canonicalized before token-based metrics run.
@@ -34,8 +34,8 @@ Preprocessing is intentionally text-first. It uses language-specific comment and
 | --- | --- |
 | `levenshtein` | Compares the prepared strings directly. |
 | `jaro_winkler` | Compares the prepared strings directly. |
-| `winnowing` | Uses Matheel's code-token regex over the prepared string. |
-| `gst` | Uses the same code-token regex as Winnowing. |
+| `winnowing` | Uses Matheel's code-token regex by default, or tree-sitter leaf node types with `lexical_tokenizer="parser"`. |
+| `gst` | Uses the same lexical tokenizer selection as Winnowing. |
 | `crystalbleu` | Uses the same code-token regex, then builds n-grams and discounts frequent n-grams. |
 | `ruby` with `ruby_mode=ngram` | Uses the same code-token regex. |
 | `ruby` with `ruby_mode=string` and `ruby_tokenizer=regex` | Uses the same code-token regex. |
@@ -47,16 +47,20 @@ Preprocessing is intentionally text-first. It uses language-specific comment and
 
 The shared code-token regex recognizes identifiers, numbers, and punctuation. It does not split snake_case or camelCase by default. For example, `totalCount` stays one token in regex mode; RUBY's `tranx` tokenizer splits it into `total` and `Count`.
 
-## Parser-Token Limitations
+## Parser-Derived Lexical Tokens
 
-Matheel does not currently expose a parser-derived token stream for `winnowing`, `gst`, `crystalbleu`, or RUBY n-gram mode. That means these metrics are deterministic and lightweight, but they are not equivalent to parser-heavy plagiarism tools that normalize code through AST or grammar tokens.
+Set `lexical_tokenizer="parser"` in Python or `--lexical-tokenizer parser` in the CLI to use parser-derived leaf node types for `winnowing` and `gst`. The default is `raw`, preserving the regex token stream used in earlier Matheel releases.
+
+Parser-derived lexical tokens make the lexical baselines less sensitive to identifier renaming. They still compare ordered token streams; they are not full AST or data-flow comparisons.
+
+## Limitations
 
 Important limitations:
 
 - lexical token baselines see surface token order and punctuation
-- parser-backed metrics depend on optional runtime availability
+- parser-derived lexical tokens and parser-backed metrics depend on parser runtime availability
 - unsupported languages fall back only where a metric explicitly supports fallback behavior
 - preprocessing language hints improve comment/import handling, but they do not guarantee full parsing
 - aggressive `advanced` preprocessing can hide identifier and literal differences that some workflows may care about
 
-For parser-heavy comparisons, report the active preprocessing mode, tokenization-sensitive parameters, selected code metric, language, and optional parser availability alongside the score.
+For parser-heavy comparisons, report the active preprocessing mode, `lexical_tokenizer`, tokenization-sensitive parameters, selected code metric, language, and parser availability alongside the score.

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -16,6 +16,7 @@ This Space is aligned with `matheel==0.4.2` and includes:
 - Pair, collection, comparison-suite, and normalized-dataset evaluation workflows
 - Metric presets for balanced, lexical, embedding-only, and code-aware runs
 - Downloadable leaderboard artifacts for dataset evaluation
+- Raw and parser-derived lexical tokenization for Winnowing and GST
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore
 - Per-metric advanced parameters via dedicated UI fields

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -35,6 +35,7 @@ from matheel.resampling import kfold_splits
 from matheel._run_metadata import elapsed_seconds_between, perf_counter
 from matheel.similarity import (
     DEFAULT_MODEL_NAME,
+    available_lexical_tokenizers,
     available_runtime_devices,
     calculate_similarity,
     get_sim_list,
@@ -63,6 +64,7 @@ CHUNK_LANGUAGE_CHOICES = [
 ]
 PREPROCESSING_UI_CHOICES = [mode for mode in available_preprocess_modes() if mode != "none"]
 CHONKIE_UI_METHODS = [method for method in available_chunking_methods() if method != "none"]
+LEXICAL_TOKENIZER_CHOICES = available_lexical_tokenizers()
 DEFAULT_RUBY_MODE = "auto"
 DEFAULT_RUBY_GRAPH_TIMEOUT = 1.0
 DEFAULT_TSED_COSTS = "1,1,1"
@@ -694,6 +696,7 @@ SUITE_COLUMNS = [
     "winnowing_window",
     "gst_weight",
     "gst_min_match_length",
+    "lexical_tokenizer",
     "threshold",
     "number_results",
 ]
@@ -815,6 +818,7 @@ def suite_rows_to_configs(rows):
             "winnowing_kgram": effective_winnowing_kgram,
             "winnowing_window": effective_winnowing_window,
             "gst_min_match_length": effective_gst_min_match_length,
+            "lexical_tokenizer": str(row.get("lexical_tokenizer") or "raw").strip() or "raw",
             "threshold": max(0.0, float(resolve_numeric_value(row.get("threshold"), 0.35))),
             "number_results": max(1, int(float(row.get("number_results") or 50))),
             "feature_weights": feature_weights,
@@ -921,6 +925,7 @@ def build_suite_run_row_data(
     winnowing_kgram,
     winnowing_window,
     gst_min_match_length,
+    lexical_tokenizer,
     code_metric,
     code_metric_weight,
     code_language,
@@ -1056,6 +1061,7 @@ def build_suite_run_row_data(
         "winnowing_window": normalized_winnowing_window,
         "gst_weight": feature_weights.get("gst", 0.0),
         "gst_min_match_length": normalized_gst_min_match_length,
+        "lexical_tokenizer": str(lexical_tokenizer or "raw").strip() or "raw",
         "threshold": max(0.0, float(resolve_numeric_value(threshold, 0.35))),
         "number_results": max(1, int(float(number_results or 50))),
     }
@@ -1081,6 +1087,7 @@ def append_suite_run_gradio(
     winnowing_kgram,
     winnowing_window,
     gst_min_match_length,
+    lexical_tokenizer,
     code_metric,
     code_metric_weight,
     code_language,
@@ -1123,6 +1130,7 @@ def append_suite_run_gradio(
         winnowing_kgram,
         winnowing_window,
         gst_min_match_length,
+        lexical_tokenizer,
         code_metric,
         code_metric_weight,
         code_language,
@@ -1265,6 +1273,7 @@ def run_suite_gradio(
     winnowing_kgram,
     winnowing_window,
     gst_min_match_length,
+    lexical_tokenizer,
     code_metric,
     code_metric_weight,
     code_language,
@@ -1326,6 +1335,7 @@ def run_suite_gradio(
             winnowing_kgram,
             winnowing_window,
             gst_min_match_length,
+            lexical_tokenizer,
             code_metric,
             code_metric_weight,
             code_language,
@@ -1490,6 +1500,7 @@ def dataset_similarity_options(
     runtime_device,
     preprocess_mode,
     code_language,
+    lexical_tokenizer="raw",
 ):
     preset = metric_preset_options(preset_name)
     feature_weights = {
@@ -1510,6 +1521,7 @@ def dataset_similarity_options(
         "device": str(runtime_device or "auto").strip() or "auto",
         "preprocess_mode": str(preprocess_mode or "none").strip() or "none",
         "code_language": str(code_language or "python").strip() or "python",
+        "lexical_tokenizer": str(lexical_tokenizer or "raw").strip() or "raw",
         "code_metric": code_metric,
         "code_metric_weight": preset["code_metric_weight"] if code_metric != "none" else 0.0,
     }
@@ -1681,6 +1693,7 @@ def evaluate_dataset_gradio(
     runtime_device,
     preprocess_mode,
     code_language,
+    lexical_tokenizer,
     threshold,
     retrieval_k,
     resampling_folds,
@@ -1711,6 +1724,7 @@ def evaluate_dataset_gradio(
         runtime_device,
         preprocess_mode,
         code_language,
+        lexical_tokenizer,
     )
     start_time = perf_counter()
     if str(task_label).startswith("Retrieval"):
@@ -1855,6 +1869,7 @@ def calculate_similarity_gradio(
     winnowing_kgram,
     winnowing_window,
     gst_min_match_length,
+    lexical_tokenizer,
     code_metric,
     code_metric_weight,
     code_language,
@@ -1966,6 +1981,7 @@ def calculate_similarity_gradio(
         winnowing_kgram=effective_winnowing_kgram,
         winnowing_window=effective_winnowing_window,
         gst_min_match_length=effective_gst_min_match_length,
+        lexical_tokenizer=lexical_tokenizer,
         vector_backend=vector_backend,
         similarity_function=similarity_function,
         pooling_method=pooling_method,
@@ -2003,6 +2019,7 @@ def get_sim_list_gradio(
     winnowing_kgram,
     winnowing_window,
     gst_min_match_length,
+    lexical_tokenizer,
     code_metric,
     code_metric_weight,
     code_language,
@@ -2116,6 +2133,7 @@ def get_sim_list_gradio(
         winnowing_kgram=effective_winnowing_kgram,
         winnowing_window=effective_winnowing_window,
         gst_min_match_length=effective_gst_min_match_length,
+        lexical_tokenizer=lexical_tokenizer,
         vector_backend=vector_backend,
         similarity_function=similarity_function,
         pooling_method=pooling_method,
@@ -2257,6 +2275,11 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                             pair_gst_min_match_length = gr.Slider(
                                 1, 32, value=5, label="Min Match Length", step=1
                             )
+                        pair_lexical_tokenizer = gr.Dropdown(
+                            choices=list(LEXICAL_TOKENIZER_CHOICES),
+                            value="raw",
+                            label="Lexical Tokenizer",
+                        )
                         with gr.Group(visible=False) as pair_code_group:
                             pair_code_metric = gr.Dropdown(
                                 choices=list(CODE_METRIC_CHOICES),
@@ -2432,6 +2455,7 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     pair_winnowing_kgram,
                     pair_winnowing_window,
                     pair_gst_min_match_length,
+                    pair_lexical_tokenizer,
                     pair_code_metric,
                     pair_code_metric_weight,
                     pair_code_language,
@@ -2597,6 +2621,11 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                             collection_gst_min_match_length = gr.Slider(
                                 1, 32, value=5, label="Min Match Length", step=1
                             )
+                        collection_lexical_tokenizer = gr.Dropdown(
+                            choices=list(LEXICAL_TOKENIZER_CHOICES),
+                            value="raw",
+                            label="Lexical Tokenizer",
+                        )
                         with gr.Group(visible=False) as collection_code_group:
                             collection_code_metric = gr.Dropdown(
                                 choices=list(CODE_METRIC_CHOICES),
@@ -2783,6 +2812,7 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     collection_winnowing_kgram,
                     collection_winnowing_window,
                     collection_gst_min_match_length,
+                    collection_lexical_tokenizer,
                     collection_code_metric,
                     collection_code_metric_weight,
                     collection_code_language,
@@ -2969,6 +2999,11 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                             suite_gst_min_match_length = gr.Slider(
                                 1, 32, value=5, label="Min Match Length", step=1
                             )
+                        suite_lexical_tokenizer = gr.Dropdown(
+                            choices=list(LEXICAL_TOKENIZER_CHOICES),
+                            value="raw",
+                            label="Lexical Tokenizer",
+                        )
                         with gr.Group(visible=False) as suite_code_group:
                             suite_code_metric = gr.Dropdown(
                                 choices=list(CODE_METRIC_CHOICES),
@@ -3184,6 +3219,7 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     suite_winnowing_kgram,
                     suite_winnowing_window,
                     suite_gst_min_match_length,
+                    suite_lexical_tokenizer,
                     suite_code_metric,
                     suite_code_metric_weight,
                     suite_code_language,
@@ -3236,6 +3272,7 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     suite_winnowing_kgram,
                     suite_winnowing_window,
                     suite_gst_min_match_length,
+                    suite_lexical_tokenizer,
                     suite_code_metric,
                     suite_code_metric_weight,
                     suite_code_language,
@@ -3418,6 +3455,11 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                             value="python",
                             label="Code Language",
                         )
+                        dataset_lexical_tokenizer = gr.Dropdown(
+                            choices=list(LEXICAL_TOKENIZER_CHOICES),
+                            value="raw",
+                            label="Lexical Tokenizer",
+                        )
 
                     with gr.Accordion("Evaluation", open=True):
                         with gr.Group(visible=True) as dataset_pair_group:
@@ -3465,6 +3507,7 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     dataset_runtime_device,
                     dataset_preprocess_mode,
                     dataset_code_language,
+                    dataset_lexical_tokenizer,
                     dataset_threshold,
                     dataset_k,
                     dataset_resampling_folds,

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -91,11 +91,14 @@ from .vectors import (
     similarity_function_score_range,
 )
 from .similarity import (
+    available_lexical_tokenizers,
     available_runtime_devices,
     calculate_similarity,
     detect_default_device,
     get_sim_list,
     inspect_model_settings,
+    normalize_lexical_tokenizer,
+    tokenize_for_lexical_matching,
 )
 
 __all__ = [
@@ -108,6 +111,7 @@ __all__ = [
     "available_dataset_presets_by_task",
     "available_dataset_sources",
     "available_dataset_task_types",
+    "available_lexical_tokenizers",
     "available_pooling_methods",
     "available_resampling_methods",
     "available_runtime_devices",
@@ -152,6 +156,7 @@ __all__ = [
     "metric_summary",
     "normalize_algorithm_options",
     "normalize_feature_weights",
+    "normalize_lexical_tokenizer",
     "PairDataset",
     "PairAlgorithm",
     "pair_algorithm_metadata",
@@ -187,4 +192,5 @@ __all__ = [
     "kfold_splits",
     "bootstrap_resamples",
     "build_matheel_pair_algorithm",
+    "tokenize_for_lexical_matching",
 ]

--- a/matheel/_run_metadata.py
+++ b/matheel/_run_metadata.py
@@ -44,10 +44,13 @@ def attach_run_metadata(
     vector_backend,
     code_metric,
     chunking_method,
+    lexical_tokenizer=None,
 ):
     frame.attrs["elapsed_seconds"] = round(float(elapsed_seconds), _METADATA_DECIMALS)
     frame.attrs["feature_set"] = format_feature_set(feature_weights)
     frame.attrs["vector_backend"] = semantic_vector_backend_metadata(feature_weights, vector_backend)
     frame.attrs["code_metric"] = code_metric
     frame.attrs["chunking_method"] = chunking_method
+    if lexical_tokenizer is not None:
+        frame.attrs["lexical_tokenizer"] = lexical_tokenizer
     return frame

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -25,7 +25,12 @@ from .datasets import (
 )
 from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
 from .reproducibility import collect_reproducibility_snapshot, write_reproducibility_snapshot
-from .similarity import DEFAULT_MODEL_NAME, available_runtime_devices, get_sim_list
+from .similarity import (
+    DEFAULT_MODEL_NAME,
+    available_lexical_tokenizers,
+    available_runtime_devices,
+    get_sim_list,
+)
 from .chunking import available_chunk_aggregations, available_chunking_methods
 from .model_routing import available_vector_backends
 from .preprocessing import available_preprocess_modes
@@ -507,6 +512,13 @@ def datasets_adapt(
 @click.option('--winnowing-window', default=4, show_default=True, help='Window size used by Winnowing fingerprint selection.')
 @click.option('--gst-min-match-length', default=5, show_default=True, help='Minimum token tile length used by Greedy String Tiling.')
 @click.option(
+    '--lexical-tokenizer',
+    type=click.Choice(available_lexical_tokenizers()),
+    default='raw',
+    show_default=True,
+    help='Token stream for Winnowing and GST. Use parser for tree-sitter leaf token types.',
+)
+@click.option(
     '--vector-backend',
     type=click.Choice(available_vector_backends()),
     default='auto',
@@ -618,6 +630,7 @@ def compare(
     winnowing_kgram,
     winnowing_window,
     gst_min_match_length,
+    lexical_tokenizer,
     vector_backend,
     similarity_function,
     normalize_semantic_scores,
@@ -704,6 +717,7 @@ def compare(
             winnowing_kgram=winnowing_kgram,
             winnowing_window=winnowing_window,
             gst_min_match_length=gst_min_match_length,
+            lexical_tokenizer=lexical_tokenizer,
             vector_backend=vector_backend,
             similarity_function=similarity_function,
             normalize_semantic_scores=normalize_semantic_scores,
@@ -726,6 +740,7 @@ def compare(
             "feature_weights": feature_weights,
             "preprocess_mode": preprocess_mode,
             "code_language": code_language,
+            "lexical_tokenizer": lexical_tokenizer,
         },
         results,
     )
@@ -844,6 +859,13 @@ def compare_suite(source_path, config_file, summary_out, details_dir, output_for
         "Defaults to levenshtein=1.0 for offline-friendly evaluation."
     ),
 )
+@click.option(
+    "--lexical-tokenizer",
+    type=click.Choice(available_lexical_tokenizers()),
+    default="raw",
+    show_default=True,
+    help="Token stream for Winnowing and GST. Use parser for tree-sitter leaf token types.",
+)
 @click.option("--model", default=DEFAULT_MODEL_NAME, show_default=True, help="Embedding model name.")
 @click.option(
     "--preprocess-mode",
@@ -903,6 +925,7 @@ def evaluate_pairs(
     algorithm_options,
     reproducibility_out,
     feature_weights,
+    lexical_tokenizer,
     model,
     preprocess_mode,
     code_language,
@@ -973,6 +996,7 @@ def evaluate_pairs(
                 "model_name": model,
                 "preprocess_mode": preprocess_mode,
                 "code_language": code_language,
+                "lexical_tokenizer": lexical_tokenizer,
                 "vector_backend": vector_backend,
                 "similarity_function": similarity_function,
                 "normalize_semantic_scores": normalize_semantic_scores,
@@ -999,6 +1023,7 @@ def evaluate_pairs(
             "model_name": model,
             "preprocess_mode": preprocess_mode,
             "code_language": code_language,
+            "lexical_tokenizer": lexical_tokenizer,
         },
         scored_pairs,
     )
@@ -1069,6 +1094,13 @@ def evaluate_pairs(
         "Defaults to levenshtein=1.0 for offline-friendly evaluation."
     ),
 )
+@click.option(
+    "--lexical-tokenizer",
+    type=click.Choice(available_lexical_tokenizers()),
+    default="raw",
+    show_default=True,
+    help="Token stream for Winnowing and GST. Use parser for tree-sitter leaf token types.",
+)
 @click.option("--model", default=DEFAULT_MODEL_NAME, show_default=True, help="Embedding model name.")
 @click.option(
     "--preprocess-mode",
@@ -1128,6 +1160,7 @@ def evaluate_retrieval(
     algorithm_options,
     reproducibility_out,
     feature_weights,
+    lexical_tokenizer,
     model,
     preprocess_mode,
     code_language,
@@ -1198,6 +1231,7 @@ def evaluate_retrieval(
                 "model_name": model,
                 "preprocess_mode": preprocess_mode,
                 "code_language": code_language,
+                "lexical_tokenizer": lexical_tokenizer,
                 "vector_backend": vector_backend,
                 "similarity_function": similarity_function,
                 "normalize_semantic_scores": normalize_semantic_scores,
@@ -1224,6 +1258,7 @@ def evaluate_retrieval(
             "model_name": model,
             "preprocess_mode": preprocess_mode,
             "code_language": code_language,
+            "lexical_tokenizer": lexical_tokenizer,
         },
         scored_results,
     )

--- a/matheel/code_metrics.py
+++ b/matheel/code_metrics.py
@@ -411,6 +411,41 @@ def tokenize_for_code_metrics(text):
     return _TOKEN_RE.findall(text or "")
 
 
+def parser_tokenize_for_code_metrics(text, language):
+    parser = _resolve_tsed_parser(language)
+    if parser is not None and not hasattr(parser, "parse"):
+        normalized_language = normalize_code_language(language)
+        with _TREE_SITTER_PARSER_CACHE_LOCK:
+            if _TREE_SITTER_PARSER_CACHE.get(normalized_language) is parser:
+                _TREE_SITTER_PARSER_CACHE.pop(normalized_language, None)
+        parser = _resolve_tsed_parser(normalized_language)
+    if parser is None:
+        raise ValueError(f"Parser-derived tokenization is unavailable for language: {language}")
+    if not hasattr(parser, "parse"):
+        raise ValueError(f"Parser-derived tokenization is unavailable for language: {language}")
+
+    try:
+        tree = parser.parse(bytes(text or "", encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"Could not parse code for language: {language}") from exc
+
+    tokens = []
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        if getattr(node, "is_missing", False):
+            continue
+        if getattr(node, "child_count", 0):
+            stack.extend(reversed(node.children))
+            continue
+        if node.type in {"comment", "line_comment", "block_comment"}:
+            continue
+        if int(node.start_byte) == int(node.end_byte):
+            continue
+        tokens.append(str(node.type))
+    return tokens
+
+
 def ngram_tuples(tokens, n):
     if n <= 0 or len(tokens) < n:
         return []

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -339,6 +339,7 @@ def _summary_metadata(options, results, elapsed_seconds):
         "vector_backend": vector_backend,
         "code_metric": attrs.get("code_metric") or options.get("code_metric", "none"),
         "chunking_method": attrs.get("chunking_method") or options.get("chunking_method", "none"),
+        "lexical_tokenizer": attrs.get("lexical_tokenizer") or options.get("lexical_tokenizer", "raw"),
         "algorithm_name": algorithm.get("algorithm_name") or "matheel",
         "algorithm_function": algorithm.get("algorithm_function") or "calculate_similarity",
         "algorithm_package_version": algorithm.get("algorithm_package_version") or "",

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -9,6 +9,7 @@ from rapidfuzz.distance import JaroWinkler, Levenshtein
 
 from .code_metrics import (
     parse_component_weights,
+    parser_tokenize_for_code_metrics,
     prepare_codebertscore_context,
     prepare_crystalbleu_context,
     prepare_ruby_context,
@@ -44,6 +45,7 @@ from .vectors import (
 
 DEFAULT_MODEL_NAME = "huggingface/CodeBERTa-small-v1"
 RESULT_COLUMNS = ["file_name_1", "file_name_2", "similarity_score"]
+LEXICAL_TOKENIZERS = ("raw", "parser")
 
 
 def load_torch():
@@ -66,6 +68,28 @@ def available_runtime_devices():
         insert_at = 1 if devices and devices[0] == "cuda" else 0
         devices.insert(insert_at, "mps")
     return tuple(dict.fromkeys(devices))
+
+
+def available_lexical_tokenizers():
+    return LEXICAL_TOKENIZERS
+
+
+def normalize_lexical_tokenizer(lexical_tokenizer):
+    selected = (lexical_tokenizer or "raw").strip().lower().replace("_", "-")
+    aliases = {
+        "code": "raw",
+        "regex": "raw",
+        "code-metrics": "raw",
+        "tree-sitter": "parser",
+        "tree_sitter": "parser",
+        "parser-derived": "parser",
+        "parser_derived": "parser",
+    }
+    selected = aliases.get(selected, selected)
+    if selected not in LEXICAL_TOKENIZERS:
+        supported = ", ".join(LEXICAL_TOKENIZERS)
+        raise ValueError(f"lexical_tokenizer must be one of: {supported}. Got: {lexical_tokenizer}")
+    return selected
 
 
 def detect_default_device():
@@ -406,7 +430,10 @@ def _stable_token_hash(tokens):
     return int.from_bytes(hashlib.blake2b(payload, digest_size=8).digest(), "big")
 
 
-def _tokenize_for_lexical_matching(code):
+def tokenize_for_lexical_matching(code, lexical_tokenizer="raw", code_language=None):
+    selected = normalize_lexical_tokenizer(lexical_tokenizer)
+    if selected == "parser":
+        return parser_tokenize_for_code_metrics(code, code_language)
     return tokenize_for_code_metrics(code)
 
 
@@ -616,6 +643,8 @@ def build_feature_scores(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    lexical_tokenizer="raw",
+    code_language=None,
     active_features=None,
     normalize_semantic_scores=False,
 ):
@@ -628,8 +657,16 @@ def build_feature_scores(
     lexical_tokens1 = None
     lexical_tokens2 = None
     if needs_token_features:
-        lexical_tokens1 = _tokenize_for_lexical_matching(code1)
-        lexical_tokens2 = _tokenize_for_lexical_matching(code2)
+        lexical_tokens1 = tokenize_for_lexical_matching(
+            code1,
+            lexical_tokenizer=lexical_tokenizer,
+            code_language=code_language,
+        )
+        lexical_tokens2 = tokenize_for_lexical_matching(
+            code2,
+            lexical_tokenizer=lexical_tokenizer,
+            code_language=code_language,
+        )
 
     feature_scores = {
         "semantic": (
@@ -702,6 +739,8 @@ def combined_similarity_from_embeddings(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    lexical_tokenizer="raw",
+    code_language=None,
     normalize_semantic_scores=False,
 ):
     validate_semantic_score_scale_options(
@@ -728,6 +767,8 @@ def combined_similarity_from_embeddings(
         winnowing_kgram=winnowing_kgram,
         winnowing_window=winnowing_window,
         gst_min_match_length=gst_min_match_length,
+        lexical_tokenizer=lexical_tokenizer,
+        code_language=code_language,
         active_features=active_features,
         normalize_semantic_scores=normalize_semantic_scores,
     )
@@ -784,6 +825,7 @@ def rank_code_pairs(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    lexical_tokenizer="raw",
     normalize_semantic_scores=False,
     progress=False,
     progress_callback=None,
@@ -865,6 +907,8 @@ def rank_code_pairs(
             winnowing_kgram=winnowing_kgram,
             winnowing_window=winnowing_window,
             gst_min_match_length=gst_min_match_length,
+            lexical_tokenizer=lexical_tokenizer,
+            code_language=code_language,
             normalize_semantic_scores=normalize_semantic_scores,
         )
         results.append((score, i, j))
@@ -933,6 +977,7 @@ def get_sim_list(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    lexical_tokenizer="raw",
     normalize_semantic_scores=False,
     progress=False,
     progress_callback=None,
@@ -951,6 +996,7 @@ def get_sim_list(
         winnowing_window=winnowing_window,
         gst_min_match_length=gst_min_match_length,
     )
+    lexical_tokenizer = normalize_lexical_tokenizer(lexical_tokenizer)
     model_info = None
     resolved_feature_weights = resolve_feature_weights(
         feature_weights=feature_weights,
@@ -1100,6 +1146,7 @@ def get_sim_list(
         winnowing_kgram=winnowing_kgram,
         winnowing_window=winnowing_window,
         gst_min_match_length=gst_min_match_length,
+        lexical_tokenizer=lexical_tokenizer,
         normalize_semantic_scores=normalize_semantic_scores,
         progress=progress,
         progress_callback=progress_callback,
@@ -1124,6 +1171,7 @@ def get_sim_list(
         vector_backend=vector_backend,
         code_metric=(code_metric or "none").strip().lower() or "none",
         chunking_method=(chunking_method or "none").strip().lower() or "none",
+        lexical_tokenizer=lexical_tokenizer,
     )
 
 
@@ -1188,6 +1236,7 @@ def calculate_similarity(
     winnowing_kgram=5,
     winnowing_window=4,
     gst_min_match_length=5,
+    lexical_tokenizer="raw",
     normalize_semantic_scores=False,
     progress=False,
     progress_callback=None,
@@ -1205,6 +1254,7 @@ def calculate_similarity(
         winnowing_window=winnowing_window,
         gst_min_match_length=gst_min_match_length,
     )
+    lexical_tokenizer = normalize_lexical_tokenizer(lexical_tokenizer)
     model_info = None
     resolved_feature_weights = resolve_feature_weights(
         feature_weights=feature_weights,
@@ -1335,6 +1385,8 @@ def calculate_similarity(
             winnowing_kgram=winnowing_kgram,
             winnowing_window=winnowing_window,
             gst_min_match_length=gst_min_match_length,
+            lexical_tokenizer=lexical_tokenizer,
+            code_language=code_language,
             normalize_semantic_scores=normalize_semantic_scores,
         )
     return score

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,6 +130,8 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
             "5",
             "--gst-min-match-length",
             "4",
+            "--lexical-tokenizer",
+            "parser",
             "--static-vector-dim",
             "512",
             "--max-token-length",
@@ -184,6 +186,7 @@ def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     assert captured["kwargs"]["winnowing_kgram"] == 6
     assert captured["kwargs"]["winnowing_window"] == 5
     assert captured["kwargs"]["gst_min_match_length"] == 4
+    assert captured["kwargs"]["lexical_tokenizer"] == "parser"
     assert captured["kwargs"]["static_vector_dim"] == 512
     assert captured["kwargs"]["max_token_length"] == 128
     assert captured["kwargs"]["pooling_method"] == "max"

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -40,6 +40,7 @@ def _build_suite_row(**overrides):
         "winnowing_kgram": 5,
         "winnowing_window": 4,
         "gst_min_match_length": 5,
+        "lexical_tokenizer": "raw",
         "code_metric": "codebleu",
         "code_metric_weight": 0.0,
         "code_language": "java",
@@ -75,6 +76,20 @@ def test_suite_threshold_preserves_zero():
     configs = gradio_app.suite_rows_to_configs([row])
 
     assert configs[0]["options"]["threshold"] == 0.0
+
+
+def test_suite_rows_preserve_lexical_tokenizer():
+    row = _build_suite_row(
+        selected_features=["Winnowing"],
+        levenshtein_weight=0.0,
+        winnowing_weight=1.0,
+        lexical_tokenizer="parser",
+    )
+
+    configs = gradio_app.suite_rows_to_configs([row])
+
+    assert row["lexical_tokenizer"] == "parser"
+    assert configs[0]["options"]["lexical_tokenizer"] == "parser"
 
 
 def test_default_suite_run_name_uses_algorithm_names():
@@ -278,6 +293,7 @@ def test_pair_comparison_requires_both_snippets():
             5,
             4,
             5,
+            "raw",
             "codebleu",
             0.0,
             "python",
@@ -367,6 +383,7 @@ def test_run_suite_export_sanitizes_detail_zip_filenames(monkeypatch):
         5,
         4,
         5,
+        "raw",
         "codebleu",
         0.0,
         "java",
@@ -438,6 +455,7 @@ def test_dataset_pair_evaluation_exports_leaderboard_artifacts(tmp_path):
         "auto",
         "none",
         "python",
+        "raw",
         0.5,
         10,
         2,
@@ -508,6 +526,7 @@ def test_dataset_retrieval_evaluation_exports_leaderboard_artifacts(tmp_path):
         "auto",
         "none",
         "python",
+        "raw",
         0.5,
         1,
         2,

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -23,6 +23,11 @@ def _vectorize(text):
     ]
 
 
+def test_lexical_tokenizer_choices_are_exported():
+    assert similarity.available_lexical_tokenizers() == ("raw", "parser")
+    assert similarity.normalize_lexical_tokenizer("tree-sitter") == "parser"
+
+
 def test_get_sim_list_uses_preprocessed_code(tmp_path, monkeypatch):
     pytest.importorskip("chonkie")
     monkeypatch.setattr(
@@ -330,6 +335,89 @@ def test_winnowing_kgram_controls_order_sensitivity():
         kgram_size=2,
         window_size=1,
     ) == pytest.approx(0.0)
+
+
+def test_parser_derived_lexical_tokenizer_uses_syntax_token_types():
+    pytest.importorskip("tree_sitter_language_pack")
+
+    tokens = similarity.tokenize_for_lexical_matching(
+        "def add(a, b):\n    return a + b\n",
+        lexical_tokenizer="parser",
+        code_language="python",
+    )
+
+    assert tokens == [
+        "def",
+        "identifier",
+        "(",
+        "identifier",
+        ",",
+        "identifier",
+        ")",
+        ":",
+        "return",
+        "identifier",
+        "+",
+        "identifier",
+    ]
+
+
+def test_parser_derived_winnowing_is_less_sensitive_to_identifier_renaming():
+    pytest.importorskip("tree_sitter_language_pack")
+
+    left = "def add(a, b):\n    total = a + b\n    return total\n"
+    renamed = "def add(x, y):\n    answer = x + y\n    return answer\n"
+    raw_score = similarity.calculate_similarity(
+        left,
+        renamed,
+        feature_weights={"winnowing": 1.0},
+        winnowing_kgram=2,
+        winnowing_window=1,
+        lexical_tokenizer="raw",
+        code_language="python",
+        vector_backend="static_hash",
+    )
+    parser_score = similarity.calculate_similarity(
+        left,
+        renamed,
+        feature_weights={"winnowing": 1.0},
+        winnowing_kgram=2,
+        winnowing_window=1,
+        lexical_tokenizer="parser",
+        code_language="python",
+        vector_backend="static_hash",
+    )
+
+    assert raw_score < 1.0
+    assert parser_score == pytest.approx(1.0)
+
+
+def test_parser_derived_gst_is_less_sensitive_to_identifier_renaming():
+    pytest.importorskip("tree_sitter_language_pack")
+
+    left = "def add(a, b):\n    total = a + b\n    return total\n"
+    renamed = "def add(x, y):\n    answer = x + y\n    return answer\n"
+    raw_score = similarity.calculate_similarity(
+        left,
+        renamed,
+        feature_weights={"gst": 1.0},
+        gst_min_match_length=2,
+        lexical_tokenizer="raw",
+        code_language="python",
+        vector_backend="static_hash",
+    )
+    parser_score = similarity.calculate_similarity(
+        left,
+        renamed,
+        feature_weights={"gst": 1.0},
+        gst_min_match_length=2,
+        lexical_tokenizer="parser",
+        code_language="python",
+        vector_backend="static_hash",
+    )
+
+    assert raw_score < 1.0
+    assert parser_score == pytest.approx(1.0)
 
 
 def test_gst_similarity_has_reference_token_accounting():


### PR DESCRIPTION
## Summary
- add an explicit raw/parser lexical tokenizer option for Winnowing and GST
- use tree-sitter leaf node types for parser-derived lexical tokens while keeping raw tokenization as the default
- wire the option through Python APIs, CLI evaluation commands, comparison-suite metadata, and Gradio controls
- document tokenization behavior and parser-mode limitations

## Validation
- .venv/bin/python -m pytest
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- git diff --check

Closes #58