### PR TITLE
Add benchmark result cache foundation

### DIFF
--- a/docs/comparison_suite.md
+++ b/docs/comparison_suite.md
@@ -88,6 +88,8 @@ One row per run, including:
 - `algorithm_package_version`
 - `algorithm_options`
 - `algorithm_source_sha256`
+- `cache_status`
+- `cache_key`
 
 `elapsed_seconds` is rounded to 4 decimal places. `feature_set` lists the active nonzero feature weights for the run.
 For custom algorithm runs, `feature_set` is `custom`.
@@ -106,7 +108,15 @@ For custom algorithm runs, `feature_set` is `custom`.
   Receives structured progress event dictionaries for run-level and pair-level work.
 - `reproducibility_out`
   Writes a JSON snapshot with package versions, source fingerprint, normalized run configs, and run metadata.
+- `cache_dir`
+  Enables a local filesystem cache for detailed run outputs.
+- `use_cache`
+  Disable this when you want to force fresh scoring even when `cache_dir` is set.
+- `cache_seed`
+  Optional run version or seed value included in cache keys.
 - Numeric score fields are rounded to 4 decimal places in suite output artifacts.
+
+Cache keys include the source fingerprint, normalized run config, dependency versions, optional seed, and custom algorithm source fingerprint when one is available. Cache entries are stored under the user-selected cache directory, not inside the repository.
 
 ## Python Example
 
@@ -153,6 +163,8 @@ summary, details = run_comparison_suite(
     sample_archive,
     runs,
     reproducibility_out="results/reproducibility.json",
+    cache_dir="results/cache",
+    cache_seed="demo-v1",
     progress=True,
 )
 print(summary)

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -16,6 +16,15 @@ from .algorithms import (
     score_pair_with_algorithm,
     score_source_pairs_with_algorithm,
 )
