### PR TITLE
Fix reproducibility and packaging bugs

### DIFF
--- a/matheel/datasets.py
+++ b/matheel/datasets.py
@@ -2537,6 +2537,16 @@ def _safe_extract_archive(archive_path, output_dir):
     raise ValueError(f"Unsupported archive format: {archive.name}")
 
 
+def _extract_downloaded_archives(destination):
+    root = _coerce_path(destination)
+    for archive_path in sorted(path for path in root.iterdir() if path.is_file()):
+        if not (zipfile.is_zipfile(archive_path) or tarfile.is_tarfile(archive_path)):
+            continue
+        _safe_extract_archive(archive_path, root)
+        archive_path.unlink(missing_ok=True)
+    return root
+
+
 def _single_child_directory_or_self(path):
     root = _coerce_path(path)
     children = [child for child in root.iterdir() if child.is_dir()]
@@ -2666,16 +2676,15 @@ def _resolve_kaggle_dataset_source(identifier, destination, revision="main", tok
                 str(identifier),
                 "-p",
                 os.fspath(destination),
-                "--unzip",
             ],
             check=True,
         )
-        return destination
+        return _extract_downloaded_archives(destination)
 
     api = KaggleApi()
     api.authenticate()
-    api.dataset_download_files(str(identifier), path=os.fspath(destination), unzip=True)
-    return destination
+    api.dataset_download_files(str(identifier), path=os.fspath(destination), unzip=False)
+    return _extract_downloaded_archives(destination)
 
 
 def register_default_dataset_sources(overwrite=False):

