### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/examples/notebooks/01_core_workflows.ipynb
+++ b/examples/notebooks/01_core_workflows.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.4.2\"\n",
+    "MATHEEL_REF = \"v0.5.0\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/02_datasets_and_reproducibility.ipynb
+++ b/examples/notebooks/02_datasets_and_reproducibility.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.4.2\"\n",
+    "MATHEEL_REF = \"v0.5.0\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/03_custom_algorithms.ipynb
+++ b/examples/notebooks/03_custom_algorithms.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.4.2\"\n",
+    "MATHEEL_REF = \"v0.5.0\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/04_gradio_app.ipynb
+++ b/examples/notebooks/04_gradio_app.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%%bash\n",
     "set -euo pipefail\n",
-    "MATHEEL_REF=\"v0.4.2\"\n",
+    "MATHEEL_REF=\"v0.5.0\"\n",
     "pip uninstall -y torchvision || true\n",
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.4.2` and includes:
+This Space is aligned with `matheel==0.5.0` and includes:
 
 - Pair, collection, comparison-suite, and normalized-dataset evaluation workflows
 - Metric presets for balanced, lexical, embedding-only, and code-aware runs

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.4.2
+matheel[all]==0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.4.2"
+version = "0.5.0"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
## Summary
- Bump package version and Gradio Space pin to 0.5.0
- Update Colab notebook refs to v0.5.0

## Validation
- .venv/bin/python -m pytest (424 passed, 4 skipped, 3 deselected)
- .venv/bin/python -m ruff check .
- .venv/bin/python -m mkdocs build --strict
- git diff --check
- .venv/bin/python scripts/sync_gradio_app_version.py --check
- .venv/bin/python -m build --outdir <temp-dist>
- .venv/bin/python -m twine check <temp-dist>/*

Closes #126