+from .benchmark_cache import (
+    benchmark_cache_key,
+    benchmark_cache_key_for_run,
+    benchmark_cache_paths,
+    benchmark_dependency_versions,
+    clear_benchmark_cache,
+    load_benchmark_cache_result,
+    write_benchmark_cache_result,
+)
 from .chunking import chunk_text, chunker_parameter_names
 from .calibration import (
     calibrate_threshold,
@@ -152,6 +161,10 @@ __all__ = [
     "available_similarity_functions",
     "available_vector_backends",
     "attach_algorithm_metadata",
+    "benchmark_cache_key",
+    "benchmark_cache_key_for_run",
+    "benchmark_cache_paths",
+    "benchmark_dependency_versions",
     "calibrate_threshold",
     "calibration_curve",
     "calibration_report",
@@ -159,6 +172,7 @@ __all__ = [
     "calculate_similarity",
     "chunk_text",
     "chunker_parameter_names",
+    "clear_benchmark_cache",
     "codebleu_components",
     "collect_reproducibility_snapshot",
     "compare_metric_samples",
@@ -181,6 +195,7 @@ __all__ = [
     "infer_model_capabilities",
     "inspect_model_settings",
     "load_code_texts",
+    "load_benchmark_cache_result",
     "load_dataset_manifest",
     "load_pair_dataset",
     "load_pair_datasets",
@@ -244,6 +259,7 @@ __all__ = [
     "write_dataset_embedding_map",
     "write_dataset_map_artifacts",
     "write_calibration_report_artifacts",
+    "write_benchmark_cache_result",
     "write_pair_dataset_explanation",
     "write_pair_explanation",
     "write_pair_explanation_artifacts",

--- a/matheel/benchmark_cache.py
+++ b/matheel/benchmark_cache.py
@@ -1,0 +1,178 @@
+import json
+import shutil
+from datetime import datetime, timezone
+from hashlib import sha256
+from importlib.metadata import PackageNotFoundError, version as package_version
+from pathlib import Path
+
+import pandas as pd
+
+from .algorithms import resolve_pair_algorithm
+from .reproducibility import fingerprint_source
+
+
+BENCHMARK_CACHE_SCHEMA_VERSION = 1
+_PACKAGE_NAMES = (
+    "matheel",
+    "numpy",
+    "pandas",
+    "rapidfuzz",
+    "sentence-transformers",
+    "model2vec",
+    "pylate",
+    "tree-sitter-language-pack",
+)
+_PATH_KEYS = frozenset(
+    {
+        "algorithm",
+        "algorithm_path",
+        "source_path",
+        "dataset_path",
+        "scores_out",
+        "metrics_out",
+        "reproducibility_out",
+        "summary_out",
+        "details_dir",
+    }
+)
+
+
+def benchmark_dependency_versions(package_names=None):
+    return {
+        name: _safe_package_version(name)
+        for name in (package_names or _PACKAGE_NAMES)
+    }
+
+
+def benchmark_cache_key(source_fingerprint, run_config, dependency_versions=None, seed=None, extra=None):
+    components = {
+        "schema_version": BENCHMARK_CACHE_SCHEMA_VERSION,
+        "source": _json_safe(source_fingerprint),
+        "run_config": _json_safe(run_config),
+        "dependency_versions": _json_safe(dependency_versions or benchmark_dependency_versions()),
+        "seed": _json_safe(seed),
+        "extra": _json_safe(extra or {}),
+    }
+    payload = json.dumps(components, sort_keys=True, separators=(",", ":"))
+    return {
+        "schema_version": BENCHMARK_CACHE_SCHEMA_VERSION,
+        "key": sha256(payload.encode("utf-8")).hexdigest(),
+        "components": components,
+    }
+
+
+def benchmark_cache_key_for_run(source_path, run_config, seed=None, dependency_versions=None, extra=None):
+    options = dict(run_config.get("options", {}))
+    algorithm_fingerprint = _algorithm_fingerprint_from_options(options)
+    key_extra = dict(extra or {})
+    if algorithm_fingerprint:
+        key_extra["algorithm_fingerprint"] = algorithm_fingerprint
+    return benchmark_cache_key(
+        fingerprint_source(source_path),
+        run_config,
+        dependency_versions=dependency_versions,
+        seed=seed,
+        extra=key_extra,
+    )
+
+
+def benchmark_cache_paths(cache_dir, cache_key):
+    safe_key = _validate_cache_key(cache_key)
+    root = Path(cache_dir) / safe_key[:2] / safe_key
+    return {
+        "root": root,
+        "metadata": root / "metadata.json",
+        "results": root / "results.csv",
+    }
+
+
+def load_benchmark_cache_result(cache_dir, cache_key):
+    paths = benchmark_cache_paths(cache_dir, cache_key)
+    if not paths["metadata"].exists() or not paths["results"].exists():
+        return None
+    metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
+    results = pd.read_csv(paths["results"])
+    results.attrs.update(metadata.get("result_attrs") or {})
+    results.attrs["cache_status"] = "hit"
+    results.attrs["cache_key"] = metadata.get("cache_key") or _validate_cache_key(cache_key)
+    return results, metadata
+
+
+def write_benchmark_cache_result(cache_dir, cache_key_payload, results, metadata=None):
+    cache_key = cache_key_payload["key"] if isinstance(cache_key_payload, dict) else cache_key_payload
+    paths = benchmark_cache_paths(cache_dir, cache_key)
+    paths["root"].mkdir(parents=True, exist_ok=True)
+    frame = results.copy()
+    frame.to_csv(paths["results"], index=False)
+    payload = {
+        "schema_version": BENCHMARK_CACHE_SCHEMA_VERSION,
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "cache_key": _validate_cache_key(cache_key),
+        "key_components": _json_safe(cache_key_payload.get("components", {}) if isinstance(cache_key_payload, dict) else {}),
+        "metadata": _json_safe(metadata or {}),
+        "result_attrs": _json_safe(getattr(results, "attrs", {})),
+    }
+    paths["metadata"].write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return paths
+
+
+def clear_benchmark_cache(cache_dir, missing_ok=True):
+    target = Path(cache_dir)
+    if not target.exists():
+        if missing_ok:
+            return False
+        raise FileNotFoundError(target)
+    shutil.rmtree(target)
+    return True
+
+
+def _safe_package_version(name):
+    try:
+        return package_version(name)
+    except PackageNotFoundError:
+        return None
+
+
+def _algorithm_fingerprint_from_options(options):
+    algorithm = options.get("algorithm") or options.get("algorithm_path")
+    if algorithm is None:
+        return None
+    try:
+        resolved = resolve_pair_algorithm(algorithm)
+    except Exception:
+        return {"source_type": "unresolved", "name": Path(str(algorithm)).name}
+    return {
+        "algorithm_name": resolved.name,
+        "algorithm_module": resolved.module_name,
+        "algorithm_package": resolved.package_name,
+        "algorithm_package_version": resolved.package_version,
+        "algorithm_source_fingerprint": dict(resolved.source_fingerprint or {}),
+    }
+
+
+def _validate_cache_key(cache_key):
+    key = str(cache_key or "").strip().lower()
+    if len(key) != 64 or any(character not in "0123456789abcdef" for character in key):
+        raise ValueError("cache_key must be a 64-character SHA-256 hex digest.")
+    return key
+
+
+def _json_safe(value, key_name=None):
+    if isinstance(value, dict):
+        return {
+            str(key): _json_safe(item, key_name=str(key))
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, Path):
+        return value.name
+    if key_name in _PATH_KEYS and isinstance(value, str):
+        return Path(value).name
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return value

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -1122,11 +1122,36 @@ def compare(
     help="Optional path to write reproducibility metadata JSON.",
 )
 @click.option(
+    "--cache-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    default=None,
+    help="Optional local directory for cached comparison run results.",
+)
+@click.option(
+    "--cache/--no-cache",
+    "use_cache",
+    default=True,
+    show_default=True,
+    help="Use cached comparison results when --cache-dir is set.",
+)
+@click.option("--cache-seed", default=None, help="Optional seed/version value included in cache keys.")
+@click.option(
     "--progress/--no-progress",
     default=None,
     help="Show progress bars on stderr. Defaults to auto for interactive terminals.",
 )
-def compare_suite(source_path, config_file, summary_out, details_dir, output_format, reproducibility_out, progress):
+def compare_suite(
+    source_path,
+    config_file,
+    summary_out,
+    details_dir,
+    output_format,
+    reproducibility_out,
+    cache_dir,
+    use_cache,
+    cache_seed,
+    progress,
+):
     """Run multiple similarity configurations from a JSON config file."""
     run_configs = load_run_configs(config_file)
     summary, _ = run_comparison_suite(
@@ -1136,6 +1161,9 @@ def compare_suite(source_path, config_file, summary_out, details_dir, output_for
         details_dir=details_dir,
         output_format=output_format,
         reproducibility_out=reproducibility_out,
+        cache_dir=cache_dir,
+        use_cache=use_cache,
+        cache_seed=cache_seed,
         progress=should_show_progress(progress, stream=sys.stderr),
     )
     if summary.empty:

--- a/matheel/comparison_suite.py
+++ b/matheel/comparison_suite.py
@@ -5,6 +5,11 @@ from pathlib import Path
 import pandas as pd
 
 from .algorithms import normalize_algorithm_options, score_source_pairs_with_algorithm
+from .benchmark_cache import (
+    benchmark_cache_key_for_run,
+    load_benchmark_cache_result,
+    write_benchmark_cache_result,
+)
 from .feature_weights import default_feature_weights, parse_feature_weights
 from ._progress import progress_iter
 from ._run_metadata import (
@@ -237,6 +242,9 @@ def run_comparison_suite(
     details_dir=None,
     output_format="csv",
     reproducibility_out=None,
+    cache_dir=None,
+    use_cache=True,
+    cache_seed=None,
     progress=False,
     progress_callback=None,
 ):
@@ -259,32 +267,25 @@ def run_comparison_suite(
         run_options = dict(options)
         run_options.setdefault("progress", progress)
         run_options.setdefault("progress_callback", _run_progress_callback(progress_callback, run_name))
-        start_time = perf_counter()
-        if _run_uses_custom_algorithm(run_options):
-            algorithm = run_options.pop("algorithm", None) or run_options.pop("algorithm_path")
-            algorithm_options = normalize_algorithm_options(run_options.pop("algorithm_options", None))
-            results = _rounded_score_frame(
-                score_source_pairs_with_algorithm(
-                    zipped_file,
-                    algorithm=algorithm,
-                    preprocess_mode=run_options.get("preprocess_mode", "none"),
-                    code_language=run_options.get("code_language"),
-                    algorithm_options=algorithm_options,
-                    threshold=run_options.get("threshold", 0.0),
-                    number_results=run_options.get("number_results", 10),
-                    progress=run_options.get("progress", False),
-                    progress_callback=run_options.get("progress_callback"),
+        cache_payload = _cache_key_payload(zipped_file, run, cache_dir, use_cache, cache_seed)
+        cached = _load_cached_run(cache_dir, cache_payload)
+        if cached is None:
+            start_time = perf_counter()
+            results = _score_suite_run(zipped_file, run_options)
+            elapsed_seconds = elapsed_seconds_between(start_time, perf_counter())
+            results.attrs["elapsed_seconds"] = elapsed_seconds
+            if cache_payload is not None:
+                results.attrs["cache_status"] = "miss"
+                results.attrs["cache_key"] = cache_payload["key"]
+                write_benchmark_cache_result(
+                    cache_dir,
+                    cache_payload,
+                    results,
+                    metadata={"run_name": run_name},
                 )
-            )
         else:
-            results = _rounded_score_frame(
-                get_sim_list(
-                    zipped_file,
-                    **run_options,
-                )
-            )
-        elapsed_seconds = elapsed_seconds_between(start_time, perf_counter())
-        results.attrs["elapsed_seconds"] = elapsed_seconds
+            results, _ = cached
+            elapsed_seconds = results.attrs.get("elapsed_seconds")
         result_frames[run_name] = results
         write_run_details(run_name, results, details_dir=details_dir)
         summary_rows.append(
@@ -311,6 +312,44 @@ def run_comparison_suite(
         write_reproducibility_snapshot(snapshot, reproducibility_out)
 
     return summary, result_frames
+
+
+def _cache_key_payload(source_path, run, cache_dir, use_cache, cache_seed):
+    if cache_dir is None or not use_cache:
+        return None
+    return benchmark_cache_key_for_run(source_path, run, seed=cache_seed)
+
+
+def _load_cached_run(cache_dir, cache_payload):
+    if cache_payload is None:
+        return None
+    return load_benchmark_cache_result(cache_dir, cache_payload["key"])
+
+
+def _score_suite_run(zipped_file, run_options):
+    run_options = dict(run_options)
+    if _run_uses_custom_algorithm(run_options):
+        algorithm = run_options.pop("algorithm", None) or run_options.pop("algorithm_path")
+        algorithm_options = normalize_algorithm_options(run_options.pop("algorithm_options", None))
+        return _rounded_score_frame(
+            score_source_pairs_with_algorithm(
+                zipped_file,
+                algorithm=algorithm,
+                preprocess_mode=run_options.get("preprocess_mode", "none"),
+                code_language=run_options.get("code_language"),
+                algorithm_options=algorithm_options,
+                threshold=run_options.get("threshold", 0.0),
+                number_results=run_options.get("number_results", 10),
+                progress=run_options.get("progress", False),
+                progress_callback=run_options.get("progress_callback"),
+            )
+        )
+    return _rounded_score_frame(
+        get_sim_list(
+            zipped_file,
+            **run_options,
+        )
+    )
 
 
 def _resolved_elapsed_seconds(results, elapsed_seconds):
@@ -345,6 +384,8 @@ def _summary_metadata(options, results, elapsed_seconds):
         "algorithm_package_version": algorithm.get("algorithm_package_version") or "",
         "algorithm_options": json.dumps(algorithm_options or {}, sort_keys=True),
         "algorithm_source_sha256": algorithm_fingerprint.get("sha256") or "",
+        "cache_status": attrs.get("cache_status") or "disabled",
+        "cache_key": attrs.get("cache_key") or "",
     }
 
 

--- a/tests/test_benchmark_cache.py
+++ b/tests/test_benchmark_cache.py
@@ -1,0 +1,136 @@
+import json
+
+import pandas as pd
+import pytest
+
+import matheel
+from matheel.benchmark_cache import (
+    benchmark_cache_key,
+    benchmark_cache_key_for_run,
+    benchmark_cache_paths,
+    benchmark_dependency_versions,
+    clear_benchmark_cache,
+    load_benchmark_cache_result,
+    write_benchmark_cache_result,
+)
+
+
+def test_benchmark_cache_helpers_are_exported_from_package_root():
+    assert matheel.benchmark_cache_key is benchmark_cache_key
+    assert matheel.benchmark_cache_key_for_run is benchmark_cache_key_for_run
+    assert matheel.benchmark_cache_paths is benchmark_cache_paths
+    assert matheel.benchmark_dependency_versions is benchmark_dependency_versions
+    assert matheel.clear_benchmark_cache is clear_benchmark_cache
+    assert matheel.load_benchmark_cache_result is load_benchmark_cache_result
+    assert matheel.write_benchmark_cache_result is write_benchmark_cache_result
+
+
+def test_benchmark_cache_key_is_deterministic_and_path_safe(tmp_path):
+    algorithm_path = tmp_path / "algo.py"
+    algorithm_path.write_text("def score_pair(code_a, code_b):\n    return 1.0\n", encoding="utf-8")
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("print(1)", encoding="utf-8")
+
+    run_config = {
+        "run_name": "custom",
+        "options": {"algorithm_path": str(algorithm_path), "threshold": 0.5},
+    }
+    first = benchmark_cache_key_for_run(
+        source_dir,
+        run_config,
+        dependency_versions={"matheel": "test"},
+        seed=7,
+    )
+    second = benchmark_cache_key_for_run(
+        source_dir,
+        run_config,
+        dependency_versions={"matheel": "test"},
+        seed=7,
+    )
+
+    assert first == second
+    assert len(first["key"]) == 64
+    assert "/" not in first["key"]
+    assert first["components"]["run_config"]["options"]["algorithm_path"] == "algo.py"
+    assert first["components"]["extra"]["algorithm_fingerprint"]["algorithm_source_fingerprint"]["sha256"]
+
+
+def test_benchmark_cache_key_changes_when_config_changes():
+    source_fingerprint = {"source_type": "directory", "sha256": "abc"}
+    baseline = benchmark_cache_key(
+        source_fingerprint,
+        {"run_name": "baseline", "options": {"threshold": 0.5}},
+        dependency_versions={"matheel": "test"},
+    )
+    changed = benchmark_cache_key(
+        source_fingerprint,
+        {"run_name": "baseline", "options": {"threshold": 0.7}},
+        dependency_versions={"matheel": "test"},
+    )
+
+    assert baseline["key"] != changed["key"]
+
+
+def test_benchmark_cache_round_trips_results_and_attrs(tmp_path):
+    cache_key = benchmark_cache_key(
+        {"source_type": "directory", "sha256": "abc"},
+        {"run_name": "baseline", "options": {"threshold": 0.5}},
+        dependency_versions={"matheel": "test"},
+    )
+    results = pd.DataFrame(
+        [{"file_name_1": "a.py", "file_name_2": "b.py", "similarity_score": 1.0}]
+    )
+    results.attrs["elapsed_seconds"] = 0.25
+    results.attrs["feature_set"] = "levenshtein"
+
+    paths = write_benchmark_cache_result(tmp_path / "cache", cache_key, results, metadata={"run_name": "baseline"})
+    cached = load_benchmark_cache_result(tmp_path / "cache", cache_key["key"])
+
+    assert paths["metadata"].exists()
+    assert paths["results"].exists()
+    assert cached is not None
+    cached_results, metadata = cached
+    pd.testing.assert_frame_equal(cached_results, results)
+    assert cached_results.attrs["elapsed_seconds"] == 0.25
+    assert cached_results.attrs["cache_status"] == "hit"
+    assert metadata["metadata"]["run_name"] == "baseline"
+
+
+def test_benchmark_cache_clear_removes_cache_directory(tmp_path):
+    cache_key = benchmark_cache_key(
+        {"source_type": "directory", "sha256": "abc"},
+        {"run_name": "baseline", "options": {}},
+        dependency_versions={"matheel": "test"},
+    )
+    results = pd.DataFrame([{"similarity_score": 1.0}])
+    write_benchmark_cache_result(tmp_path / "cache", cache_key, results)
+
+    assert clear_benchmark_cache(tmp_path / "cache") is True
+    assert load_benchmark_cache_result(tmp_path / "cache", cache_key["key"]) is None
+    assert clear_benchmark_cache(tmp_path / "cache") is False
+
+
+def test_benchmark_cache_rejects_invalid_keys(tmp_path):
+    with pytest.raises(ValueError, match="SHA-256"):
+        benchmark_cache_paths(tmp_path / "cache", "../bad")
+
+
+def test_benchmark_cache_metadata_does_not_store_absolute_paths(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "a.py").write_text("print(1)", encoding="utf-8")
+    run_config = {
+        "run_name": "baseline",
+        "options": {"algorithm_path": str(tmp_path / "algorithm.py")},
+    }
+    payload = benchmark_cache_key_for_run(
+        source_dir,
+        run_config,
+        dependency_versions={"matheel": "test"},
+    )
+    results = pd.DataFrame([{"similarity_score": 1.0}])
+    paths = write_benchmark_cache_result(tmp_path / "cache", payload, results)
+    metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
+
+    assert str(tmp_path) not in json.dumps(metadata)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1378,6 +1378,9 @@ def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
         details_dir,
         output_format,
         reproducibility_out,
+        cache_dir,
+        use_cache,
+        cache_seed,
         progress,
     ):
         captured["zipfile"] = zipfile
@@ -1386,6 +1389,9 @@ def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
         captured["details_dir"] = details_dir
         captured["output_format"] = output_format
         captured["reproducibility_out"] = reproducibility_out
+        captured["cache_dir"] = cache_dir
+        captured["use_cache"] = use_cache
+        captured["cache_seed"] = cache_seed
         captured["progress"] = progress
         return (
             pd.DataFrame(
@@ -1426,6 +1432,10 @@ def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
             str(tmp_path / "details"),
             "--format",
             "json",
+            "--cache-dir",
+            str(tmp_path / "cache"),
+            "--cache-seed",
+            "demo",
             "--progress",
         ],
     )
@@ -1437,4 +1447,7 @@ def test_compare_suite_command_runs_config_file(tmp_path, monkeypatch):
     assert captured["details_dir"].endswith("details")
     assert captured["output_format"] == "json"
     assert captured["reproducibility_out"] is None
+    assert captured["cache_dir"].endswith("cache")
+    assert captured["use_cache"] is True
+    assert captured["cache_seed"] == "demo"
     assert captured["progress"] is True

--- a/tests/test_comparison_suite.py
+++ b/tests/test_comparison_suite.py
@@ -179,6 +179,108 @@ def test_run_comparison_suite_writes_summary_and_details(tmp_path, monkeypatch):
     assert "0.9877" in strong_details_text
 
 
+def test_run_comparison_suite_uses_cache_on_second_run(tmp_path, monkeypatch):
+    calls = {"count": 0}
+
+    def fake_get_sim_list(zipped_file, **kwargs):
+        calls["count"] += 1
+        return pd.DataFrame(
+            [
+                {"file_name_1": "a.py", "file_name_2": "b.py", "similarity_score": 0.8},
+            ]
+        )
+
+    monkeypatch.setattr("matheel.comparison_suite.get_sim_list", fake_get_sim_list)
+    times = iter([10.0, 10.5])
+    monkeypatch.setattr("matheel.comparison_suite.perf_counter", lambda: next(times))
+    run_configs = [{"run_name": "baseline", "feature_weights": {"levenshtein": 1.0}}]
+    cache_dir = tmp_path / "cache"
+
+    first_summary, first_results = run_comparison_suite(
+        "codes.zip",
+        run_configs,
+        cache_dir=cache_dir,
+        cache_seed=7,
+    )
+    second_summary, second_results = run_comparison_suite(
+        "codes.zip",
+        run_configs,
+        cache_dir=cache_dir,
+        cache_seed=7,
+    )
+
+    assert calls["count"] == 1
+    assert first_summary.loc[0, "cache_status"] == "miss"
+    assert second_summary.loc[0, "cache_status"] == "hit"
+    assert first_summary.loc[0, "cache_key"] == second_summary.loc[0, "cache_key"]
+    pd.testing.assert_frame_equal(first_results["baseline"], second_results["baseline"])
+
+
+def test_run_comparison_suite_cache_invalidates_when_config_changes(tmp_path, monkeypatch):
+    calls = {"count": 0}
+
+    def fake_get_sim_list(zipped_file, **kwargs):
+        calls["count"] += 1
+        return pd.DataFrame(
+            [
+                {"file_name_1": "a.py", "file_name_2": "b.py", "similarity_score": kwargs["threshold"]},
+            ]
+        )
+
+    monkeypatch.setattr("matheel.comparison_suite.get_sim_list", fake_get_sim_list)
+    times = iter([10.0, 10.5, 20.0, 20.5])
+    monkeypatch.setattr("matheel.comparison_suite.perf_counter", lambda: next(times))
+    cache_dir = tmp_path / "cache"
+
+    first_summary, _ = run_comparison_suite(
+        "codes.zip",
+        [{"run_name": "baseline", "feature_weights": {"levenshtein": 1.0}, "threshold": 0.4}],
+        cache_dir=cache_dir,
+    )
+    second_summary, _ = run_comparison_suite(
+        "codes.zip",
+        [{"run_name": "baseline", "feature_weights": {"levenshtein": 1.0}, "threshold": 0.6}],
+        cache_dir=cache_dir,
+    )
+
+    assert calls["count"] == 2
+    assert first_summary.loc[0, "cache_key"] != second_summary.loc[0, "cache_key"]
+
+
+def test_run_comparison_suite_cache_can_be_disabled(tmp_path, monkeypatch):
+    calls = {"count": 0}
+
+    def fake_get_sim_list(zipped_file, **kwargs):
+        calls["count"] += 1
+        return pd.DataFrame(
+            [
+                {"file_name_1": "a.py", "file_name_2": "b.py", "similarity_score": 0.8},
+            ]
+        )
+
+    monkeypatch.setattr("matheel.comparison_suite.get_sim_list", fake_get_sim_list)
+    times = iter([10.0, 10.5, 20.0, 20.5])
+    monkeypatch.setattr("matheel.comparison_suite.perf_counter", lambda: next(times))
+    run_configs = [{"run_name": "baseline", "feature_weights": {"levenshtein": 1.0}}]
+
+    first_summary, _ = run_comparison_suite(
+        "codes.zip",
+        run_configs,
+        cache_dir=tmp_path / "cache",
+        use_cache=False,
+    )
+    second_summary, _ = run_comparison_suite(
+        "codes.zip",
+        run_configs,
+        cache_dir=tmp_path / "cache",
+        use_cache=False,
+    )
+
+    assert calls["count"] == 2
+    assert first_summary.loc[0, "cache_status"] == "disabled"
+    assert second_summary.loc[0, "cache_status"] == "disabled"
+
+
 def test_run_comparison_suite_marks_backend_inactive_without_semantic_feature(monkeypatch):
     def fake_get_sim_list(zipped_file, **kwargs):
         _ = (zipped_file, kwargs)


### PR DESCRIPTION
Summary:
- Add deterministic benchmark cache key and local filesystem storage APIs.
- Include source fingerprints, normalized run configs, dependency versions, optional cache seed, and custom algorithm source fingerprints in cache keys.
- Integrate cache hits and misses into comparison-suite runs and summary metadata.
- Add compare-suite CLI cache options and documentation.

Verification:
- python -m pytest tests/test_benchmark_cache.py tests/test_comparison_suite.py tests/test_cli.py
- python -m ruff check .
- python -m mkdocs build --strict
- python -m pytest
- git diff --check

Closes #157.