--- a/matheel/resampling.py
+++ b/matheel/resampling.py
@@ -403,6 +403,8 @@ def _folds_from_labels_or_groups(count, groups=None, labels=None, n_splits=5, sh
     generator = _rng(seed)
     if groups is not None:
         unique_groups = np.unique(groups)
+        if n_splits > len(unique_groups):
+            raise ValueError("n_splits must not exceed the number of unique groups.")
         if shuffle:
             generator.shuffle(unique_groups)
         group_sizes = {group: int(np.sum(groups == group)) for group in unique_groups}
@@ -415,8 +417,12 @@ def _folds_from_labels_or_groups(count, groups=None, labels=None, n_splits=5, sh
         return [np.where(np.isin(groups, fold_groups[index]))[0] for index in range(n_splits)]
 
     if labels is not None:
+        unique_labels, label_counts = np.unique(labels, return_counts=True)
+        smallest_label_count = int(np.min(label_counts)) if label_counts.size else 0
+        if n_splits > smallest_label_count:
+            raise ValueError("n_splits must not exceed the smallest label count.")
         folds = [[] for _ in range(n_splits)]
-        for label in np.unique(labels):
+        for label in unique_labels:
             label_indices = np.where(labels == label)[0]
             if shuffle:
                 generator.shuffle(label_indices)

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -21,6 +21,7 @@ from .feature_weights import combine_weighted_scores, resolve_feature_weights
 from .model_routing import (
     backend_is_multivector,
     load_hf_model_info,
+    normalize_vector_backend_name,
     resolve_vector_backend,
 )
 from ._progress import emit_progress, progress_iter
@@ -46,6 +47,23 @@ from .vectors import (
 DEFAULT_MODEL_NAME = "huggingface/CodeBERTa-small-v1"
 RESULT_COLUMNS = ["file_name_1", "file_name_2", "similarity_score"]
 LEXICAL_TOKENIZERS = ("raw", "parser")
+
+
+def _semantic_backend_dependency_error(vector_backend, exc):
+    backend = normalize_vector_backend_name(vector_backend)
+    if backend == "auto":
+        backend = "sentence_transformers"
+    package_by_backend = {
+        "sentence_transformers": "sentence-transformers",
+        "model2vec": "model2vec",
+        "pylate": "pylate",
+    }
+    package_name = package_by_backend.get(backend, backend)
+    return ImportError(
+        f"Semantic scoring with vector_backend='{backend}' requires the optional "
+        f"'{package_name}' dependency. Install `matheel[semantic]` or `matheel[all]`, "
+        "or disable semantic scoring with lexical-only feature weights."
+    )
 
 
 def load_torch():
@@ -152,18 +170,8 @@ def load_backend_model(
             pooling_method=selected_pooling,
             max_token_length=max_token_length,
         )
-    except ImportError:
-        if vector_backend == "model2vec":
-            return None
-        if vector_backend == "pylate":
-            return load_model(
-                model_name or DEFAULT_MODEL_NAME,
-                device=normalized_device,
-                similarity_function=selected_similarity,
-                pooling_method=selected_pooling,
-                max_token_length=max_token_length,
-            )
-        raise
+    except ImportError as exc:
+        raise _semantic_backend_dependency_error(vector_backend, exc) from exc
 
 
 def inspect_model_settings(
@@ -583,12 +591,16 @@ def build_document_embeddings(
     if not codes:
         return []
 
-    if vector_backend == "static_hash":
+    backend = normalize_vector_backend_name(vector_backend)
+    if backend == "static_hash":
         return build_static_hash_vectors(codes, dim=static_vector_dim, lowercase=static_vector_lowercase)
-    if vector_backend == "model2vec" and model is None:
-        return build_static_hash_vectors(codes, dim=static_vector_dim, lowercase=static_vector_lowercase)
+    if backend == "model2vec" and model is None:
+        raise ValueError(
+            "vector_backend='model2vec' requires a loaded Model2Vec model. "
+            "Use vector_backend='static_hash' for dependency-free static hashing."
+        )
 
-    if backend_is_multivector(vector_backend):
+    if backend_is_multivector(backend):
         return build_multivector_embeddings(
             model,
             codes,
@@ -600,14 +612,14 @@ def build_document_embeddings(
             chunker_options=chunker_options,
         )
 
-    if vector_backend == "sentence_transformers" and model is not None:
+    if backend == "sentence_transformers" and model is not None:
         model = configure_sentence_transformer_pooling(model, pooling_method=pooling_method)
 
     if not _should_use_chunking(chunking_method):
         return encode_single_vectors(
             model,
             codes,
-            vector_backend=vector_backend,
+            vector_backend=backend,
             static_vector_dim=static_vector_dim,
             static_vector_lowercase=static_vector_lowercase,
         )

--- a/matheel/vectors.py
+++ b/matheel/vectors.py
@@ -400,30 +400,26 @@ def _load_model2vec_model(model_name, max_token_length=None):
 def _load_pylate_model(model_name, device="auto", max_token_length=None):
     try:
         from pylate import models as pylate_models
-    except ImportError:
-        pylate_models = None
+    except ImportError as exc:
+        raise ImportError("PyLate backend requires the optional 'pylate' package.") from exc
 
-    if pylate_models is not None:
-        for attr_name in ("ColBERT", "SentenceTransformer", "LateInteractionModel"):
-            model_class = getattr(pylate_models, attr_name, None)
-            if model_class is None:
-                continue
-            if hasattr(model_class, "from_pretrained"):
-                try:
-                    model = model_class.from_pretrained(model_name, device=device)
-                except TypeError:
-                    model = model_class.from_pretrained(model_name)
-                return configure_model_max_token_length(model, max_token_length=max_token_length)
+    for attr_name in ("ColBERT", "SentenceTransformer", "LateInteractionModel"):
+        model_class = getattr(pylate_models, attr_name, None)
+        if model_class is None:
+            continue
+        if hasattr(model_class, "from_pretrained"):
             try:
-                model = model_class(model_name, device=device)
+                model = model_class.from_pretrained(model_name, device=device)
             except TypeError:
-                model = model_class(model_name)
+                model = model_class.from_pretrained(model_name)
             return configure_model_max_token_length(model, max_token_length=max_token_length)
+        try:
+            model = model_class(model_name, device=device)
+        except TypeError:
+            model = model_class(model_name)
+        return configure_model_max_token_length(model, max_token_length=max_token_length)
 
-    from sentence_transformers import SentenceTransformer
-
-    model = SentenceTransformer(model_name, device=device)
-    return configure_model_max_token_length(model, max_token_length=max_token_length)
+    raise ValueError("Installed PyLate package does not provide a supported model class.")
 
 
 def load_vector_model(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,5 +1,7 @@
 import json
+import sys
 import zipfile
+from types import ModuleType
 
 import pandas as pd
 import pytest
@@ -31,6 +33,7 @@ from matheel.datasets import (
     resolve_dataset_source,
     write_retrieval_dataset,
     write_pair_dataset,
+    _resolve_kaggle_dataset_source,
     _safe_extract_archive,
 )
 
@@ -119,6 +122,74 @@ def test_safe_archive_extraction_rejects_path_traversal(tmp_path):
         _safe_extract_archive(archive_path, tmp_path / "out")
 
     assert not (tmp_path / "escape.txt").exists()
+
+
+def test_kaggle_api_resolver_downloads_then_safe_extracts(tmp_path, monkeypatch):
+    captured = {}
+
+    class FakeKaggleApi:
+        def authenticate(self):
+            captured["authenticated"] = True
+
+        def dataset_download_files(self, identifier, path, unzip=False):
+            captured["identifier"] = identifier
+            captured["path"] = path
+            captured["unzip"] = unzip
+            with zipfile.ZipFile(tmp_path / "kaggle" / "download.zip", "w") as archive:
+                archive.writestr("rows.csv", "value\n1\n")
+
+    kaggle_module = ModuleType("kaggle")
+    kaggle_api_module = ModuleType("kaggle.api")
+    kaggle_extended_module = ModuleType("kaggle.api.kaggle_api_extended")
+    kaggle_extended_module.KaggleApi = FakeKaggleApi
+    monkeypatch.setitem(sys.modules, "kaggle", kaggle_module)
+    monkeypatch.setitem(sys.modules, "kaggle.api", kaggle_api_module)
+    monkeypatch.setitem(sys.modules, "kaggle.api.kaggle_api_extended", kaggle_extended_module)
+
+    destination = tmp_path / "kaggle"
+    resolved = _resolve_kaggle_dataset_source("owner/dataset", destination)
+
+    assert resolved == destination.resolve()
+    assert captured == {
+        "authenticated": True,
+        "identifier": "owner/dataset",
+        "path": str(destination.resolve()),
+        "unzip": False,
+    }
+    assert (destination / "rows.csv").read_text(encoding="utf-8") == "value\n1\n"
+    assert not (destination / "download.zip").exists()
+
+
+def test_kaggle_cli_resolver_downloads_then_safe_extracts(tmp_path, monkeypatch):
+    captured = {}
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "kaggle.api.kaggle_api_extended":
+            raise ImportError("blocked kaggle api")
+        return real_import(name, *args, **kwargs)
+
+    def fake_run(command, check):
+        captured["command"] = command
+        captured["check"] = check
+        output_path = command[command.index("-p") + 1]
+        with zipfile.ZipFile(tmp_path / "kaggle_cli" / "download.zip", "w") as archive:
+            archive.writestr("rows.csv", "value\n1\n")
+        assert output_path == str((tmp_path / "kaggle_cli").resolve())
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    monkeypatch.setattr("matheel.datasets.shutil.which", lambda name: "kaggle" if name == "kaggle" else None)
+    monkeypatch.setattr("matheel.datasets.subprocess.run", fake_run)
+
+    destination = tmp_path / "kaggle_cli"
+    resolved = _resolve_kaggle_dataset_source("owner/dataset", destination)
+
+    assert resolved == destination.resolve()
+    assert "--unzip" not in captured["command"]
+    assert captured["check"] is True
+    assert (destination / "rows.csv").read_text(encoding="utf-8") == "value\n1\n"
+    assert not (destination / "download.zip").exists()
 
 
 def test_custom_source_and_preset_load_pair_dataset(tmp_path):

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -55,6 +55,16 @@ def test_kfold_splits_can_stratify_labels():
         assert sorted(split_labels) == [0, 1]
 
 
+def test_kfold_splits_rejects_label_folds_that_would_be_empty():
+    with pytest.raises(ValueError, match="smallest label count"):
+        kfold_splits(2, n_splits=2, labels=[1, 0])
+
+
+def test_kfold_splits_rejects_group_folds_that_would_be_empty():
+    with pytest.raises(ValueError, match="unique groups"):
+        kfold_splits(4, n_splits=3, groups=["a", "a", "b", "b"])
+
+
 def test_repeated_kfold_splits_marks_method_and_count():
     splits = repeated_kfold_splits(20, n_splits=4, n_repeats=2, seed=42)
 

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -691,23 +691,43 @@ def test_calculate_similarity_guards_raw_distance_scores_in_weighted_blends():
     assert score == pytest.approx(1.0)
 
 
-def test_calculate_similarity_falls_back_when_model2vec_is_unavailable(monkeypatch):
-    monkeypatch.setattr(
-        similarity,
-        "load_backend_model",
-        lambda model_name, vector_backend="auto", device="auto", similarity_function="cosine", pooling_method="mean", max_token_length=None: None,
-    )
+def test_calculate_similarity_reports_missing_semantic_dependency(monkeypatch):
+    def missing_model(*args, **kwargs):
+        _ = (args, kwargs)
+        raise ImportError("No module named 'sentence_transformers'")
 
-    score = similarity.calculate_similarity(
-        "def add(a, b):\n    return a + b\n",
-        "def add(b, a):\n    return b + a\n",
-        model_name="Jarbas/m2v-256-paraphrase-multilingual-MiniLM-L12-v2",
-        feature_weights={"semantic": 1.0},
-        vector_backend="model2vec",
-        static_vector_dim=64,
-    )
+    monkeypatch.setattr(similarity, "load_vector_model", missing_model)
 
-    assert score == pytest.approx(1.0)
+    with pytest.raises(ImportError, match=r"matheel\[semantic\]"):
+        similarity.calculate_similarity(
+            "def add(a, b):\n    return a + b\n",
+            "def add(b, a):\n    return b + a\n",
+            feature_weights={"semantic": 1.0},
+            vector_backend="sentence_transformers",
+        )
+
+
+def test_model2vec_backend_does_not_fall_back_to_static_hash(monkeypatch):
+    def missing_model(*args, **kwargs):
+        _ = (args, kwargs)
+        raise ImportError("No module named 'model2vec'")
+
+    monkeypatch.setattr(similarity, "load_vector_model", missing_model)
+
+    with pytest.raises(ImportError, match="model2vec"):
+        similarity.calculate_similarity(
+            "def add(a, b):\n    return a + b\n",
+            "def add(b, a):\n    return b + a\n",
+            model_name="Jarbas/m2v-256-paraphrase-multilingual-MiniLM-L12-v2",
+            feature_weights={"semantic": 1.0},
+            vector_backend="model2vec",
+            static_vector_dim=64,
+        )
+
+
+def test_model2vec_embeddings_require_loaded_model():
+    with pytest.raises(ValueError, match="static_hash"):
+        similarity.build_document_embeddings(None, ["print(1)"], vector_backend="model2vec")
 
 
 def test_calculate_similarity_supports_multivector_backend(monkeypatch):

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -195,3 +195,17 @@ def test_configure_model_max_token_length_updates_pylate_style_lengths():
     assert model.document_length == 96
     assert model.query_length == 32
     assert model.max_seq_length == 96
+
+
+def test_load_vector_model_requires_pylate_package(monkeypatch):
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pylate" or name.startswith("pylate."):
+            raise ImportError("blocked pylate import")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(ImportError, match="pylate"):
+        vectors_module.load_vector_model("demo/model", vector_backend="pylate")


### PR DESCRIPTION
## Summary
- report missing semantic backend dependencies with an explicit extras message instead of silently falling back
- require requested Model2Vec and PyLate backends to actually load their backend models
- validate stratified and grouped k-fold inputs before empty folds are emitted
- route Kaggle archive downloads through Matheel safe extraction for both API and CLI paths

Closes #148

## Tests
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- git diff --check