### PR TITLE
Polish version reporting and resampling validation

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -482,6 +482,8 @@ folds = kfold_splits(100, n_splits=5, seed=7)
 bootstraps = bootstrap_resamples(100, n_rounds=100, seed=7)
 ```
 
+For stratified k-fold splits, `n_splits` must not exceed the smallest label count. For grouped k-fold splits, `n_splits` must not exceed the number of unique groups. This keeps every fold valid and prevents empty test folds.
+
 For pair-classification results, splits are applied to scored pair rows:
 
 ```python

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -1666,6 +1666,7 @@ def _write_leaderboard_artifacts(
 def _resample_pair_scores(scored, folds, seed, threshold):
     if not folds:
         return pd.DataFrame(), pd.DataFrame()
+    _validate_pair_resampling_folds(scored, int(folds))
     splits = kfold_splits(
         len(scored),
         n_splits=int(folds),
@@ -1680,8 +1681,29 @@ def _resample_retrieval_scores(scored, dataset, folds, seed, k):
     if not folds:
         return pd.DataFrame(), pd.DataFrame()
     query_ids = tuple(sorted(scored["query_id"].astype(str).unique().tolist()))
+    _validate_retrieval_resampling_folds(query_ids, int(folds))
     splits = kfold_splits(query_ids, n_splits=int(folds), shuffle=True, seed=int(seed))
     return evaluate_retrieval_resamples(scored, splits, qrels=dataset.qrels, k=k)
+
+
+def _validate_resampling_fold_count(item_count, folds, item_label):
+    if folds < 2:
+        raise gr.Error("K-fold resampling needs at least 2 folds, or set folds to 0 to turn it off.")
+    if folds > item_count:
+        raise gr.Error(f"K-fold resampling folds must not exceed the number of {item_label}.")
+
+
+def _validate_pair_resampling_folds(scored, folds):
+    _validate_resampling_fold_count(len(scored), folds, "scored pair rows")
+    if "label" not in scored:
+        return
+    label_counts = scored["label"].value_counts()
+    if not label_counts.empty and folds > int(label_counts.min()):
+        raise gr.Error("K-fold resampling folds must not exceed the smallest label count.")
+
+
+def _validate_retrieval_resampling_folds(query_ids, folds):
+    _validate_resampling_fold_count(len(query_ids), folds, "queries")
 
 
 def evaluate_dataset_gradio(

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -1,3 +1,10 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("matheel")
+except PackageNotFoundError:  # pragma: no cover - source tree without install metadata
+    __version__ = "0+unknown"
+
 from .algorithms import (
     PairAlgorithm,
     attach_algorithm_metadata,
@@ -102,6 +109,7 @@ from .similarity import (
 )
 
 __all__ = [
+    "__version__",
     "available_code_metrics",
     "available_code_metric_languages",
     "available_default_features",

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import click
 
+from . import __version__
 from .algorithms import normalize_algorithm_options, score_source_pairs_with_algorithm
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
@@ -40,6 +41,7 @@ from .vectors import (
 )
 
 @click.group()
+@click.version_option(version=__version__, prog_name="matheel")
 def main():
     """Matheel CLI - Compute Code Similarity"""
     pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+from importlib.metadata import version
 from pathlib import Path
 import subprocess
 import sys
@@ -8,9 +9,19 @@ from zipfile import ZipFile
 from click.testing import CliRunner
 import pandas as pd
 
+import matheel
 import matheel.datasets as datasets_module
 from matheel.cli import main
 from matheel.datasets import register_dataset_preset, write_pair_dataset, write_retrieval_dataset
+
+
+def test_cli_and_package_expose_version():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+
+    assert result.exit_code == 0
+    assert version("matheel") in result.output
+    assert matheel.__version__ == version("matheel")
 
 
 def test_compare_command_accepts_new_options(tmp_path, monkeypatch):

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -483,6 +483,20 @@ def test_dataset_pair_evaluation_exports_leaderboard_artifacts(tmp_path):
     assert manifest["dataset_kind"] == "pair_classification"
 
 
+def test_dataset_pair_resampling_reports_invalid_label_folds():
+    scored = pd.DataFrame(
+        {
+            "left_id": ["a", "b"],
+            "right_id": ["c", "d"],
+            "label": [0, 1],
+            "similarity_score": [0.1, 0.9],
+        }
+    )
+
+    with pytest.raises(gradio_app.gr.Error, match="smallest label count"):
+        gradio_app._resample_pair_scores(scored, folds=2, seed=7, threshold=0.5)
+
+
 def test_dataset_retrieval_evaluation_exports_leaderboard_artifacts(tmp_path):
     dataset_root = tmp_path / "retrieval_dataset"
     write_retrieval_dataset(
@@ -548,3 +562,29 @@ def test_dataset_retrieval_evaluation_exports_leaderboard_artifacts(tmp_path):
         assert "retrieval_resampling_summary.csv" in names
         manifest = json.loads(archive.read("leaderboard_manifest.json").decode("utf-8"))
     assert manifest["dataset_kind"] == "retrieval"
+
+
+def test_dataset_retrieval_resampling_reports_invalid_query_folds(tmp_path):
+    dataset = write_retrieval_dataset(
+        tmp_path / "retrieval_dataset",
+        files=pd.DataFrame(
+            [
+                {"file_id": "q1_file", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "d1_file", "text": "print(1)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "q1_file"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "d1_file"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    )
+    scored = pd.DataFrame(
+        {
+            "query_id": ["q1"],
+            "document_id": ["d1"],
+            "similarity_score": [1.0],
+            "relevance": [1.0],
+        }
+    )
+
+    with pytest.raises(gradio_app.gr.Error, match="number of queries"):
+        gradio_app._resample_retrieval_scores(scored, dataset, folds=2, seed=7, k=1)


### PR DESCRIPTION
## Summary
- expose package version through matheel.__version__ and matheel --version
- add friendly Gradio errors for invalid dataset k-fold resampling settings
- document stratified/grouped k-fold constraints

Closes #150

## Tests
- python -m pytest tests/test_cli.py tests/test_gradio_app.py tests/test_resampling.py
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- git diff --check