### PR TITLE
Release v0.5.2

### DIFF
--- a/examples/notebooks/01_core_workflows.ipynb
+++ b/examples/notebooks/01_core_workflows.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.1\"\n",
+    "MATHEEL_REF = \"v0.5.2\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/02_datasets_and_reproducibility.ipynb
+++ b/examples/notebooks/02_datasets_and_reproducibility.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.1\"\n",
+    "MATHEEL_REF = \"v0.5.2\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/03_custom_algorithms.ipynb
+++ b/examples/notebooks/03_custom_algorithms.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.1\"\n",
+    "MATHEEL_REF = \"v0.5.2\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/04_gradio_app.ipynb
+++ b/examples/notebooks/04_gradio_app.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%%bash\n",
     "set -euo pipefail\n",
-    "MATHEEL_REF=\"v0.5.1\"\n",
+    "MATHEEL_REF=\"v0.5.2\"\n",
     "pip uninstall -y torchvision || true\n",
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",

--- a/examples/notebooks/05_visualization_and_leaderboard.ipynb
+++ b/examples/notebooks/05_visualization_and_leaderboard.ipynb
@@ -20,7 +20,7 @@
         "import sys\n",
         "from pathlib import Path\n",
         "\n",
-        "MATHEEL_REF = \"v0.5.1\"\n",
+        "MATHEEL_REF = \"v0.5.2\"\n",
         "\n",
         "\n",
         "def run(*args, cwd=None):\n",

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.5.1` and includes:
+This Space is aligned with `matheel==0.5.2` and includes:
 
 - Pair, collection, comparison-suite, normalized-dataset, visualization, ready-leaderboard, and leaderboard-inspection workflows
 - Metric presets for balanced, lexical, embedding-only, and code-aware runs

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.5.1
+matheel[all]==0.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.5.1"
+version = "0.5.2"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
## Summary
- bump Matheel package version to 0.5.2
- sync Gradio app package pin and README version reference
- update release-facing notebooks to checkout v0.5.2

## Tests
- python scripts/sync_gradio_app_version.py --check
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- python -m build
- python -m twine check dist artifacts
- jq empty examples/notebooks/01_core_workflows.ipynb examples/notebooks/02_datasets_and_reproducibility.ipynb examples/notebooks/03_custom_algorithms.ipynb examples/notebooks/04_gradio_app.ipynb examples/notebooks/05_visualization_and_leaderboard.ipynb
- git diff --check

Closes #188.