### PR TITLE
Add calibration report artifacts

### DIFF
--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -86,6 +86,45 @@ report = calibrate_threshold(
 
 Use `evaluate_threshold(...)` when you already have a threshold and want confusion counts, precision, recall, F1, and accuracy.
 
+## Calibration Reports
+
+For scored pair CSVs, export a threshold sweep, ROC curve, precision-recall curve, and summary JSON:
+
+```bash
+matheel calibration-report scored_pairs.csv \
+  --score-column similarity_score \
+  --label-column label \
+  --output-dir calibration_artifacts
+```
+
+The output includes:
+
+- `calibration_threshold_sweep.csv`: threshold, confusion counts, precision, recall, F1, and accuracy.
+- `calibration_roc.csv`: threshold rows with false-positive and true-positive rates.
+- `calibration_precision_recall.csv`: threshold rows with precision and recall.
+- `calibration_summary.json`: AUROC, average precision, and the optimized threshold.
+- `calibration_report.json`: all curve rows plus the summary in one JSON artifact.
+
+The ROC and precision-recall reports require at least one positive and one negative label. Single-class labeled samples fail clearly because AUROC and average precision are not meaningful there.
+
+```python
+from matheel.calibration import calibration_report
+
+report = calibration_report(
+    [
+        {"similarity_score": 0.95, "label": 1},
+        {"similarity_score": 0.82, "label": 1},
+        {"similarity_score": 0.30, "label": 0},
+        {"similarity_score": 0.10, "label": 0},
+    ],
+    score_key="similarity_score",
+    label_key="label",
+)
+
+print(report["summary"]["auroc"])
+print(report["summary"]["optimized_threshold"]["threshold"])
+```
+
 ## Comparing Runs
 
 When comparing algorithms or configurations:

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Examples are grouped by workflow:
 
 - `basic/`: preprocessing, chunking, lexical scoring, vectors, code metrics, and archive ranking.
-- `evaluation/`: dataset adapters, comparison suites, dataset maps, pair explanations, and reproducible benchmark outputs.
+- `evaluation/`: dataset adapters, comparison suites, calibration reports, dataset maps, pair explanations, and reproducible benchmark outputs.
 - `custom/`: custom `score_pair` algorithm modules.
 - `notebooks/`: ordered Colab notebooks.
 - `sample_data.py`: deterministic generator for the tiny Java sample archive used by examples and docs.

--- a/examples/evaluation/calibration_report_demo.py
+++ b/examples/evaluation/calibration_report_demo.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory, gettempdir
+
+import pandas as pd
+
+# Configure Matplotlib before importing Matheel's evaluation stack.
+_MPLCONFIGDIR = Path(gettempdir()) / "matheel_matplotlib"
+_MPLCONFIGDIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", os.fspath(_MPLCONFIGDIR))
+
+from matheel.calibration import write_calibration_report_artifacts  # noqa: E402
+
+
+def main():
+    scored_pairs = pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.95, "label": 1},
+            {"left_id": "c", "right_id": "d", "similarity_score": 0.82, "label": 1},
+            {"left_id": "e", "right_id": "f", "similarity_score": 0.30, "label": 0},
+            {"left_id": "g", "right_id": "h", "similarity_score": 0.10, "label": 0},
+        ]
+    )
+
+    with TemporaryDirectory() as tmp:
+        output_dir = Path(tmp) / "calibration_artifacts"
+        report, artifacts = write_calibration_report_artifacts(
+            scored_pairs,
+            output_dir,
+            score_key="similarity_score",
+            label_key="label",
+        )
+
+        print("AUROC:", round(report["summary"]["auroc"], 4))
+        print("Average precision:", round(report["summary"]["average_precision"], 4))
+        print("Best threshold:", report["summary"]["optimized_threshold"]["threshold"])
+        print("Summary artifact:", artifacts["summary_json"])
+
+
+if __name__ == "__main__":
+    main()

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -20,8 +20,14 @@ from .chunking import chunk_text, chunker_parameter_names
 from .calibration import (
     calibrate_threshold,
     calibration_curve,
+    calibration_report,
+    calibration_report_payload,
     evaluate_threshold,
     feature_score_range,
+    precision_recall_curve,
+    roc_curve,
+    threshold_sweep,
+    write_calibration_report_artifacts,
 )
 from .comparison_suite import load_run_configs, parse_run_configs, run_comparison_suite
 from .code_metrics import (
@@ -148,6 +154,8 @@ __all__ = [
     "attach_algorithm_metadata",
     "calibrate_threshold",
     "calibration_curve",
+    "calibration_report",
+    "calibration_report_payload",
     "calculate_similarity",
     "chunk_text",
     "chunker_parameter_names",
@@ -228,10 +236,14 @@ __all__ = [
     "dataset_map_payload",
     "pair_explanation_html",
     "pair_explanation_payload",
+    "precision_recall_curve",
     "tokenize_for_lexical_matching",
     "project_embeddings",
+    "roc_curve",
+    "threshold_sweep",
     "write_dataset_embedding_map",
     "write_dataset_map_artifacts",
+    "write_calibration_report_artifacts",
     "write_pair_dataset_explanation",
     "write_pair_explanation",
     "write_pair_explanation_artifacts",

--- a/matheel/calibration.py
+++ b/matheel/calibration.py
@@ -1,4 +1,8 @@
+import json
 import math
+from pathlib import Path
+
+import pandas as pd
 
 from .feature_weights import available_default_features
 from .vectors import similarity_function_score_range
@@ -39,6 +43,10 @@ def _coerce_score_label_pairs(
         if len(score_values) != len(label_values):
             raise ValueError("scores and labels must have the same length.")
         pairs = zip(score_values, label_values)
+    elif isinstance(scores, pd.DataFrame):
+        if score_key not in scores.columns or label_key not in scores.columns:
+            raise ValueError(f"scored rows must contain {score_key!r} and {label_key!r}.")
+        pairs = ((row[score_key], row[label_key]) for row in scores.to_dict(orient="records"))
     else:
         pairs = []
         for item in scores:
@@ -57,6 +65,19 @@ def _coerce_score_label_pairs(
     return parsed
 
 
+def _class_counts(pairs):
+    positive_count = sum(1 for _, label in pairs if label)
+    negative_count = len(pairs) - positive_count
+    return positive_count, negative_count
+
+
+def _require_two_classes(pairs):
+    positive_count, negative_count = _class_counts(pairs)
+    if positive_count == 0 or negative_count == 0:
+        raise ValueError("ROC and precision-recall reports require at least one positive and one negative label.")
+    return positive_count, negative_count
+
+
 def _threshold_candidates(scores):
     unique_scores = sorted(set(float(score) for score in scores))
     if len(unique_scores) == 1:
@@ -71,6 +92,39 @@ def _threshold_candidates(scores):
         (left + right) / 2.0 for left, right in zip(unique_scores, unique_scores[1:])
     )
     return tuple(sorted(set(candidates)))
+
+
+def _ordered_curve_thresholds(scores, greater_is_match=True):
+    unique_scores = sorted(set(float(score) for score in scores))
+    if len(unique_scores) == 1:
+        margin = max(abs(unique_scores[0]) * 1e-12, 1e-12)
+    else:
+        margin = max((unique_scores[-1] - unique_scores[0]) * 1e-12, 1e-12)
+    lower = unique_scores[0] - margin
+    upper = unique_scores[-1] + margin
+    if greater_is_match:
+        return tuple([upper, *reversed(unique_scores), lower])
+    return tuple([lower, *unique_scores, upper])
+
+
+def _trapezoid_auc(x_values, y_values):
+    points = sorted((float(x), float(y)) for x, y in zip(x_values, y_values))
+    area = 0.0
+    for (x1, y1), (x2, y2) in zip(points, points[1:]):
+        area += (x2 - x1) * (y1 + y2) / 2.0
+    return area
+
+
+def _average_precision_from_rows(rows):
+    previous_recall = 0.0
+    average_precision = 0.0
+    for row in rows:
+        recall = float(row["recall"])
+        precision = float(row["precision"])
+        delta = max(0.0, recall - previous_recall)
+        average_precision += delta * precision
+        previous_recall = max(previous_recall, recall)
+    return average_precision
 
 
 def feature_score_range(
@@ -173,6 +227,125 @@ def calibration_curve(
     ]
 
 
+def threshold_sweep(
+    scores,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+):
+    rows = calibration_curve(
+        scores,
+        labels=labels,
+        thresholds=thresholds,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+        greater_is_match=greater_is_match,
+    )
+    frame = pd.DataFrame(rows)
+    frame.attrs["curve_type"] = "threshold_sweep"
+    frame.attrs["score_key"] = score_key
+    frame.attrs["label_key"] = label_key
+    frame.attrs["greater_is_match"] = bool(greater_is_match)
+    return frame
+
+
+def roc_curve(
+    scores,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+):
+    pairs = _coerce_score_label_pairs(
+        scores,
+        labels=labels,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+    )
+    positive_count, negative_count = _require_two_classes(pairs)
+    selected_thresholds = thresholds
+    if selected_thresholds is None:
+        selected_thresholds = _ordered_curve_thresholds(
+            [score for score, _ in pairs],
+            greater_is_match=greater_is_match,
+        )
+
+    rows = []
+    for threshold in selected_thresholds:
+        row = evaluate_threshold(
+            pairs,
+            threshold=threshold,
+            positive_label=True,
+            greater_is_match=greater_is_match,
+        )
+        row["true_positive_rate"] = row["recall"]
+        row["false_positive_rate"] = row["false_positive"] / float(negative_count)
+        row["positive_count"] = positive_count
+        row["negative_count"] = negative_count
+        rows.append(row)
+
+    frame = pd.DataFrame(rows)
+    frame.attrs["curve_type"] = "roc"
+    frame.attrs["auroc"] = _trapezoid_auc(frame["false_positive_rate"], frame["true_positive_rate"])
+    frame.attrs["score_key"] = score_key
+    frame.attrs["label_key"] = label_key
+    frame.attrs["greater_is_match"] = bool(greater_is_match)
+    return frame
+
+
+def precision_recall_curve(
+    scores,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+):
+    pairs = _coerce_score_label_pairs(
+        scores,
+        labels=labels,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+    )
+    positive_count, negative_count = _require_two_classes(pairs)
+    selected_thresholds = thresholds
+    if selected_thresholds is None:
+        selected_thresholds = _ordered_curve_thresholds(
+            [score for score, _ in pairs],
+            greater_is_match=greater_is_match,
+        )
+
+    rows = []
+    for threshold in selected_thresholds:
+        row = evaluate_threshold(
+            pairs,
+            threshold=threshold,
+            positive_label=True,
+            greater_is_match=greater_is_match,
+        )
+        row["predicted_positive"] = row["true_positive"] + row["false_positive"]
+        row["positive_count"] = positive_count
+        row["negative_count"] = negative_count
+        rows.append(row)
+
+    frame = pd.DataFrame(rows)
+    frame.attrs["curve_type"] = "precision_recall"
+    frame.attrs["average_precision"] = _average_precision_from_rows(rows)
+    frame.attrs["score_key"] = score_key
+    frame.attrs["label_key"] = label_key
+    frame.attrs["greater_is_match"] = bool(greater_is_match)
+    return frame
+
+
 def calibrate_threshold(
     scores,
     labels=None,
@@ -211,3 +384,143 @@ def calibrate_threshold(
     result["optimized_metric"] = metric_name
     result["candidate_count"] = len(curve)
     return result
+
+
+def calibration_report(
+    scores,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+    optimize="f1",
+):
+    pairs = _coerce_score_label_pairs(
+        scores,
+        labels=labels,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+    )
+    positive_count, negative_count = _require_two_classes(pairs)
+    sweep = threshold_sweep(
+        pairs,
+        thresholds=thresholds,
+        positive_label=True,
+        greater_is_match=greater_is_match,
+    )
+    roc = roc_curve(
+        pairs,
+        positive_label=True,
+        greater_is_match=greater_is_match,
+    )
+    pr = precision_recall_curve(
+        pairs,
+        positive_label=True,
+        greater_is_match=greater_is_match,
+    )
+    best = calibrate_threshold(
+        pairs,
+        thresholds=thresholds,
+        positive_label=True,
+        greater_is_match=greater_is_match,
+        optimize=optimize,
+    )
+    summary = {
+        "pair_count": int(len(pairs)),
+        "positive_count": int(positive_count),
+        "negative_count": int(negative_count),
+        "score_key": score_key,
+        "label_key": label_key,
+        "greater_is_match": bool(greater_is_match),
+        "auroc": float(roc.attrs["auroc"]),
+        "average_precision": float(pr.attrs["average_precision"]),
+        "optimized_threshold": best,
+    }
+    return {
+        "summary": summary,
+        "threshold_sweep": sweep,
+        "roc": roc,
+        "precision_recall": pr,
+    }
+
+
+def calibration_report_payload(report):
+    return {
+        "schema_version": 1,
+        "summary": _json_safe_mapping(report["summary"]),
+        "threshold_sweep": _frame_records(report["threshold_sweep"]),
+        "roc": _frame_records(report["roc"]),
+        "precision_recall": _frame_records(report["precision_recall"]),
+    }
+
+
+def write_calibration_report_artifacts(
+    scores,
+    output_dir,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+    optimize="f1",
+    basename="calibration",
+):
+    report = calibration_report(
+        scores,
+        labels=labels,
+        thresholds=thresholds,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+        greater_is_match=greater_is_match,
+        optimize=optimize,
+    )
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    stem = _safe_artifact_basename(basename or "calibration")
+    artifacts = {
+        "threshold_sweep_csv": target / f"{stem}_threshold_sweep.csv",
+        "roc_csv": target / f"{stem}_roc.csv",
+        "precision_recall_csv": target / f"{stem}_precision_recall.csv",
+        "summary_json": target / f"{stem}_summary.json",
+        "report_json": target / f"{stem}_report.json",
+    }
+    report["threshold_sweep"].to_csv(artifacts["threshold_sweep_csv"], index=False)
+    report["roc"].to_csv(artifacts["roc_csv"], index=False)
+    report["precision_recall"].to_csv(artifacts["precision_recall_csv"], index=False)
+    artifacts["summary_json"].write_text(
+        json.dumps(_json_safe_mapping(report["summary"]), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    artifacts["report_json"].write_text(
+        json.dumps(calibration_report_payload(report), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return report, artifacts
+
+
+def _frame_records(frame):
+    return [_json_safe_mapping(row) for row in frame.to_dict(orient="records")]
+
+
+def _json_safe_mapping(values):
+    payload = {}
+    for key, value in dict(values).items():
+        if isinstance(value, dict):
+            payload[str(key)] = _json_safe_mapping(value)
+        elif pd.isna(value):
+            payload[str(key)] = None
+        elif isinstance(value, (int, float, str, bool)) or value is None:
+            payload[str(key)] = value
+        else:
+            payload[str(key)] = value.item() if hasattr(value, "item") else value
+    return payload
+
+
+def _safe_artifact_basename(value):
+    text = str(value or "").strip()
+    safe = "".join(character if character.isalnum() or character in "._-" else "_" for character in text)
+    return safe.strip("._") or "calibration"

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -3,9 +3,11 @@ import sys
 from pathlib import Path
 
 import click
+import pandas as pd
 
 from . import __version__
 from .algorithms import normalize_algorithm_options, score_source_pairs_with_algorithm
+from .calibration import write_calibration_report_artifacts
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
 from ._progress import should_show_progress
@@ -302,6 +304,35 @@ def _echo_pair_explanation_summary(summary, output_format):
         click.echo(f"{level}={count}")
     for name, path in summary["artifacts"].items():
         click.echo(f"{name}={path}")
+
+
+def _echo_calibration_report_summary(summary, output_format):
+    if output_format == "json":
+        _echo_json(summary)
+        return
+    click.echo(f"pair_count={summary['pair_count']}")
+    click.echo(f"positive_count={summary['positive_count']}")
+    click.echo(f"negative_count={summary['negative_count']}")
+    click.echo(f"auroc={summary['auroc']:.4f}")
+    click.echo(f"average_precision={summary['average_precision']:.4f}")
+    optimized = summary["optimized_threshold"]
+    click.echo(f"optimized_threshold={optimized['threshold']:.6g}")
+    click.echo(f"optimized_metric={optimized['optimized_metric']}")
+    click.echo(f"optimized_f1={optimized['f1']:.4f}")
+    for name, path in summary["artifacts"].items():
+        click.echo(f"{name}={path}")
+
+
+def _calibration_cli_summary(report, artifacts):
+    summary = dict(report["summary"])
+    summary["artifacts"] = {name: str(path) for name, path in artifacts.items()}
+    return summary
+
+
+def _parse_positive_label(value):
+    if value is None:
+        return True
+    return _coerce_cli_option_value(value)
 
 
 def _pair_explanation_summary(explanation, artifacts):
@@ -634,6 +665,71 @@ def explain_pair(
 
     _echo_pair_explanation_summary(
         _pair_explanation_summary(explanation, artifacts),
+        output_format,
+    )
+
+
+@main.command(name="calibration-report")
+@click.argument("scores_path", type=click.Path(exists=True, file_okay=True, dir_okay=False))
+@click.option("--score-column", default="similarity_score", show_default=True, help="Column containing pair scores.")
+@click.option("--label-column", default="label", show_default=True, help="Column containing pair labels.")
+@click.option(
+    "--positive-label",
+    default=None,
+    help="Positive label value. Defaults to boolean coercion, suitable for 0/1 labels.",
+)
+@click.option(
+    "--greater-is-match/--lower-is-match",
+    default=True,
+    show_default=True,
+    help="Whether larger scores mean stronger matches.",
+)
+@click.option(
+    "--optimize",
+    type=click.Choice(("f1", "accuracy", "precision", "recall")),
+    default="f1",
+    show_default=True,
+    help="Metric used for the recommended threshold.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=True,
+    help="Directory where calibration artifacts will be written.",
+)
+@click.option("--basename", default="calibration", show_default=True, help="Artifact filename stem.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def calibration_report_command(
+    scores_path,
+    score_column,
+    label_column,
+    positive_label,
+    greater_is_match,
+    optimize,
+    output_dir,
+    basename,
+    output_format,
+):
+    """Write ROC, precision-recall, and threshold calibration artifacts."""
+    scored_pairs = pd.read_csv(scores_path)
+    report, artifacts = write_calibration_report_artifacts(
+        scored_pairs,
+        output_dir,
+        score_key=score_column,
+        label_key=label_column,
+        positive_label=_parse_positive_label(positive_label),
+        greater_is_match=greater_is_match,
+        optimize=optimize,
+        basename=basename,
+    )
+    _echo_calibration_report_summary(
+        _calibration_cli_summary(report, artifacts),
         output_format,
     )
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,11 +1,20 @@
+import json
+
+import pandas as pd
 import pytest
 
 import matheel
 from matheel.calibration import (
     calibrate_threshold,
     calibration_curve,
+    calibration_report,
+    calibration_report_payload,
     evaluate_threshold,
     feature_score_range,
+    precision_recall_curve,
+    roc_curve,
+    threshold_sweep,
+    write_calibration_report_artifacts,
 )
 
 
@@ -30,8 +39,14 @@ def test_evaluate_threshold_reports_confusion_counts_and_metrics():
 def test_calibration_helpers_are_exported_from_package_root():
     assert matheel.calibrate_threshold is calibrate_threshold
     assert matheel.calibration_curve is calibration_curve
+    assert matheel.calibration_report is calibration_report
+    assert matheel.calibration_report_payload is calibration_report_payload
     assert matheel.evaluate_threshold is evaluate_threshold
     assert matheel.feature_score_range is feature_score_range
+    assert matheel.precision_recall_curve is precision_recall_curve
+    assert matheel.roc_curve is roc_curve
+    assert matheel.threshold_sweep is threshold_sweep
+    assert matheel.write_calibration_report_artifacts is write_calibration_report_artifacts
 
 
 def test_calibrate_threshold_finds_best_cutoff_for_tiny_labeled_dataset():
@@ -80,6 +95,84 @@ def test_calibration_curve_accepts_explicit_thresholds():
     assert [item["threshold"] for item in curve] == [0.5, 0.8]
     assert curve[0]["false_positive"] == 1
     assert curve[1]["false_positive"] == 0
+
+
+def test_threshold_sweep_returns_dataframe_with_confusion_counts():
+    frame = threshold_sweep(
+        pd.DataFrame(
+            [
+                {"similarity_score": 0.9, "label": 1},
+                {"similarity_score": 0.2, "label": 0},
+            ]
+        ),
+        score_key="similarity_score",
+        label_key="label",
+        thresholds=[0.5],
+    )
+
+    assert frame.attrs["curve_type"] == "threshold_sweep"
+    assert frame.loc[0, "true_positive"] == 1
+    assert frame.loc[0, "true_negative"] == 1
+    assert frame.loc[0, "f1"] == pytest.approx(1.0)
+
+
+def test_roc_and_precision_recall_curves_report_perfect_ranking_metrics():
+    scores = [0.95, 0.82, 0.3, 0.1]
+    labels = [True, True, False, False]
+
+    roc = roc_curve(scores, labels)
+    pr = precision_recall_curve(scores, labels)
+
+    assert roc.attrs["auroc"] == pytest.approx(1.0)
+    assert pr.attrs["average_precision"] == pytest.approx(1.0)
+    assert roc.iloc[0]["false_positive_rate"] == pytest.approx(0.0)
+    assert roc.iloc[0]["true_positive_rate"] == pytest.approx(0.0)
+    assert roc.iloc[-1]["false_positive_rate"] == pytest.approx(1.0)
+    assert roc.iloc[-1]["true_positive_rate"] == pytest.approx(1.0)
+    assert pr.iloc[-1]["recall"] == pytest.approx(1.0)
+
+
+def test_calibration_report_payload_and_artifacts_are_deterministic(tmp_path):
+    scored_pairs = pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.9, "label": 1},
+            {"left_id": "a", "right_id": "c", "similarity_score": 0.8, "label": 1},
+            {"left_id": "d", "right_id": "e", "similarity_score": 0.4, "label": 0},
+            {"left_id": "d", "right_id": "f", "similarity_score": 0.2, "label": 0},
+        ]
+    )
+
+    report, artifacts = write_calibration_report_artifacts(
+        scored_pairs,
+        tmp_path / "calibration",
+        score_key="similarity_score",
+        label_key="label",
+        basename="tiny run",
+    )
+    payload = calibration_report_payload(report)
+
+    assert report["summary"]["auroc"] == pytest.approx(1.0)
+    assert report["summary"]["average_precision"] == pytest.approx(1.0)
+    assert payload["schema_version"] == 1
+    assert payload["summary"]["pair_count"] == 4
+    assert artifacts["threshold_sweep_csv"].name == "tiny_run_threshold_sweep.csv"
+    assert artifacts["roc_csv"].exists()
+    assert artifacts["precision_recall_csv"].exists()
+    summary = json.loads(artifacts["summary_json"].read_text(encoding="utf-8"))
+    assert summary["optimized_threshold"]["f1"] == pytest.approx(1.0)
+    full_payload = json.loads(artifacts["report_json"].read_text(encoding="utf-8"))
+    assert len(full_payload["roc"]) == len(report["roc"])
+
+
+def test_roc_and_precision_recall_require_both_classes():
+    with pytest.raises(ValueError, match="positive and one negative"):
+        roc_curve([0.9, 0.8], [True, True])
+
+    with pytest.raises(ValueError, match="positive and one negative"):
+        precision_recall_curve([0.2, 0.1], [False, False])
+
+    with pytest.raises(ValueError, match="positive and one negative"):
+        calibration_report([0.9], [True])
 
 
 def test_calibrate_threshold_supports_lower_scores_as_matches():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,6 +163,42 @@ def test_explain_pair_command_accepts_source_archive_names(tmp_path):
     assert (output_dir / "a.py_vs_b.py.json").exists()
 
 
+def test_calibration_report_command_writes_artifacts(tmp_path):
+    scores_path = tmp_path / "scored_pairs.csv"
+    pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.9, "label": 1},
+            {"left_id": "a", "right_id": "c", "similarity_score": 0.8, "label": 1},
+            {"left_id": "d", "right_id": "e", "similarity_score": 0.3, "label": 0},
+            {"left_id": "d", "right_id": "f", "similarity_score": 0.1, "label": 0},
+        ]
+    ).to_csv(scores_path, index=False)
+    output_dir = tmp_path / "calibration"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "calibration-report",
+            str(scores_path),
+            "--output-dir",
+            str(output_dir),
+            "--basename",
+            "tiny",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = json.loads(result.output)
+    assert summary["auroc"] == 1.0
+    assert summary["average_precision"] == 1.0
+    assert (output_dir / "tiny_threshold_sweep.csv").exists()
+    assert (output_dir / "tiny_roc.csv").exists()
+    assert (output_dir / "tiny_precision_recall.csv").exists()
+    assert (output_dir / "tiny_report.json").exists()
+
+
 def test_compare_command_accepts_new_options(tmp_path, monkeypatch):
     archive_path = tmp_path / "codes.zip"
     archive_path.write_bytes(b"placeholder")


### PR DESCRIPTION
Summary:
- Add threshold sweep, ROC curve, precision-recall curve, calibration report, and artifact writer APIs.
- Add calibration-report CLI support for scored pair CSVs.
- Document calibration artifacts and add a runnable evaluation example.
- Cover deterministic curve output, single-class failures, artifact payloads, and CLI output.

Verification:
- python -m pytest tests/test_calibration.py tests/test_cli.py
- python -m ruff check .
- python -m mkdocs build --strict
- python -m pytest
- git diff --check
- python examples/evaluation/calibration_report_demo.py

Closes #156.
Refs #151.