### PR TITLE
Add static benchmark report writer

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -59,16 +59,21 @@ Artifacts:
 
 The JSON artifact also includes dataset cards and algorithm cards. Cards keep concise metadata such as task family, counts, source type, license when present, sanitized source identifiers, algorithm options, package versions, and content fingerprints. Local absolute paths and credential-like fields are not included in card fields.
 
+The HTML artifact is a static benchmark report. It bundles aggregate rankings, per-dataset rankings, dataset cards, algorithm cards, and sanitized links to the exported CSV/JSON metadata files.
+
 ## Python
 
 ```python
 from matheel.leaderboard import load_leaderboard_manifest, run_leaderboard
+from matheel.reports import write_benchmark_report
 
 manifest = load_leaderboard_manifest("leaderboard.json")
 report, artifacts = run_leaderboard(
     manifest,
     output_dir="leaderboard_artifacts",
 )
+
+write_benchmark_report(report, "leaderboard_artifacts/leaderboard_report.html")
 
 print(report["aggregate"])
 print(artifacts["json"])

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -122,6 +122,7 @@ from .reproducibility import (
     fingerprint_source,
     write_reproducibility_snapshot,
 )
+from .reports import benchmark_report_html, write_benchmark_report
 from .vectors import (
     available_pooling_methods,
     available_similarity_functions,
@@ -182,6 +183,7 @@ __all__ = [
     "benchmark_cache_key_for_run",
     "benchmark_cache_paths",
     "benchmark_dependency_versions",
+    "benchmark_report_html",
     "calibrate_threshold",
     "calibration_curve",
     "calibration_report",
@@ -285,6 +287,7 @@ __all__ = [
     "write_dataset_map_artifacts",
     "write_calibration_report_artifacts",
     "write_benchmark_cache_result",
+    "write_benchmark_report",
     "write_leaderboard_artifacts",
     "write_pair_dataset_explanation",
     "write_pair_explanation",

--- a/matheel/leaderboard.py
+++ b/matheel/leaderboard.py
@@ -172,8 +172,18 @@ def write_leaderboard_artifacts(report, output_dir, basename="leaderboard"):
     report["per_dataset"].to_csv(artifacts["per_dataset_csv"], index=False)
     report["aggregate"].to_csv(artifacts["aggregate_csv"], index=False)
     artifacts["json"].write_text(json.dumps(leaderboard_payload(report), indent=2, sort_keys=True), encoding="utf-8")
+    from .reports import benchmark_report_html
+
     artifacts["html"].write_text(
-        leaderboard_html(report, title=str(report["metadata"].get("name") or "Matheel Leaderboard")),
+        benchmark_report_html(
+            report,
+            title=str(report["metadata"].get("name") or "Matheel Leaderboard"),
+            artifact_links={
+                name: path
+                for name, path in artifacts.items()
+                if name != "html"
+            },
+        ),
         encoding="utf-8",
     )
     snapshot = collect_reproducibility_snapshot(run_configs=[report.get("manifest", {})])

--- a/matheel/reports.py
+++ b/matheel/reports.py
@@ -1,0 +1,140 @@
+import html
+from pathlib import Path
+
+import pandas as pd
+
+from .leaderboard import leaderboard_payload
+
+
+def benchmark_report_html(report, title=None, artifact_links=None):
+    payload = leaderboard_payload(report)
+    report_title = str(title or payload["metadata"].get("name") or "Matheel Benchmark Report")
+    aggregate = pd.DataFrame(payload["aggregate"])
+    per_dataset = pd.DataFrame(payload["per_dataset"])
+    cards = payload.get("cards", {})
+    links = _sanitize_artifact_links(artifact_links or {})
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{html.escape(report_title)}</title>
+  <style>
+    :root {{ color-scheme: light; }}
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #111827; background: #ffffff; }}
+    header {{ padding: 24px 28px; border-bottom: 1px solid #d1d5db; background: #f9fafb; }}
+    main {{ padding: 20px 28px 32px; }}
+    h1 {{ font-size: 1.6rem; margin: 0 0 8px; }}
+    h2 {{ font-size: 1.15rem; margin: 28px 0 10px; }}
+    h3 {{ font-size: 1rem; margin: 16px 0 6px; }}
+    .meta {{ color: #4b5563; margin: 0; }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; }}
+    .card {{ border: 1px solid #d1d5db; border-radius: 8px; padding: 12px; background: #ffffff; }}
+    .card dl {{ display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 5px 10px; margin: 0; }}
+    dt {{ color: #4b5563; font-weight: 600; }}
+    dd {{ margin: 0; overflow-wrap: anywhere; }}
+    table {{ border-collapse: collapse; width: 100%; font-size: 0.9rem; margin-bottom: 12px; }}
+    th, td {{ border: 1px solid #e5e7eb; padding: 6px 8px; text-align: left; }}
+    th {{ background: #f3f4f6; }}
+    .links ul {{ margin: 0; padding-left: 18px; }}
+    code {{ background: #f3f4f6; padding: 1px 4px; border-radius: 4px; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{html.escape(report_title)}</h1>
+    <p class="meta">schema={payload.get("schema_version", 1)}; seed={html.escape(str(payload["metadata"].get("seed") or ""))}</p>
+  </header>
+  <main>
+    <section>
+      <h2>Aggregate Ranking</h2>
+      {_table_html(aggregate)}
+    </section>
+    <section>
+      <h2>Per-Dataset Ranking</h2>
+      {_table_html(per_dataset)}
+    </section>
+    <section>
+      <h2>Dataset Cards</h2>
+      <div class="grid">{_cards_html(cards.get("datasets", []))}</div>
+    </section>
+    <section>
+      <h2>Algorithm Cards</h2>
+      <div class="grid">{_cards_html(cards.get("algorithms", []))}</div>
+    </section>
+    <section class="links">
+      <h2>Artifacts</h2>
+      {_artifact_links_html(links)}
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def write_benchmark_report(report, output_path, title=None, artifact_links=None):
+    target = Path(output_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        benchmark_report_html(report, title=title, artifact_links=artifact_links),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _table_html(frame):
+    if frame.empty:
+        return "<p>No rows.</p>"
+    return frame.to_html(index=False, escape=True)
+
+
+def _cards_html(cards):
+    if not cards:
+        return '<p class="card">No cards.</p>'
+    return "\n".join(_card_html(card) for card in cards)
+
+
+def _card_html(card):
+    rows = []
+    for key in (
+        "name",
+        "card_type",
+        "task_family",
+        "dataset_kind",
+        "algorithm_kind",
+        "license",
+        "package",
+        "package_version",
+    ):
+        value = card.get(key)
+        if value not in (None, ""):
+            rows.append(f"<dt>{html.escape(key)}</dt><dd>{html.escape(str(value))}</dd>")
+    fingerprint = card.get("fingerprint") or {}
+    sha = fingerprint.get("sha256")
+    if sha:
+        rows.append(f"<dt>sha256</dt><dd><code>{html.escape(str(sha))}</code></dd>")
+    counts = card.get("counts") or {}
+    if counts:
+        count_text = ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
+        rows.append(f"<dt>counts</dt><dd>{html.escape(count_text)}</dd>")
+    if not rows:
+        rows.append("<dt>card</dt><dd>empty</dd>")
+    return f'<article class="card"><dl>{"".join(rows)}</dl></article>'
+
+
+def _artifact_links_html(links):
+    if not links:
+        return "<p>No linked artifacts.</p>"
+    items = "\n".join(
+        f"<li>{html.escape(str(name))}: <code>{html.escape(str(path))}</code></li>"
+        for name, path in sorted(links.items())
+    )
+    return f"<ul>{items}</ul>"
+
+
+def _sanitize_artifact_links(links):
+    sanitized = {}
+    for name, value in dict(links).items():
+        if value in (None, ""):
+            continue
+        sanitized[str(name)] = Path(str(value)).name
+    return sanitized

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,93 @@
+import pandas as pd
+
+import matheel
+from matheel.reports import benchmark_report_html, write_benchmark_report
+
+
+def test_report_helpers_are_exported_from_package_root():
+    assert matheel.benchmark_report_html is benchmark_report_html
+    assert matheel.write_benchmark_report is write_benchmark_report
+
+
+def test_benchmark_report_html_escapes_content_and_sanitizes_links(tmp_path):
+    report = _synthetic_report()
+    output = benchmark_report_html(
+        report,
+        title="<unsafe>",
+        artifact_links={"dataset_map": tmp_path / "nested" / "map.html"},
+    )
+
+    assert "<unsafe>" not in output
+    assert "&lt;unsafe&gt;" in output
+    assert "<dataset>" not in output
+    assert "&lt;dataset&gt;" in output
+    assert "<algorithm>" not in output
+    assert str(tmp_path) not in output
+    assert "map.html" in output
+    assert "Aggregate Ranking" in output
+    assert "Dataset Cards" in output
+    assert "Algorithm Cards" in output
+
+
+def test_write_benchmark_report_writes_static_html(tmp_path):
+    output_path = tmp_path / "reports" / "leaderboard.html"
+
+    written = write_benchmark_report(_synthetic_report(), output_path)
+
+    assert written == output_path
+    text = output_path.read_text(encoding="utf-8")
+    assert text.startswith("<!doctype html>")
+    assert "Per-Dataset Ranking" in text
+
+
+def _synthetic_report():
+    return {
+        "metadata": {"name": "<benchmark>", "seed": 7},
+        "manifest": {"name": "<benchmark>"},
+        "cards": {
+            "datasets": [
+                {
+                    "card_type": "dataset",
+                    "name": "<dataset>",
+                    "task_family": "pair",
+                    "dataset_kind": "pair_classification",
+                    "license": "synthetic",
+                    "counts": {"pairs": 2},
+                    "fingerprint": {"sha256": "a" * 64},
+                    "source": {"identifier": "pairs"},
+                }
+            ],
+            "algorithms": [
+                {
+                    "card_type": "algorithm",
+                    "name": "<algorithm>",
+                    "algorithm_kind": "custom",
+                    "algorithm_path_name": "algo.py",
+                    "fingerprint": {"sha256": "b" * 64},
+                }
+            ],
+        },
+        "aggregate": pd.DataFrame(
+            [
+                {
+                    "task_family": "pair",
+                    "algorithm_name": "<algorithm>",
+                    "metric": "f1",
+                    "mean_score": 1.0,
+                    "rank": 1,
+                }
+            ]
+        ),
+        "per_dataset": pd.DataFrame(
+            [
+                {
+                    "task_family": "pair",
+                    "dataset_name": "<dataset>",
+                    "algorithm_name": "<algorithm>",
+                    "metric": "f1",
+                    "score": 1.0,
+                    "rank": 1,
+                }
+            ]
+        ),
+    }


### PR DESCRIPTION
Summary:
- Add self-contained static benchmark report HTML generation.
- Render aggregate rankings, per-dataset rankings, dataset cards, algorithm cards, and sanitized artifact links.
- Integrate the report writer into leaderboard HTML artifacts.
- Add docs and tests for escaping and local path sanitization.

Verification:
- python -m pytest tests/test_reports.py tests/test_leaderboard.py
- python -m ruff check .
- python -m mkdocs build --strict
- python -m pytest
- git diff --check

Closes #159.
Refs #158.