### PR TITLE
Preserve metadata in dataset maps

### DIFF
--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -50,6 +50,26 @@ print(artifacts["html"])
 
 Projection metadata is stored in `projection.attrs`, including the requested method, actual method, seed, dataset kind, dataset name, and embedding source.
 
+Dataset maps preserve normalized `files.csv` metadata except raw code text, and Python callers can merge extra per-document metadata keyed by `document_id`. Use this for color columns such as split, cluster, label, metric score, or algorithm family:
+
+```python
+projection = build_dataset_embedding_map(
+    "./normalized_pairs",
+    kind="pair",
+    method="pca",
+    document_metadata=[
+        {"document_id": "a", "metric_score": 0.91, "algorithm": "baseline"},
+        {"document_id": "b", "metric_score": 0.88, "algorithm": "baseline"},
+    ],
+)
+
+artifacts = write_dataset_map_artifacts(
+    projection,
+    "visualization_artifacts",
+    color_column="metric_score",
+)
+```
+
 ## Pair Explanations
 
 Pair explanations export side-by-side HTML and machine-readable JSON for a selected code pair. Matheel segments each submission by line, token, or fixed-size line chunks, then marks non-overlapping local matches as high, medium, low, or no match.

--- a/matheel/visualization.py
+++ b/matheel/visualization.py
@@ -79,7 +79,14 @@ def build_embedding_projection(embeddings, ids=None, metadata=None, method="auto
     return projection
 
 
-def build_dataset_embedding_map(dataset, kind="auto", method="auto", seed=7, static_vector_dim=256):
+def build_dataset_embedding_map(
+    dataset,
+    kind="auto",
+    method="auto",
+    seed=7,
+    static_vector_dim=256,
+    document_metadata=None,
+):
     loaded, dataset_kind = _load_visualization_dataset(dataset, kind=kind)
     texts = load_code_texts(loaded)
     document_ids = tuple(sorted(texts))
@@ -88,7 +95,12 @@ def build_dataset_embedding_map(dataset, kind="auto", method="auto", seed=7, sta
         dim=int(static_vector_dim),
         lowercase=True,
     )
-    metadata = _dataset_document_metadata(loaded, dataset_kind, document_ids)
+    metadata = _dataset_document_metadata(
+        loaded,
+        dataset_kind,
+        document_ids,
+        document_metadata=document_metadata,
+    )
     projection = build_embedding_projection(
         vectors,
         ids=document_ids,
@@ -177,13 +189,22 @@ def write_dataset_map_artifacts(projection, output_dir, basename="dataset_map", 
     return {"csv": csv_path, "json": json_path, "html": html_path}
 
 
-def write_dataset_embedding_map(dataset, output_dir, kind="auto", method="auto", seed=7, static_vector_dim=256):
+def write_dataset_embedding_map(
+    dataset,
+    output_dir,
+    kind="auto",
+    method="auto",
+    seed=7,
+    static_vector_dim=256,
+    document_metadata=None,
+):
     projection = build_dataset_embedding_map(
         dataset,
         kind=kind,
         method=method,
         seed=seed,
         static_vector_dim=static_vector_dim,
+        document_metadata=document_metadata,
     )
     artifacts = write_dataset_map_artifacts(
         projection,
@@ -783,7 +804,7 @@ def _load_visualization_dataset(dataset, kind="auto"):
     raise ValueError("Could not detect dataset kind. Use kind='pair' or kind='retrieval'.")
 
 
-def _dataset_document_metadata(dataset, dataset_kind, document_ids):
+def _dataset_document_metadata(dataset, dataset_kind, document_ids, document_metadata=None):
     files = dataset.files.copy()
     files["document_id"] = files["file_id"].astype(str)
     selected = files[files["document_id"].isin(document_ids)].copy()
@@ -794,8 +815,58 @@ def _dataset_document_metadata(dataset, dataset_kind, document_ids):
         selected["role"] = "submission"
         pair_counts = _pair_file_counts(dataset)
         selected["pair_count"] = selected["document_id"].map(pair_counts).fillna(0).astype(int)
-    metadata_columns = [column for column in ("document_id", "file_path", "role", "pair_count") if column in selected.columns]
-    return selected[metadata_columns].to_dict(orient="records")
+    excluded_columns = {"file_id", "text"}
+    metadata_columns = [
+        "document_id",
+        *[
+            column
+            for column in selected.columns
+            if column != "document_id" and column not in excluded_columns
+        ],
+    ]
+    records = selected[metadata_columns].to_dict(orient="records")
+    return _merge_document_metadata(records, document_metadata)
+
+
+def _merge_document_metadata(records, document_metadata):
+    if document_metadata is None:
+        return records
+    base = pd.DataFrame(records)
+    extra = _coerce_document_metadata(document_metadata)
+    if "document_id" not in extra.columns:
+        raise ValueError("document_metadata must include a document_id column.")
+    extra = extra.copy()
+    extra["document_id"] = extra["document_id"].astype(str)
+    override_columns = [
+        column
+        for column in extra.columns
+        if column != "document_id" and column in base.columns
+    ]
+    if override_columns:
+        base = base.drop(columns=override_columns)
+    merged = base.merge(extra, on="document_id", how="left")
+    return merged.to_dict(orient="records")
+
+
+def _coerce_document_metadata(document_metadata):
+    if isinstance(document_metadata, pd.DataFrame):
+        return document_metadata.copy()
+    if isinstance(document_metadata, dict):
+        if "document_id" in document_metadata:
+            try:
+                return pd.DataFrame(document_metadata)
+            except ValueError:
+                return pd.DataFrame([document_metadata])
+        rows = []
+        for document_id, value in document_metadata.items():
+            row = {"document_id": document_id}
+            if isinstance(value, dict):
+                row.update(value)
+            else:
+                row["value"] = value
+            rows.append(row)
+        return pd.DataFrame(rows)
+    return pd.DataFrame(document_metadata)
 
 
 def _pair_file_counts(dataset):

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -596,9 +596,9 @@ def test_gradio_dataset_map_exports_visualization_artifacts(tmp_path):
         dataset_root,
         files=pd.DataFrame(
             [
-                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
-                {"file_id": "b", "text": "print(1)", "suffix": ".py"},
-                {"file_id": "c", "text": "print(2)", "suffix": ".py"},
+                {"file_id": "a", "text": "print(1)", "suffix": ".py", "split": "train"},
+                {"file_id": "b", "text": "print(1)", "suffix": ".py", "split": "train"},
+                {"file_id": "c", "text": "print(2)", "suffix": ".py", "split": "test"},
             ]
         ),
         pairs=pd.DataFrame(
@@ -617,14 +617,17 @@ def test_gradio_dataset_map_exports_visualization_artifacts(tmp_path):
         "pca",
         7,
         32,
-        "role",
+        "split",
         progress=None,
     )
 
     assert "Dataset Map" in summary_html
     assert "tiny_map_pairs" in summary_html
     assert "document_id" in points_frame.columns
+    assert "split" in points_frame.columns
     assert len(points_frame) == 3
+    assert "train" in map_html
+    assert "test" in map_html
     assert "<svg" in map_html
 
     with zipfile.ZipFile(artifacts_path) as archive:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -108,6 +108,71 @@ def test_dataset_embedding_map_writes_pair_artifacts(tmp_path):
     assert "tiny_pairs" in artifacts["html"].read_text(encoding="utf-8")
 
 
+def test_dataset_embedding_map_preserves_file_and_extra_metadata(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {
+                    "file_id": "a",
+                    "text": "print(1)",
+                    "suffix": ".py",
+                    "split": "train",
+                    "cluster": "alpha",
+                },
+                {
+                    "file_id": "b",
+                    "text": "print(1)",
+                    "suffix": ".py",
+                    "split": "train",
+                    "cluster": "alpha",
+                },
+                {
+                    "file_id": "c",
+                    "text": "print(2)",
+                    "suffix": ".py",
+                    "split": "test",
+                    "cluster": "beta",
+                },
+            ]
+        ),
+        pairs=pd.DataFrame(
+            [
+                {"left_id": "a", "right_id": "b", "label": 1},
+                {"left_id": "a", "right_id": "c", "label": 0},
+            ]
+        ),
+        metadata={"name": "metadata_pairs"},
+    )
+
+    projection = build_dataset_embedding_map(
+        dataset_root,
+        kind="pair",
+        method="pca",
+        document_metadata=pd.DataFrame(
+            [
+                {"document_id": "a", "metric_score": 0.95, "algorithm": "exact"},
+                {"document_id": "b", "metric_score": 0.9, "algorithm": "exact"},
+                {"document_id": "c", "metric_score": 0.2, "algorithm": "baseline"},
+            ]
+        ),
+    )
+
+    by_id = projection.set_index("document_id")
+    assert by_id.loc["a", "split"] == "train"
+    assert by_id.loc["c", "cluster"] == "beta"
+    assert by_id.loc["a", "metric_score"] == 0.95
+    assert by_id.loc["c", "algorithm"] == "baseline"
+
+    split_html = dataset_map_html(projection, color_column="split")
+    score_payload = dataset_map_payload(projection)
+
+    assert "train" in split_html
+    assert "test" in split_html
+    assert score_payload["points"][0]["metric_score"] == 0.95
+
+
 def test_dataset_embedding_map_marks_retrieval_roles(tmp_path):
     dataset_root = tmp_path / "retrieval"
     write_retrieval_dataset(


### PR DESCRIPTION
## Summary
- preserve normalized file metadata in dataset embedding maps while excluding raw code text
- add optional per-document metadata overlays for split, cluster, label, score, or algorithm coloring
- update visualization docs and Gradio callback coverage for metadata-based map colors

## Tests
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- git diff --check

Closes #151.