### PR TITLE
Add dataset embedding map visualizations

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,6 +18,7 @@ The base package includes the CLI, preprocessing, lexical similarity, and the co
 pip install "matheel[semantic]"
 pip install "matheel[chunking]"
 pip install "matheel[metrics]"
+pip install "matheel[visualization]"
 pip install "matheel[gradio]"
 pip install "matheel[all]"
 ```
@@ -27,6 +28,7 @@ pip install "matheel[all]"
 | `matheel[semantic]` | Sentence Transformers, Model2Vec, and PyLate semantic scoring backends. |
 | `matheel[chunking]` | Chonkie chunkers for splitting code before embedding. |
 | `matheel[metrics]` | Optional code metric runtimes such as TSED and CodeBERTScore. |
+| `matheel[visualization]` | UMAP projection for dataset visualization. |
 | `matheel[gradio]` | Dependencies for running the Gradio web app. |
 | `matheel[all]` | All supported optional backends in one install. |
 

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,0 +1,51 @@
+# Visualization
+
+Matheel can export dataset-level embedding maps for normalized pair and retrieval datasets. The first visualization path uses dependency-free static hash embeddings by default, then projects documents to two dimensions with UMAP when `umap-learn` is installed. If UMAP is unavailable and `method=auto`, Matheel uses deterministic PCA.
+
+Install the optional UMAP backend when you want UMAP projections:
+
+```bash
+pip install "matheel[visualization]"
+```
+
+## CLI
+
+Generate CSV, JSON, and HTML artifacts:
+
+```bash
+matheel visualize-dataset ./normalized_pairs \
+  --kind pair \
+  --method auto \
+  --seed 7 \
+  --output-dir visualization_artifacts
+```
+
+The output directory contains:
+
+- `dataset_map.csv`: projected coordinates and document metadata.
+- `dataset_map.json`: machine-readable points plus projection metadata.
+- `dataset_map.html`: static scatter plot for local inspection or report bundles.
+
+Use `--method pca` for dependency-free deterministic projections, or `--method umap` to require UMAP explicitly.
+
+## Python
+
+```python
+from matheel.visualization import build_dataset_embedding_map, write_dataset_map_artifacts
+
+projection = build_dataset_embedding_map(
+    "./normalized_pairs",
+    kind="pair",
+    method="pca",
+    seed=7,
+)
+
+artifacts = write_dataset_map_artifacts(
+    projection,
+    "visualization_artifacts",
+)
+
+print(artifacts["html"])
+```
+
+Projection metadata is stored in `projection.attrs`, including the requested method, actual method, seed, dataset kind, dataset name, and embedding source.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Examples are grouped by workflow:
 
 - `basic/`: preprocessing, chunking, lexical scoring, vectors, code metrics, and archive ranking.
-- `evaluation/`: dataset adapters, comparison suites, and reproducible benchmark outputs.
+- `evaluation/`: dataset adapters, comparison suites, visualization, and reproducible benchmark outputs.
 - `custom/`: custom `score_pair` algorithm modules.
 - `notebooks/`: ordered Colab notebooks.
 - `sample_data.py`: deterministic generator for the tiny Java sample archive used by examples and docs.

--- a/examples/evaluation/visualization_demo.py
+++ b/examples/evaluation/visualization_demo.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory, gettempdir
+
+import pandas as pd
+
+# Configure Matplotlib before importing Matheel's evaluation stack.
+_MPLCONFIGDIR = Path(gettempdir()) / "matheel_matplotlib"
+_MPLCONFIGDIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", os.fspath(_MPLCONFIGDIR))
+
+from matheel.datasets import write_pair_dataset  # noqa: E402
+from matheel.visualization import write_dataset_embedding_map  # noqa: E402
+
+
+def main():
+    with TemporaryDirectory() as tmp:
+        workspace = Path(tmp)
+        dataset_root = workspace / "normalized_pairs"
+        write_pair_dataset(
+            dataset_root,
+            files=pd.DataFrame(
+                [
+                    {"file_id": "a", "text": "def add(a, b):\n    return a + b\n", "suffix": ".py"},
+                    {"file_id": "b", "text": "def add(x, y):\n    return x + y\n", "suffix": ".py"},
+                    {"file_id": "c", "text": "def subtract(a, b):\n    return a - b\n", "suffix": ".py"},
+                ]
+            ),
+            pairs=pd.DataFrame(
+                [
+                    {"left_id": "a", "right_id": "b", "label": 1},
+                    {"left_id": "a", "right_id": "c", "label": 0},
+                ]
+            ),
+            metadata={"name": "tiny_visualization_pairs"},
+        )
+
+        projection, artifacts = write_dataset_embedding_map(
+            dataset_root,
+            workspace / "visualization_artifacts",
+            kind="pair",
+            method="pca",
+        )
+
+        print(projection[["document_id", "x", "y", "role"]].to_string(index=False))
+        print("HTML artifact:", artifacts["html"])
+
+
+if __name__ == "__main__":
+    main()

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -97,6 +97,16 @@ from .vectors import (
     available_similarity_functions,
     similarity_function_score_range,
 )
+from .visualization import (
+    available_projection_methods,
+    build_dataset_embedding_map,
+    build_embedding_projection,
+    dataset_map_html,
+    dataset_map_payload,
+    project_embeddings,
+    write_dataset_embedding_map,
+    write_dataset_map_artifacts,
+)
 from .similarity import (
     available_lexical_tokenizers,
     available_runtime_devices,
@@ -121,6 +131,7 @@ __all__ = [
     "available_dataset_task_types",
     "available_lexical_tokenizers",
     "available_pooling_methods",
+    "available_projection_methods",
     "available_resampling_methods",
     "available_runtime_devices",
     "available_similarity_functions",
@@ -200,5 +211,12 @@ __all__ = [
     "kfold_splits",
     "bootstrap_resamples",
     "build_matheel_pair_algorithm",
+    "build_dataset_embedding_map",
+    "build_embedding_projection",
+    "dataset_map_html",
+    "dataset_map_payload",
     "tokenize_for_lexical_matching",
+    "project_embeddings",
+    "write_dataset_embedding_map",
+    "write_dataset_map_artifacts",
 ]

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -39,6 +39,7 @@ from .vectors import (
     available_pooling_methods,
     available_similarity_functions,
 )
+from .visualization import available_projection_methods, write_dataset_embedding_map
 
 @click.group()
 @click.version_option(version=__version__, prog_name="matheel")
@@ -270,6 +271,18 @@ def _echo_dataset_summary(summary, output_format):
         click.echo(f"task_type={task_type}")
 
 
+def _echo_visualization_summary(summary, output_format):
+    if output_format == "json":
+        _echo_json(summary)
+        return
+    click.echo(f"dataset_name={summary['dataset_name']}")
+    click.echo(f"dataset_kind={summary['dataset_kind']}")
+    click.echo(f"projection_method={summary['projection_method']}")
+    click.echo(f"documents={summary['documents']}")
+    for name, path in summary["artifacts"].items():
+        click.echo(f"{name}={path}")
+
+
 @main.group(name="datasets")
 def datasets_cli():
     """Inspect, validate, and adapt Matheel datasets."""
@@ -392,6 +405,59 @@ def datasets_adapt(
         summary = _retrieval_dataset_summary(load_retrieval_dataset(adapted_root))
     summary["adapter"] = adapter_name
     _echo_dataset_summary(summary, output_format)
+
+
+@main.command(name="visualize-dataset")
+@click.argument("dataset_path", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+@click.option(
+    "--kind",
+    type=click.Choice(("auto", "pair", "retrieval")),
+    default="auto",
+    show_default=True,
+    help="Normalized dataset kind. Auto detects pair or retrieval manifests.",
+)
+@click.option(
+    "--method",
+    type=click.Choice(available_projection_methods()),
+    default="auto",
+    show_default=True,
+    help="Projection method. Auto uses UMAP when installed, otherwise deterministic PCA.",
+)
+@click.option("--seed", default=7, show_default=True, help="Projection seed for stochastic reducers.")
+@click.option("--static-vector-dim", default=256, show_default=True, help="Static hash embedding dimension.")
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=True,
+    help="Directory where dataset map artifacts will be written.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def visualize_dataset(dataset_path, kind, method, seed, static_vector_dim, output_dir, output_format):
+    """Write dataset-level embedding map artifacts for a normalized dataset."""
+    projection, artifacts = write_dataset_embedding_map(
+        dataset_path,
+        output_dir,
+        kind=kind,
+        method=method,
+        seed=seed,
+        static_vector_dim=static_vector_dim,
+    )
+    summary = {
+        "dataset_name": projection.attrs.get("dataset_name"),
+        "dataset_kind": projection.attrs.get("dataset_kind"),
+        "projection_method": projection.attrs.get("projection_method"),
+        "requested_projection_method": projection.attrs.get("requested_projection_method"),
+        "embedding_source": projection.attrs.get("embedding_source"),
+        "documents": int(len(projection)),
+        "artifacts": {name: str(path) for name, path in artifacts.items()},
+    }
+    _echo_visualization_summary(summary, output_format)
 
 
 @main.command()

--- a/matheel/visualization.py
+++ b/matheel/visualization.py
@@ -1,0 +1,386 @@
+import html
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from .datasets import PairDataset, RetrievalDataset, load_code_texts, load_pair_dataset, load_retrieval_dataset
+from .vectors import build_static_hash_vectors
+
+
+_PROJECTION_METHODS = ("auto", "umap", "pca")
+_PALETTE = (
+    "#2563eb",
+    "#dc2626",
+    "#16a34a",
+    "#ca8a04",
+    "#9333ea",
+    "#0891b2",
+    "#db2777",
+    "#4b5563",
+)
+
+
+def available_projection_methods():
+    return _PROJECTION_METHODS
+
+
+def project_embeddings(embeddings, method="auto", seed=7):
+    array = _coerce_embedding_matrix(embeddings)
+    selected = _normalize_projection_method(method)
+    if array.shape[0] == 0:
+        raise ValueError("embeddings must contain at least one vector.")
+
+    actual_method = selected
+    if selected == "auto":
+        try:
+            coordinates = _project_umap(array, seed=seed)
+            actual_method = "umap"
+        except ImportError:
+            coordinates = _project_pca(array)
+            actual_method = "pca"
+    elif selected == "umap":
+        coordinates = _project_umap(array, seed=seed)
+    else:
+        coordinates = _project_pca(array)
+
+    frame = pd.DataFrame(coordinates, columns=["x", "y"])
+    frame.attrs["projection_method"] = actual_method
+    frame.attrs["requested_projection_method"] = selected
+    frame.attrs["seed"] = int(seed)
+    frame.attrs["embedding_count"] = int(array.shape[0])
+    frame.attrs["embedding_dim"] = int(array.shape[1])
+    return frame
+
+
+def build_embedding_projection(embeddings, ids=None, metadata=None, method="auto", seed=7):
+    array = _coerce_embedding_matrix(embeddings)
+    document_ids = _document_ids_for_embeddings(array, ids)
+    projection = project_embeddings(array, method=method, seed=seed)
+    projection.insert(0, "document_id", document_ids)
+    attrs = dict(projection.attrs)
+    if metadata is not None:
+        metadata_frame = pd.DataFrame(metadata).copy()
+        if "document_id" not in metadata_frame.columns:
+            raise ValueError("metadata must include a document_id column.")
+        metadata_frame["document_id"] = metadata_frame["document_id"].astype(str)
+        projection = projection.merge(metadata_frame, on="document_id", how="left")
+        projection.attrs.update(attrs)
+    return projection
+
+
+def build_dataset_embedding_map(dataset, kind="auto", method="auto", seed=7, static_vector_dim=256):
+    loaded, dataset_kind = _load_visualization_dataset(dataset, kind=kind)
+    texts = load_code_texts(loaded)
+    document_ids = tuple(sorted(texts))
+    vectors = build_static_hash_vectors(
+        [texts[document_id] for document_id in document_ids],
+        dim=int(static_vector_dim),
+        lowercase=True,
+    )
+    metadata = _dataset_document_metadata(loaded, dataset_kind, document_ids)
+    projection = build_embedding_projection(
+        vectors,
+        ids=document_ids,
+        metadata=metadata,
+        method=method,
+        seed=seed,
+    )
+    projection.attrs["dataset_kind"] = dataset_kind
+    projection.attrs["dataset_name"] = str(loaded.metadata.get("name") or loaded.root.name)
+    projection.attrs["embedding_source"] = "static_hash"
+    projection.attrs["static_vector_dim"] = int(static_vector_dim)
+    return projection
+
+
+def dataset_map_payload(projection):
+    frame = projection.copy() if isinstance(projection, pd.DataFrame) else pd.DataFrame(projection)
+    required = {"document_id", "x", "y"}
+    missing = sorted(required.difference(frame.columns))
+    if missing:
+        raise ValueError(f"projection is missing required columns: {', '.join(missing)}")
+    return {
+        "schema_version": 1,
+        "metadata": _json_safe_dict(getattr(frame, "attrs", {})),
+        "points": [_json_safe_dict(row) for row in frame.to_dict(orient="records")],
+    }
+
+
+def dataset_map_html(projection, title="Matheel Dataset Map", color_column=None):
+    frame = projection.copy() if isinstance(projection, pd.DataFrame) else pd.DataFrame(projection)
+    if frame.empty:
+        raise ValueError("projection must contain at least one point.")
+    color_column = color_column or _default_color_column(frame)
+    points = _svg_points(frame, color_column=color_column)
+    legend = _legend_html(points)
+    rows = "\n".join(_point_table_row(point) for point in points)
+    escaped_title = html.escape(str(title))
+    svg_body = "\n".join(_svg_circle(point) for point in points)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{escaped_title}</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 24px; color: #111827; }}
+    h1 {{ font-size: 1.5rem; margin: 0 0 16px; }}
+    .layout {{ display: grid; grid-template-columns: minmax(360px, 2fr) minmax(260px, 1fr); gap: 20px; align-items: start; }}
+    svg {{ width: 100%; height: auto; border: 1px solid #d1d5db; background: #f9fafb; }}
+    table {{ border-collapse: collapse; width: 100%; font-size: 0.9rem; }}
+    th, td {{ border-bottom: 1px solid #e5e7eb; padding: 6px 8px; text-align: left; }}
+    th {{ background: #f3f4f6; }}
+    .legend {{ display: flex; gap: 12px; flex-wrap: wrap; margin: 0 0 12px; font-size: 0.9rem; }}
+    .swatch {{ display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }}
+  </style>
+</head>
+<body>
+  <h1>{escaped_title}</h1>
+  <div class="legend">{legend}</div>
+  <div class="layout">
+    <svg viewBox="0 0 960 620" role="img" aria-label="{escaped_title}">
+      <rect x="48" y="32" width="864" height="520" fill="#ffffff" stroke="#e5e7eb"/>
+      {svg_body}
+    </svg>
+    <table>
+      <thead><tr><th>Document</th><th>{html.escape(str(color_column or "Group"))}</th><th>x</th><th>y</th></tr></thead>
+      <tbody>
+{rows}
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>
+"""
+
+
+def write_dataset_map_artifacts(projection, output_dir, basename="dataset_map", title=None, color_column=None):
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    frame = projection.copy() if isinstance(projection, pd.DataFrame) else pd.DataFrame(projection)
+    csv_path = target / f"{basename}.csv"
+    json_path = target / f"{basename}.json"
+    html_path = target / f"{basename}.html"
+    frame.to_csv(csv_path, index=False)
+    json_path.write_text(json.dumps(dataset_map_payload(frame), indent=2, sort_keys=True), encoding="utf-8")
+    html_title = title or str(frame.attrs.get("dataset_name") or "Matheel Dataset Map")
+    html_path.write_text(dataset_map_html(frame, title=html_title, color_column=color_column), encoding="utf-8")
+    return {"csv": csv_path, "json": json_path, "html": html_path}
+
+
+def write_dataset_embedding_map(dataset, output_dir, kind="auto", method="auto", seed=7, static_vector_dim=256):
+    projection = build_dataset_embedding_map(
+        dataset,
+        kind=kind,
+        method=method,
+        seed=seed,
+        static_vector_dim=static_vector_dim,
+    )
+    artifacts = write_dataset_map_artifacts(
+        projection,
+        output_dir,
+        title=str(projection.attrs.get("dataset_name") or "Matheel Dataset Map"),
+        color_column="role" if "role" in projection.columns else None,
+    )
+    return projection, artifacts
+
+
+def _normalize_projection_method(method):
+    selected = str(method or "auto").strip().lower().replace("-", "_")
+    if selected not in _PROJECTION_METHODS:
+        supported = ", ".join(_PROJECTION_METHODS)
+        raise ValueError(f"Projection method must be one of: {supported}. Got: {method}")
+    return selected
+
+
+def _coerce_embedding_matrix(embeddings):
+    if isinstance(embeddings, pd.DataFrame):
+        array = embeddings.to_numpy(dtype=float)
+    else:
+        array = np.asarray(list(embeddings), dtype=float)
+    if array.ndim == 1:
+        array = array.reshape(1, -1)
+    if array.ndim != 2:
+        raise ValueError("embeddings must be a 2D matrix.")
+    if array.shape[1] == 0:
+        raise ValueError("embeddings must contain at least one dimension.")
+    if not np.all(np.isfinite(array)):
+        raise ValueError("embeddings must contain only finite values.")
+    return array
+
+
+def _document_ids_for_embeddings(array, ids):
+    if ids is None:
+        return [f"doc_{index + 1}" for index in range(array.shape[0])]
+    document_ids = [str(value) for value in ids]
+    if len(document_ids) != array.shape[0]:
+        raise ValueError("ids must have the same length as embeddings.")
+    return document_ids
+
+
+def _project_pca(array):
+    if array.shape[0] == 1:
+        return np.zeros((1, 2), dtype=float)
+    centered = array - array.mean(axis=0, keepdims=True)
+    _, _, vt = np.linalg.svd(centered, full_matrices=False)
+    components = vt[:2].T
+    coordinates = centered @ components
+    if coordinates.shape[1] == 1:
+        coordinates = np.column_stack([coordinates[:, 0], np.zeros(array.shape[0], dtype=float)])
+    return coordinates[:, :2]
+
+
+def _project_umap(array, seed=7):
+    if array.shape[0] < 3:
+        return _project_pca(array)
+    try:
+        import umap
+    except ImportError as exc:
+        raise ImportError(
+            "UMAP projection requires the optional 'umap-learn' dependency. "
+            "Install `matheel[visualization]` or use method='pca'."
+        ) from exc
+    n_neighbors = min(15, max(2, array.shape[0] - 1))
+    reducer = umap.UMAP(n_components=2, n_neighbors=n_neighbors, random_state=int(seed))
+    return np.asarray(reducer.fit_transform(array), dtype=float)
+
+
+def _load_visualization_dataset(dataset, kind="auto"):
+    if isinstance(dataset, PairDataset):
+        return dataset, "pair_classification"
+    if isinstance(dataset, RetrievalDataset):
+        return dataset, "retrieval"
+    path = Path(dataset)
+    selected = str(kind or "auto").strip().lower()
+    if selected in ("pair", "pair_classification"):
+        return load_pair_dataset(path), "pair_classification"
+    if selected == "retrieval":
+        return load_retrieval_dataset(path), "retrieval"
+    if (path / "pairs.csv").exists():
+        return load_pair_dataset(path), "pair_classification"
+    if (path / "queries.csv").exists() and (path / "corpus.csv").exists():
+        return load_retrieval_dataset(path), "retrieval"
+    raise ValueError("Could not detect dataset kind. Use kind='pair' or kind='retrieval'.")
+
+
+def _dataset_document_metadata(dataset, dataset_kind, document_ids):
+    files = dataset.files.copy()
+    files["document_id"] = files["file_id"].astype(str)
+    selected = files[files["document_id"].isin(document_ids)].copy()
+    if dataset_kind == "retrieval":
+        selected["role"] = selected["document_id"].map(_retrieval_file_roles(dataset))
+        selected["role"] = selected["role"].fillna("other")
+    else:
+        selected["role"] = "submission"
+        pair_counts = _pair_file_counts(dataset)
+        selected["pair_count"] = selected["document_id"].map(pair_counts).fillna(0).astype(int)
+    metadata_columns = [column for column in ("document_id", "file_path", "role", "pair_count") if column in selected.columns]
+    return selected[metadata_columns].to_dict(orient="records")
+
+
+def _pair_file_counts(dataset):
+    counts = {}
+    for row in dataset.pairs.to_dict(orient="records"):
+        for key in ("left_id", "right_id"):
+            file_id = str(row[key])
+            counts[file_id] = counts.get(file_id, 0) + 1
+    return counts
+
+
+def _retrieval_file_roles(dataset):
+    roles = {}
+    for row in dataset.queries.to_dict(orient="records"):
+        roles.setdefault(str(row["file_id"]), set()).add("query")
+    for row in dataset.corpus.to_dict(orient="records"):
+        roles.setdefault(str(row["file_id"]), set()).add("document")
+    return {
+        file_id: "both" if len(role_set) > 1 else next(iter(role_set))
+        for file_id, role_set in roles.items()
+    }
+
+
+def _default_color_column(frame):
+    for column in ("role", "label", "dataset", "split", "cluster", "algorithm"):
+        if column in frame.columns:
+            return column
+    return None
+
+
+def _svg_points(frame, color_column=None):
+    x_values = frame["x"].astype(float).to_numpy()
+    y_values = frame["y"].astype(float).to_numpy()
+    groups = _color_groups(frame, color_column)
+    colors = {group: _PALETTE[index % len(_PALETTE)] for index, group in enumerate(sorted(set(groups)))}
+    points = []
+    for index, row in enumerate(frame.to_dict(orient="records")):
+        group = groups[index]
+        points.append(
+            {
+                **row,
+                "_screen_x": _scale_value(float(row["x"]), x_values, 72, 888),
+                "_screen_y": _scale_value(float(row["y"]), y_values, 528, 56),
+                "_group": group,
+                "_color": colors[group],
+            }
+        )
+    return points
+
+
+def _color_groups(frame, color_column):
+    if color_column is None or color_column not in frame.columns:
+        return ["documents"] * len(frame)
+    return [str(value) if pd.notna(value) else "unknown" for value in frame[color_column].tolist()]
+
+
+def _scale_value(value, values, output_min, output_max):
+    minimum = float(np.min(values))
+    maximum = float(np.max(values))
+    if np.isclose(minimum, maximum):
+        return (output_min + output_max) / 2.0
+    ratio = (value - minimum) / (maximum - minimum)
+    return output_min + ratio * (output_max - output_min)
+
+
+def _svg_circle(point):
+    document_id = html.escape(str(point["document_id"]))
+    group = html.escape(str(point["_group"]))
+    return (
+        f'<circle cx="{point["_screen_x"]:.2f}" cy="{point["_screen_y"]:.2f}" r="7" '
+        f'fill="{point["_color"]}" stroke="#111827" stroke-width="1">'
+        f"<title>{document_id} ({group})</title></circle>"
+    )
+
+
+def _legend_html(points):
+    seen = {}
+    for point in points:
+        seen.setdefault(point["_group"], point["_color"])
+    return " ".join(
+        f'<span><span class="swatch" style="background:{color}"></span>{html.escape(str(group))}</span>'
+        for group, color in sorted(seen.items())
+    )
+
+
+def _point_table_row(point):
+    document_id = html.escape(str(point["document_id"]))
+    group = html.escape(str(point["_group"]))
+    return (
+        f"<tr><td>{document_id}</td><td>{group}</td>"
+        f"<td>{float(point['x']):.4f}</td><td>{float(point['y']):.4f}</td></tr>"
+    )
+
+
+def _json_safe_dict(values):
+    payload = {}
+    for key, value in dict(values).items():
+        if key.startswith("_"):
+            continue
+        if isinstance(value, (np.integer,)):
+            payload[str(key)] = int(value)
+        elif isinstance(value, (np.floating,)):
+            payload[str(key)] = float(value)
+        elif pd.isna(value):
+            payload[str(key)] = None
+        else:
+            payload[str(key)] = value
+    return payload

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Evaluation:
       - Scoring and calibration: scoring.md
       - Datasets and evaluation: datasets.md
+      - Visualization: visualization.md
       - Reproducible benchmark demo: reproducible_benchmark.md
       - Custom algorithms: customization.md
       - Comparison suite: comparison_suite.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ gradio = [
     "gradio>=5,<6",
     "gradio-huggingfacehub-search>=0.0.8,<0.1"
 ]
+visualization = [
+    "umap-learn>=0.5,<0.6"
+]
 all = [
     "chonkie[code]>=1.5,<1.7",
     "apted>=1.0,<2",
@@ -86,6 +89,7 @@ all = [
     "sentencepiece>=0.2,<0.3",
     "model2vec>=0.7,<0.9",
     "pylate>=1.4,<1.5",
+    "umap-learn>=0.5,<0.6",
     # gradio-huggingfacehub-search 0.0.x requires Gradio <6.
     "gradio>=5,<6",
     "gradio-huggingfacehub-search>=0.0.8,<0.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,42 @@ def test_cli_and_package_expose_version():
     assert matheel.__version__ == version("matheel")
 
 
+def test_visualize_dataset_command_writes_artifacts(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 0}]),
+        metadata={"name": "tiny_pairs"},
+    )
+    output_dir = tmp_path / "viz"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "visualize-dataset",
+            str(dataset_root),
+            "--kind",
+            "pair",
+            "--method",
+            "pca",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "projection_method=pca" in result.output
+    assert (output_dir / "dataset_map.csv").exists()
+    assert (output_dir / "dataset_map.json").exists()
+    assert (output_dir / "dataset_map.html").exists()
+
+
 def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     archive_path = tmp_path / "codes.zip"
     archive_path.write_bytes(b"placeholder")

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,152 @@
+import json
+
+import pandas as pd
+import pytest
+
+import matheel
+from matheel.datasets import write_pair_dataset, write_retrieval_dataset
+from matheel.visualization import (
+    available_projection_methods,
+    build_dataset_embedding_map,
+    build_embedding_projection,
+    dataset_map_html,
+    dataset_map_payload,
+    project_embeddings,
+    write_dataset_embedding_map,
+    write_dataset_map_artifacts,
+)
+
+
+def test_visualization_helpers_are_exported_from_package_root():
+    assert matheel.available_projection_methods is available_projection_methods
+    assert matheel.project_embeddings is project_embeddings
+    assert matheel.build_dataset_embedding_map is build_dataset_embedding_map
+    assert matheel.write_dataset_embedding_map is write_dataset_embedding_map
+
+
+def test_project_embeddings_pca_is_deterministic():
+    embeddings = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+
+    first = project_embeddings(embeddings, method="pca", seed=7)
+    second = project_embeddings(embeddings, method="pca", seed=99)
+
+    pd.testing.assert_frame_equal(first, second)
+    assert first.attrs["projection_method"] == "pca"
+    assert first.attrs["requested_projection_method"] == "pca"
+    assert first.attrs["embedding_count"] == 3
+    assert first.shape == (3, 2)
+
+
+def test_project_embeddings_rejects_invalid_values():
+    with pytest.raises(ValueError, match="finite"):
+        project_embeddings([[1.0], [float("nan")]], method="pca")
+
+    with pytest.raises(ValueError, match="same length"):
+        build_embedding_projection([[1.0], [2.0]], ids=["a"], method="pca")
+
+
+def test_build_embedding_projection_merges_metadata():
+    projection = build_embedding_projection(
+        [[1.0, 0.0], [0.0, 1.0]],
+        ids=["a", "b"],
+        metadata=[{"document_id": "a", "role": "query"}, {"document_id": "b", "role": "document"}],
+        method="pca",
+    )
+
+    assert projection["document_id"].tolist() == ["a", "b"]
+    assert projection["role"].tolist() == ["query", "document"]
+
+
+def test_dataset_embedding_map_writes_pair_artifacts(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "def add(a, b): return a + b", "suffix": ".py"},
+                {"file_id": "b", "text": "def add(x, y): return x + y", "suffix": ".py"},
+                {"file_id": "c", "text": "def sub(a, b): return a - b", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame(
+            [
+                {"left_id": "a", "right_id": "b", "label": 1},
+                {"left_id": "a", "right_id": "c", "label": 0},
+            ]
+        ),
+        metadata={"name": "tiny_pairs"},
+    )
+
+    projection, artifacts = write_dataset_embedding_map(
+        dataset_root,
+        tmp_path / "viz",
+        kind="pair",
+        method="pca",
+        seed=7,
+        static_vector_dim=32,
+    )
+
+    assert projection.attrs["dataset_name"] == "tiny_pairs"
+    assert projection.attrs["dataset_kind"] == "pair_classification"
+    assert projection.attrs["embedding_source"] == "static_hash"
+    assert projection["document_id"].tolist() == ["a", "b", "c"]
+    assert set(artifacts) == {"csv", "json", "html"}
+    assert artifacts["csv"].exists()
+    assert artifacts["json"].exists()
+    assert artifacts["html"].exists()
+    payload = json.loads(artifacts["json"].read_text(encoding="utf-8"))
+    assert payload["metadata"]["projection_method"] == "pca"
+    assert [point["document_id"] for point in payload["points"]] == ["a", "b", "c"]
+    assert "tiny_pairs" in artifacts["html"].read_text(encoding="utf-8")
+
+
+def test_dataset_embedding_map_marks_retrieval_roles(tmp_path):
+    dataset_root = tmp_path / "retrieval"
+    write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "q_file", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "d_file", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "q_file"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "d_file"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+        metadata={"name": "tiny_retrieval"},
+    )
+
+    projection = build_dataset_embedding_map(dataset_root, kind="retrieval", method="pca")
+
+    assert projection.attrs["dataset_kind"] == "retrieval"
+    assert projection.set_index("document_id").loc["q_file", "role"] == "query"
+    assert projection.set_index("document_id").loc["d_file", "role"] == "document"
+
+
+def test_dataset_map_html_escapes_document_ids():
+    projection = build_embedding_projection(
+        [[1.0, 0.0]],
+        ids=["<script>"],
+        metadata=[{"document_id": "<script>", "role": "submission"}],
+        method="pca",
+    )
+
+    output = dataset_map_html(projection, title="<unsafe>")
+
+    assert "<unsafe>" not in output
+    assert "&lt;unsafe&gt;" in output
+    assert "<script>" not in output
+    assert "&lt;script&gt;" in output
+
+
+def test_dataset_map_artifact_payload_requires_coordinates():
+    with pytest.raises(ValueError, match="required columns"):
+        dataset_map_payload(pd.DataFrame([{"document_id": "a"}]))
+
+
+def test_write_dataset_map_artifacts_accepts_projection(tmp_path):
+    projection = build_embedding_projection([[1.0, 0.0]], ids=["a"], method="pca")
+    artifacts = write_dataset_map_artifacts(projection, tmp_path / "artifacts")
+
+    assert artifacts["csv"].name == "dataset_map.csv"
+    assert json.loads(artifacts["json"].read_text(encoding="utf-8"))["points"][0]["document_id"] == "a"


### PR DESCRIPTION
## Summary
- add `matheel.visualization` APIs for embedding projection and dataset map artifacts
- add optional UMAP support with deterministic PCA fallback
- add `matheel visualize-dataset` to export CSV, JSON, and static HTML maps for normalized datasets
- document the visualization workflow and add an example script

Closes #160
Refs #151

## Tests
- python -m pytest tests/test_visualization.py tests/test_cli.py
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- git diff --check
- python examples/evaluation/visualization_demo.py