### PR TITLE
Add benchmark dataset and algorithm cards

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -57,6 +57,8 @@ Artifacts:
 - `run_001.html`: static aggregate and per-dataset tables.
 - `run_001_reproducibility.json`: package versions and normalized manifest metadata.
 
+The JSON artifact also includes dataset cards and algorithm cards. Cards keep concise metadata such as task family, counts, source type, license when present, sanitized source identifiers, algorithm options, package versions, and content fingerprints. Local absolute paths and credential-like fields are not included in card fields.
+
 ## Python
 
 ```python

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -25,6 +25,12 @@ from .benchmark_cache import (
     load_benchmark_cache_result,
     write_benchmark_cache_result,
 )
+from .benchmark_cards import (
+    algorithm_card,
+    card_markdown,
+    dataset_card,
+    leaderboard_cards,
+)
 from .chunking import chunk_text, chunker_parameter_names
 from .calibration import (
     calibrate_threshold,
@@ -170,6 +176,7 @@ __all__ = [
     "available_runtime_devices",
     "available_similarity_functions",
     "available_vector_backends",
+    "algorithm_card",
     "attach_algorithm_metadata",
     "benchmark_cache_key",
     "benchmark_cache_key_for_run",
@@ -179,6 +186,7 @@ __all__ = [
     "calibration_curve",
     "calibration_report",
     "calibration_report_payload",
+    "card_markdown",
     "calculate_similarity",
     "chunk_text",
     "chunker_parameter_names",
@@ -189,6 +197,7 @@ __all__ = [
     "DataSplit",
     "adapt_pair_dataset",
     "adapt_retrieval_dataset",
+    "dataset_card",
     "dataset_preset_task_families",
     "default_feature_weights",
     "evaluate_threshold",
@@ -204,6 +213,7 @@ __all__ = [
     "infer_model_backend",
     "infer_model_capabilities",
     "inspect_model_settings",
+    "leaderboard_cards",
     "leaderboard_html",
     "leaderboard_payload",
     "load_code_texts",

--- a/matheel/benchmark_cards.py
+++ b/matheel/benchmark_cards.py
@@ -1,0 +1,171 @@
+import json
+from pathlib import Path
+
+from .algorithms import normalize_algorithm_options, resolve_pair_algorithm
+from .datasets import PairDataset, RetrievalDataset, load_pair_dataset, load_retrieval_dataset
+from .reproducibility import fingerprint_source
+
+
+CARD_SCHEMA_VERSION = 1
+_PATH_KEYS = {"identifier", "algorithm_path", "path", "destination", "adapted_destination"}
+_CREDENTIAL_KEYS = {
+    "access_token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "password",
+    "secret",
+    "token",
+}
+
+
+def dataset_card(dataset, name=None, task_family=None, source_spec=None):
+    loaded = _load_card_dataset(dataset, task_family=task_family)
+    metadata = dict(getattr(loaded, "metadata", {}) or {})
+    resolved_task_family = task_family or ("retrieval" if isinstance(loaded, RetrievalDataset) else "pair")
+    return {
+        "schema_version": CARD_SCHEMA_VERSION,
+        "card_type": "dataset",
+        "name": str(name or metadata.get("name") or loaded.root.name),
+        "task_family": resolved_task_family,
+        "dataset_kind": str(metadata.get("dataset_kind") or _dataset_kind_from_task(resolved_task_family)),
+        "task_type": str(metadata.get("task_type") or "plagiarism"),
+        "license": str(metadata.get("license") or "unknown"),
+        "source_url": str(metadata.get("source_url") or metadata.get("url") or ""),
+        "counts": _dataset_counts(loaded),
+        "fingerprint": fingerprint_source(loaded.root),
+        "metadata": _sanitize_mapping(metadata),
+        "source": _sanitize_mapping(source_spec or {}),
+    }
+
+
+def algorithm_card(config, name=None):
+    payload = dict(config or {})
+    options = dict(payload.get("options") or payload.get("similarity_options") or {})
+    algorithm_path = payload.get("algorithm_path") or options.pop("algorithm_path", None)
+    algorithm_options = normalize_algorithm_options(payload.get("algorithm_options") or options.pop("algorithm_options", None))
+    for key, value in payload.items():
+        if key not in {"name", "options", "similarity_options", "algorithm_path", "algorithm_options"}:
+            options[key] = value
+    card = {
+        "schema_version": CARD_SCHEMA_VERSION,
+        "card_type": "algorithm",
+        "name": str(name or payload.get("name") or _algorithm_name_from_path(algorithm_path) or "matheel"),
+        "algorithm_kind": "custom" if algorithm_path else "builtin",
+        "algorithm_path_name": Path(str(algorithm_path)).name if algorithm_path else "",
+        "algorithm_options": _sanitize_mapping(algorithm_options),
+        "similarity_options": _sanitize_mapping(options),
+        "fingerprint": {},
+        "package": "",
+        "package_version": "",
+    }
+    if algorithm_path:
+        card.update(_custom_algorithm_card_fields(algorithm_path))
+    return card
+
+
+def leaderboard_cards(manifest):
+    return {
+        "datasets": [
+            dataset_card(
+                dataset["spec"],
+                name=dataset.get("name"),
+                task_family=dataset.get("task_family"),
+                source_spec=dataset.get("spec"),
+            )
+            for dataset in manifest.get("datasets", [])
+        ],
+        "algorithms": [
+            algorithm_card(algorithm, name=algorithm.get("name"))
+            for algorithm in manifest.get("algorithms", [])
+        ],
+    }
+
+
+def card_markdown(card):
+    title = f"{card.get('card_type', 'card').title()}: {card.get('name', 'unknown')}"
+    lines = [f"# {title}", ""]
+    for key, value in card.items():
+        if key in {"schema_version", "card_type", "name"}:
+            continue
+        lines.append(f"- `{key}`: {json.dumps(value, sort_keys=True)}")
+    return "\n".join(lines) + "\n"
+
+
+def _load_card_dataset(dataset, task_family=None):
+    if isinstance(dataset, (PairDataset, RetrievalDataset)):
+        return dataset
+    task = task_family
+    if task is None and isinstance(dataset, dict):
+        task_families = dataset.get("task_families") or ()
+        task = next(iter(task_families), None)
+    if task == "retrieval":
+        return load_retrieval_dataset(_dataset_identifier(dataset))
+    return load_pair_dataset(_dataset_identifier(dataset))
+
+
+def _dataset_identifier(dataset):
+    if isinstance(dataset, dict):
+        return dataset.get("identifier")
+    return dataset
+
+
+def _dataset_counts(dataset):
+    if isinstance(dataset, RetrievalDataset):
+        return {
+            "files": int(len(dataset.files)),
+            "queries": int(len(dataset.queries)),
+            "documents": int(len(dataset.corpus)),
+            "qrels": int(len(dataset.qrels)),
+        }
+    return {
+        "files": int(len(dataset.files)),
+        "pairs": int(len(dataset.pairs)),
+        "positive_pairs": int(dataset.pairs["label"].sum()) if "label" in dataset.pairs else 0,
+    }
+
+
+def _dataset_kind_from_task(task_family):
+    return "retrieval" if task_family == "retrieval" else "pair_classification"
+
+
+def _algorithm_name_from_path(algorithm_path):
+    if not algorithm_path:
+        return None
+    return Path(str(algorithm_path)).stem
+
+
+def _custom_algorithm_card_fields(algorithm_path):
+    try:
+        resolved = resolve_pair_algorithm(algorithm_path)
+    except Exception:
+        return {
+            "fingerprint": {"source_type": "unresolved", "file_name": Path(str(algorithm_path)).name},
+        }
+    return {
+        "resolved_algorithm_name": resolved.name,
+        "package": resolved.package_name or "",
+        "package_version": resolved.package_version or "",
+        "fingerprint": dict(resolved.source_fingerprint or {}),
+    }
+
+
+def _sanitize_mapping(values):
+    sanitized = {}
+    for key, value in dict(values or {}).items():
+        name = str(key)
+        lowered = name.lower()
+        if lowered in _CREDENTIAL_KEYS:
+            sanitized[name] = "<redacted>"
+        elif lowered in _PATH_KEYS and isinstance(value, (str, Path)):
+            sanitized[name] = Path(value).name
+        elif isinstance(value, dict):
+            sanitized[name] = _sanitize_mapping(value)
+        elif isinstance(value, (list, tuple)):
+            sanitized[name] = [
+                _sanitize_mapping(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            sanitized[name] = value
+    return sanitized

--- a/matheel/leaderboard.py
+++ b/matheel/leaderboard.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from .algorithms import normalize_algorithm_options
+from .benchmark_cards import leaderboard_cards
 from .calibration import calibration_report
 from .datasets import load_pair_datasets, load_retrieval_datasets
 from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
@@ -101,6 +102,7 @@ def run_leaderboard(manifest, output_dir=None, basename="leaderboard"):
             "retrieval_metrics": list(config["retrieval_metrics"]),
         },
         "manifest": config,
+        "cards": leaderboard_cards(config),
         "per_dataset": per_dataset,
         "aggregate": aggregate,
     }
@@ -115,6 +117,7 @@ def leaderboard_payload(report):
         "schema_version": 1,
         "metadata": _json_safe(report.get("metadata", {})),
         "manifest": _json_safe(report.get("manifest", {})),
+        "cards": _json_safe(report.get("cards", {})),
         "per_dataset": _frame_records(report["per_dataset"]),
         "aggregate": _frame_records(report["aggregate"]),
     }
@@ -125,6 +128,8 @@ def leaderboard_html(report, title="Matheel Leaderboard"):
     escaped_title = html.escape(str(title))
     aggregate = pd.DataFrame(payload["aggregate"])
     per_dataset = pd.DataFrame(payload["per_dataset"])
+    dataset_count = len(payload.get("cards", {}).get("datasets", []))
+    algorithm_count = len(payload.get("cards", {}).get("algorithms", []))
     aggregate_html = aggregate.to_html(index=False, escape=True) if not aggregate.empty else "<p>No aggregate rows.</p>"
     per_dataset_html = per_dataset.to_html(index=False, escape=True) if not per_dataset.empty else "<p>No dataset rows.</p>"
     return f"""<!doctype html>
@@ -143,6 +148,7 @@ def leaderboard_html(report, title="Matheel Leaderboard"):
 </head>
 <body>
   <h1>{escaped_title}</h1>
+  <p>{dataset_count} dataset card(s), {algorithm_count} algorithm card(s)</p>
   <h2>Aggregate</h2>
   {aggregate_html}
   <h2>Per Dataset</h2>

--- a/tests/test_benchmark_cards.py
+++ b/tests/test_benchmark_cards.py
@@ -1,0 +1,106 @@
+import json
+
+import pandas as pd
+
+import matheel
+from matheel.benchmark_cards import (
+    algorithm_card,
+    card_markdown,
+    dataset_card,
+    leaderboard_cards,
+)
+from matheel.datasets import write_pair_dataset
+
+
+def test_benchmark_card_helpers_are_exported_from_package_root():
+    assert matheel.algorithm_card is algorithm_card
+    assert matheel.card_markdown is card_markdown
+    assert matheel.dataset_card is dataset_card
+    assert matheel.leaderboard_cards is leaderboard_cards
+
+
+def test_dataset_card_uses_metadata_counts_and_fingerprint(tmp_path):
+    dataset_root = _write_pair_fixture(tmp_path)
+
+    card = dataset_card(dataset_root, source_spec={"identifier": str(dataset_root), "token": "secret"})
+
+    assert card["card_type"] == "dataset"
+    assert card["name"] == "tiny_pairs"
+    assert card["task_family"] == "pair"
+    assert card["dataset_kind"] == "pair_classification"
+    assert card["counts"]["pairs"] == 1
+    assert card["fingerprint"]["sha256"]
+    assert card["source"]["identifier"] == "pairs"
+    assert card["source"]["token"] == "<redacted>"
+    assert str(tmp_path) not in json.dumps(card)
+
+
+def test_algorithm_card_sanitizes_paths_and_fingerprints_custom_algorithm(tmp_path):
+    algorithm_path = tmp_path / "custom_algo.py"
+    algorithm_path.write_text("def score_pair(code_a, code_b):\n    return 1.0\n", encoding="utf-8")
+
+    card = algorithm_card(
+        {
+            "name": "custom",
+            "algorithm_path": str(algorithm_path),
+            "algorithm_options": {"bias": 0.1},
+            "similarity_options": {"preprocess_mode": "basic"},
+        }
+    )
+
+    assert card["card_type"] == "algorithm"
+    assert card["name"] == "custom"
+    assert card["algorithm_kind"] == "custom"
+    assert card["algorithm_path_name"] == "custom_algo.py"
+    assert card["fingerprint"]["sha256"]
+    assert card["algorithm_options"] == {"bias": 0.1}
+    assert str(tmp_path) not in json.dumps(card)
+
+
+def test_algorithm_card_defaults_for_builtin_config():
+    card = algorithm_card({"name": "levenshtein", "feature_weights": {"levenshtein": 1.0}})
+
+    assert card["algorithm_kind"] == "builtin"
+    assert card["algorithm_path_name"] == ""
+    assert card["similarity_options"]["feature_weights"] == {"levenshtein": 1.0}
+    assert card["fingerprint"] == {}
+
+
+def test_leaderboard_cards_and_markdown(tmp_path):
+    dataset_root = _write_pair_fixture(tmp_path)
+    algorithm_path = tmp_path / "custom_algo.py"
+    algorithm_path.write_text("def score_pair(code_a, code_b):\n    return 1.0\n", encoding="utf-8")
+    cards = leaderboard_cards(
+        {
+            "datasets": [
+                {
+                    "name": "pairs",
+                    "task_family": "pair",
+                    "spec": {"identifier": str(dataset_root), "task_families": ("pair",)},
+                }
+            ],
+            "algorithms": [
+                {"name": "custom", "algorithm_path": str(algorithm_path), "similarity_options": {}}
+            ],
+        }
+    )
+
+    assert cards["datasets"][0]["name"] == "pairs"
+    assert cards["algorithms"][0]["name"] == "custom"
+    assert "# Dataset: pairs" in card_markdown(cards["datasets"][0])
+
+
+def _write_pair_fixture(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(1)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+        metadata={"name": "tiny_pairs", "license": "synthetic"},
+    )
+    return dataset_root

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -54,6 +54,9 @@ def test_leaderboard_runs_pair_and_retrieval_datasets(tmp_path):
     assert artifacts["json"].exists()
     assert artifacts["html"].exists()
     assert artifacts["reproducibility_json"].exists()
+    payload = json.loads(artifacts["json"].read_text(encoding="utf-8"))
+    assert payload["cards"]["datasets"][0]["name"] == "pairs"
+    assert payload["cards"]["algorithms"][0]["name"] == "exact"
     per_dataset = report["per_dataset"]
     aggregate = report["aggregate"]
     pair_f1 = per_dataset[


### PR DESCRIPTION
Summary:
- Add dataset and algorithm card helpers with sanitized public fields.
- Include counts, fingerprints, metadata defaults, algorithm options, and custom algorithm source fingerprints.
- Embed cards in leaderboard JSON and basic HTML artifacts.
- Document leaderboard card contents and add tests for sanitization and defaults.

Verification:
- python -m pytest tests/test_benchmark_cards.py tests/test_leaderboard.py
- python -m ruff check .
- python -m mkdocs build --strict
- python -m pytest
- git diff --check

Closes #155.
Refs #159, #158.