### PR TITLE
Add dataset validation and threshold tuning workflows

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -220,6 +220,32 @@ matheel datasets validate tiny_pairs --format json
 matheel datasets validate tiny_retrieval --kind retrieval
 ```
 
+Add `--output-dir` when you want a structured validation report with JSON, CSV, and HTML artifacts:
+
+```bash
+matheel datasets validate tiny_pairs \
+  --kind pair \
+  --output-dir dataset_validation \
+  --format json
+```
+
+The validation report separates blocking errors from warnings and checks manifests, duplicate ids, missing references, empty files, label coverage, qrel coverage, and basic metadata completeness.
+
+Python usage:
+
+```python
+from matheel.dataset_validation import write_dataset_validation_report
+
+report, artifacts = write_dataset_validation_report(
+    "tiny_pairs",
+    "dataset_validation",
+    kind="pair",
+)
+
+print(report["status"], report["error_count"], report["warning_count"])
+print(artifacts["report_html"])
+```
+
 Use `matheel datasets adapt` to convert a raw local tabular dataset into normalized Matheel manifests. Always provide an explicit output directory so repeated runs write to the same location:
 
 ```bash

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -86,6 +86,42 @@ report = calibrate_threshold(
 
 Use `evaluate_threshold(...)` when you already have a threshold and want confusion counts, precision, recall, F1, and accuracy.
 
+## Threshold Tuning Reports
+
+Use `tune-threshold` for a reproducible threshold sweep over scored pair rows. Unlike the fuller calibration report, this workflow also works for all-positive or all-negative samples and records a warning when ROC or precision-recall summaries are not meaningful.
+
+```bash
+matheel tune-threshold scored_pairs.csv \
+  --score-column similarity_score \
+  --label-column label \
+  --optimize f1 \
+  --output-dir threshold_tuning
+```
+
+The output includes:
+
+- `threshold_tuning_threshold_sweep.csv`: threshold, confusion counts, precision, recall, F1, and accuracy.
+- `threshold_tuning_summary.json`: selected threshold and reproducibility settings.
+- `threshold_tuning_report.json`: machine-readable report payload.
+- `threshold_tuning_report.html`: local HTML summary.
+
+Python usage:
+
+```python
+from matheel.calibration import write_threshold_tuning_report_artifacts
+
+report, artifacts = write_threshold_tuning_report_artifacts(
+    scored_pairs,
+    "threshold_tuning",
+    score_key="similarity_score",
+    label_key="label",
+    optimize="f1",
+)
+
+print(report["summary"]["optimized_threshold"]["threshold"])
+print(artifacts["threshold_sweep_csv"])
+```
+
 ## Calibration Reports
 
 For scored pair CSVs, export a threshold sweep, ROC curve, precision-recall curve, and summary JSON:

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Examples are grouped by workflow:
 
 - `basic/`: preprocessing, chunking, lexical scoring, vectors, code metrics, and archive ranking.
-- `evaluation/`: dataset adapters, comparison suites, calibration reports, dataset maps, pair explanations, leaderboards, and reproducible benchmark outputs.
+- `evaluation/`: dataset adapters, validation reports, threshold tuning, comparison suites, calibration reports, dataset maps, pair explanations, leaderboards, and reproducible benchmark outputs.
 - `custom/`: custom `score_pair` algorithm modules.
 - `notebooks/`: ordered Colab notebooks.
 - `sample_data.py`: deterministic generator for the tiny Java sample archive used by examples and docs.
@@ -25,6 +25,8 @@ Run the local visualization and leaderboard examples when you want generated art
 ```bash
 python examples/evaluation/visualization_demo.py
 python examples/evaluation/leaderboard_demo.py --overwrite
+python examples/evaluation/dataset_validation_demo.py
+python examples/evaluation/threshold_tuning_demo.py
 ```
 
 Generated archives and benchmark outputs are ignored by git.

--- a/examples/evaluation/dataset_validation_demo.py
+++ b/examples/evaluation/dataset_validation_demo.py
@@ -1,0 +1,44 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory, gettempdir
+
+import pandas as pd
+
+_MPLCONFIGDIR = Path(gettempdir()) / "matheel_matplotlib"
+_MPLCONFIGDIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", os.fspath(_MPLCONFIGDIR))
+
+from matheel.dataset_validation import write_dataset_validation_report  # noqa: E402
+from matheel.datasets import write_pair_dataset  # noqa: E402
+
+
+def main():
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        dataset_root = root / "normalized_pairs"
+        write_pair_dataset(
+            dataset_root,
+            files=pd.DataFrame(
+                [
+                    {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                    {"file_id": "b", "text": "print(2)", "suffix": ".py"},
+                ]
+            ),
+            pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 0}]),
+            metadata={"name": "demo_pairs"},
+        )
+
+        report, artifacts = write_dataset_validation_report(
+            dataset_root,
+            root / "validation_report",
+            kind="pair",
+        )
+
+        print("Status:", report["status"])
+        print("Errors:", report["error_count"])
+        print("Warnings:", report["warning_count"])
+        print("HTML report:", artifacts["report_html"])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/evaluation/threshold_tuning_demo.py
+++ b/examples/evaluation/threshold_tuning_demo.py
@@ -1,0 +1,41 @@
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory, gettempdir
+
+import pandas as pd
+
+_MPLCONFIGDIR = Path(gettempdir()) / "matheel_matplotlib"
+_MPLCONFIGDIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("MPLCONFIGDIR", os.fspath(_MPLCONFIGDIR))
+
+from matheel.calibration import write_threshold_tuning_report_artifacts  # noqa: E402
+
+
+def main():
+    scored_pairs = pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.95, "label": 1},
+            {"left_id": "c", "right_id": "d", "similarity_score": 0.82, "label": 1},
+            {"left_id": "e", "right_id": "f", "similarity_score": 0.30, "label": 0},
+            {"left_id": "g", "right_id": "h", "similarity_score": 0.10, "label": 0},
+        ]
+    )
+
+    with TemporaryDirectory() as tmp:
+        output_dir = Path(tmp) / "threshold_tuning"
+        report, artifacts = write_threshold_tuning_report_artifacts(
+            scored_pairs,
+            output_dir,
+            score_key="similarity_score",
+            label_key="label",
+            optimize="f1",
+        )
+
+        best = report["summary"]["optimized_threshold"]
+        print("Best threshold:", best["threshold"])
+        print("Best F1:", round(best["f1"], 4))
+        print("Threshold sweep:", artifacts["threshold_sweep_csv"])
+
+
+if __name__ == "__main__":
+    main()

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -13,9 +13,9 @@ Interactive code-similarity analysis with configurable embedding, lexical, chunk
 
 This Space is aligned with `matheel==0.5.2` and includes:
 
-- Pair, collection, comparison-suite, normalized-dataset, visualization, ready-leaderboard, and leaderboard-inspection workflows
+- Pair, collection, comparison-suite, normalized-dataset, dataset-validation, threshold-tuning, visualization, ready-leaderboard, and leaderboard-inspection workflows
 - Metric presets for balanced, lexical, embedding-only, and code-aware runs
-- Downloadable artifacts for dataset evaluation, dataset maps, pair explanations, ready leaderboards, and leaderboard reports
+- Downloadable artifacts for dataset evaluation, validation reports, threshold sweeps, dataset maps, pair explanations, ready leaderboards, and leaderboard reports
 - Raw and parser-derived lexical tokenization for Winnowing and GST
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST
 - Code metrics: CodeBLEU, CrystalBLEU, RUBY, TSED, CodeBERTScore

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -19,8 +19,10 @@ except ModuleNotFoundError:
     from html_utils import escape_html
 
 from matheel.chunking import available_chunk_aggregations, available_chunking_methods
+from matheel.calibration import write_threshold_tuning_report_artifacts
 from matheel.comparison_suite import run_comparison_suite, slugify_run_name
 from matheel.code_metrics import available_code_metric_languages, available_code_metrics
+from matheel.dataset_validation import write_dataset_validation_report
 from matheel.datasets import (
     available_dataset_presets,
     get_dataset_preset,
@@ -133,6 +135,7 @@ READY_LEADERBOARD_RETRIEVAL_METRICS = (
     "precision_at_k",
     "recall_at_k",
 )
+THRESHOLD_OPTIMIZE_CHOICES = ("f1", "accuracy", "precision", "recall")
 PAIR_DATASET_SCORE_COLUMNS = [
     "left_id",
     "right_id",
@@ -1519,6 +1522,22 @@ def empty_ready_leaderboard_summary_html():
     )
 
 
+def empty_dataset_validation_summary_html():
+    return summary_panel_html(
+        "Dataset Validation",
+        [("Status", "No dataset checked"), ("Artifacts", "None")],
+        variant="empty",
+    )
+
+
+def empty_threshold_tuning_summary_html():
+    return summary_panel_html(
+        "Threshold Tuning",
+        [("Status", "No pair scores available"), ("Artifacts", "None")],
+        variant="empty",
+    )
+
+
 def ready_leaderboard_registered_datasets_frame():
     rows = []
     for preset_name in available_dataset_presets():
@@ -2253,6 +2272,16 @@ def _write_leaderboard_artifacts(
         resample_summary_path = root / f"{prefix}_resampling_summary.csv"
         resample_summary.to_csv(resample_summary_path, index=False)
         files["resampling_summary"] = resample_summary_path.name
+    if prefix == "pair":
+        _, threshold_artifacts = write_threshold_tuning_report_artifacts(
+            scored,
+            root,
+            score_key="similarity_score",
+            label_key="label",
+            basename="pair_threshold_tuning",
+        )
+        for name, path in threshold_artifacts.items():
+            files[f"threshold_{name}"] = Path(path).name
 
     manifest = {
         "schema_version": 1,
@@ -2320,6 +2349,158 @@ def _validate_pair_resampling_folds(scored, folds):
 
 def _validate_retrieval_resampling_folds(query_ids, folds):
     _validate_resampling_fold_count(len(query_ids), folds, "queries")
+
+
+def dataset_validation_summary_html(report):
+    return summary_panel_html(
+        "Dataset Validation",
+        [
+            ("Dataset", str(report.get("dataset_name") or "dataset")),
+            ("Kind", str(report.get("dataset_kind") or "unknown").replace("_", " ")),
+            ("Status", str(report.get("status") or "unknown")),
+            ("Errors", str(report.get("error_count", 0))),
+            ("Warnings", str(report.get("warning_count", 0))),
+        ],
+        variant="error" if report.get("error_count") else "empty" if report.get("warning_count") else "summary",
+    )
+
+
+def dataset_validation_issues_frame(report):
+    issues = list((report or {}).get("issues") or [])
+    if not issues:
+        return pd.DataFrame(columns=["Severity", "Code", "Message", "Count"])
+    frame = pd.DataFrame(issues)
+    return frame.rename(
+        columns={
+            "severity": "Severity",
+            "code": "Code",
+            "message": "Message",
+            "count": "Count",
+        }
+    )[["Severity", "Code", "Message", "Count"]]
+
+
+def validate_dataset_gradio(dataset_file, task_label, progress=gr.Progress(track_tqdm=True)):
+    if dataset_file is None:
+        return empty_dataset_validation_summary_html(), pd.DataFrame(), "", None
+    dataset_root = _dataset_root_from_upload(dataset_file, task_label)
+    if progress is not None:
+        progress(0.3, desc="Inspecting dataset")
+    export_root = Path(tempfile.mkdtemp(prefix="matheel-dataset-validation-"))
+    report, artifacts = write_dataset_validation_report(
+        dataset_root,
+        export_root,
+        kind=_dataset_kind_from_task_label(task_label),
+        basename="dataset_validation",
+    )
+    artifacts_zip = _zip_artifact_paths(
+        artifacts.values(),
+        export_root / "dataset_validation_artifacts.zip",
+    )
+    if progress is not None:
+        progress(1.0, desc="Dataset validation complete")
+    return (
+        dataset_validation_summary_html(report),
+        dataset_validation_issues_frame(report),
+        artifacts["report_html"].read_text(encoding="utf-8"),
+        artifacts_zip,
+    )
+
+
+def threshold_tuning_summary_html(report):
+    summary = report["summary"]
+    optimized = summary["optimized_threshold"]
+    items = [
+        ("Pairs", str(summary["pair_count"])),
+        ("Positive Labels", str(summary["positive_count"])),
+        ("Negative Labels", str(summary["negative_count"])),
+        ("Optimized Metric", str(summary["optimized_metric"])),
+        ("Best Threshold", f"{float(optimized['threshold']):.4f}"),
+        ("Best F1", f"{float(optimized['f1']):.3f}"),
+        ("Best Accuracy", f"{float(optimized['accuracy']):.3f}"),
+    ]
+    if summary.get("auroc") is not None:
+        items.append(("AUROC", f"{float(summary['auroc']):.3f}"))
+    if summary.get("average_precision") is not None:
+        items.append(("Average Precision", f"{float(summary['average_precision']):.3f}"))
+    return summary_panel_html(
+        "Threshold Tuning",
+        items,
+        variant="empty" if summary.get("warnings") else "summary",
+    )
+
+
+def threshold_sweep_display_frame(report):
+    frame = report["threshold_sweep"].copy()
+    if frame.empty:
+        return pd.DataFrame(columns=["Threshold", "Precision", "Recall", "F1", "Accuracy"])
+    for column in ("threshold", "precision", "recall", "f1", "accuracy"):
+        if column in frame.columns:
+            frame[column] = frame[column].astype(float).round(4)
+    columns = [
+        column
+        for column in (
+            "threshold",
+            "true_positive",
+            "false_positive",
+            "true_negative",
+            "false_negative",
+            "precision",
+            "recall",
+            "f1",
+            "accuracy",
+        )
+        if column in frame.columns
+    ]
+    return frame[columns].rename(
+        columns={
+            "threshold": "Threshold",
+            "true_positive": "TP",
+            "false_positive": "FP",
+            "true_negative": "TN",
+            "false_negative": "FN",
+            "precision": "Precision",
+            "recall": "Recall",
+            "f1": "F1",
+            "accuracy": "Accuracy",
+        }
+    )
+
+
+def threshold_tuning_gradio(scored_state, optimize, progress=gr.Progress(track_tqdm=True)):
+    if not scored_state:
+        return empty_threshold_tuning_summary_html(), pd.DataFrame(), "", None
+    if scored_state.get("task") != "pair":
+        raise gr.Error("Threshold tuning is only available for pair-classification scores.")
+    scored = pd.DataFrame(scored_state.get("scored") or [])
+    if scored.empty:
+        return empty_threshold_tuning_summary_html(), pd.DataFrame(), "", None
+    if progress is not None:
+        progress(0.35, desc="Sweeping thresholds")
+    export_root = Path(tempfile.mkdtemp(prefix="matheel-threshold-tuning-"))
+    try:
+        report, artifacts = write_threshold_tuning_report_artifacts(
+            scored,
+            export_root,
+            score_key="similarity_score",
+            label_key="label",
+            optimize=optimize,
+            basename="threshold_tuning",
+        )
+    except ValueError as exc:
+        raise gr.Error(str(exc)) from exc
+    artifacts_zip = _zip_artifact_paths(
+        artifacts.values(),
+        export_root / "threshold_tuning_artifacts.zip",
+    )
+    if progress is not None:
+        progress(1.0, desc="Threshold tuning complete")
+    return (
+        threshold_tuning_summary_html(report),
+        threshold_sweep_display_frame(report),
+        artifacts["report_html"].read_text(encoding="utf-8"),
+        artifacts_zip,
+    )
 
 
 def evaluate_dataset_gradio(
@@ -2415,6 +2596,34 @@ def evaluate_dataset_gradio(
         resample_summary,
         str(artifacts_zip),
     )
+
+
+def evaluate_dataset_gradio_with_state(*args, **kwargs):
+    outputs = evaluate_dataset_gradio(*args, **kwargs)
+    scored = outputs[2]
+    task_label = args[1] if len(args) > 1 else kwargs.get("task_label", DEFAULT_DATASET_TASK)
+    state = {
+        "task": "retrieval" if str(task_label).startswith("Retrieval") else "pair",
+        "scored": _state_scored_records(scored),
+    }
+    return (*outputs, state)
+
+
+def _state_scored_records(display_frame):
+    frame = display_frame.copy() if isinstance(display_frame, pd.DataFrame) else pd.DataFrame(display_frame)
+    if frame.empty:
+        return []
+    rename = {
+        "Left File": "left_id",
+        "Right File": "right_id",
+        "Label": "label",
+        "Similarity Score": "similarity_score",
+        "Query": "query_id",
+        "Document": "document_id",
+        "Relevance": "relevance",
+    }
+    frame = frame.rename(columns=rename)
+    return frame.to_dict(orient="records")
 
 
 def score_card_html(
@@ -4005,10 +4214,28 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                 )
 
         with gr.Tab("Datasets"):
+            dataset_scored_state = gr.State(None)
             with gr.Row():
                 with gr.Column(scale=8):
                     dataset_file = gr.File(label="Normalized Dataset ZIP", file_types=[".zip"])
-                    dataset_run = gr.Button("Run Dataset Evaluation", variant="primary")
+                    with gr.Row():
+                        dataset_validate = gr.Button("Validate Dataset", variant="secondary")
+                        dataset_run = gr.Button("Run Dataset Evaluation", variant="primary")
+                    dataset_validation_summary = gr.HTML(
+                        value=empty_dataset_validation_summary_html(),
+                        padding=False,
+                    )
+                    dataset_validation_issues = gr.Dataframe(
+                        label="Validation Issues",
+                        wrap=False,
+                        interactive=False,
+                        max_height=220,
+                        row_count=1,
+                        show_search="filter",
+                        elem_classes=["matheel-table"],
+                    )
+                    dataset_validation_report = gr.HTML(value="", padding=False)
+                    dataset_validation_artifacts = gr.File(label="Validation Artifacts")
                     dataset_summary = gr.HTML(
                         value=summary_panel_html(
                             "Dataset Evaluation",
@@ -4054,6 +4281,21 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                         elem_classes=["matheel-table"],
                     )
                     dataset_artifacts = gr.File(label="Leaderboard Artifacts")
+                    dataset_threshold_summary = gr.HTML(
+                        value=empty_threshold_tuning_summary_html(),
+                        padding=False,
+                    )
+                    dataset_threshold_sweep = gr.Dataframe(
+                        label="Threshold Sweep",
+                        wrap=False,
+                        interactive=False,
+                        max_height=300,
+                        row_count=1,
+                        show_search="filter",
+                        elem_classes=["matheel-table"],
+                    )
+                    dataset_threshold_report = gr.HTML(value="", padding=False)
+                    dataset_threshold_artifacts = gr.File(label="Threshold Tuning Artifacts")
 
                 with gr.Column(scale=5):
                     with gr.Accordion("Dataset", open=True):
@@ -4128,14 +4370,30 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                             precision=0,
                             label="Resampling Seed",
                         )
+                        dataset_threshold_optimize = gr.Dropdown(
+                            choices=list(THRESHOLD_OPTIMIZE_CHOICES),
+                            value="f1",
+                            label="Threshold Tuning Metric",
+                        )
+                        dataset_threshold_tune = gr.Button("Tune Pair Threshold", variant="secondary")
 
             dataset_task.change(
                 update_dataset_task_sections,
                 inputs=dataset_task,
                 outputs=[dataset_pair_group, dataset_retrieval_group],
             )
+            dataset_validate.click(
+                validate_dataset_gradio,
+                inputs=[dataset_file, dataset_task],
+                outputs=[
+                    dataset_validation_summary,
+                    dataset_validation_issues,
+                    dataset_validation_report,
+                    dataset_validation_artifacts,
+                ],
+            )
             dataset_run.click(
-                evaluate_dataset_gradio,
+                evaluate_dataset_gradio_with_state,
                 inputs=[
                     dataset_file,
                     dataset_task,
@@ -4158,6 +4416,17 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     dataset_resampling_metrics,
                     dataset_resampling_summary,
                     dataset_artifacts,
+                    dataset_scored_state,
+                ],
+            )
+            dataset_threshold_tune.click(
+                threshold_tuning_gradio,
+                inputs=[dataset_scored_state, dataset_threshold_optimize],
+                outputs=[
+                    dataset_threshold_summary,
+                    dataset_threshold_sweep,
+                    dataset_threshold_report,
+                    dataset_threshold_artifacts,
                 ],
             )
 

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -42,7 +42,11 @@ from .calibration import (
     precision_recall_curve,
     roc_curve,
     threshold_sweep,
+    threshold_tuning_report,
+    threshold_tuning_report_html,
+    threshold_tuning_report_payload,
     write_calibration_report_artifacts,
+    write_threshold_tuning_report_artifacts,
 )
 from .comparison_suite import load_run_configs, parse_run_configs, run_comparison_suite
 from .code_metrics import (
@@ -83,6 +87,12 @@ from .datasets import (
     validate_retrieval_dataset,
     write_pair_dataset,
     write_retrieval_dataset,
+)
+from .dataset_validation import (
+    dataset_validation_report_html,
+    dataset_validation_report_payload,
+    validate_dataset_report,
+    write_dataset_validation_report,
 )
 from .evaluation import (
     evaluate_pair_dataset,
@@ -201,6 +211,8 @@ __all__ = [
     "adapt_retrieval_dataset",
     "dataset_card",
     "dataset_preset_task_families",
+    "dataset_validation_report_html",
+    "dataset_validation_report_payload",
     "default_feature_weights",
     "evaluate_threshold",
     "evaluate_pair_dataset",
@@ -262,6 +274,7 @@ __all__ = [
     "similarity_function_score_range",
     "single_split",
     "summarize_metric_samples",
+    "validate_dataset_report",
     "validate_pair_dataset",
     "validate_retrieval_dataset",
     "write_pair_dataset",
@@ -283,9 +296,14 @@ __all__ = [
     "project_embeddings",
     "roc_curve",
     "threshold_sweep",
+    "threshold_tuning_report",
+    "threshold_tuning_report_html",
+    "threshold_tuning_report_payload",
     "write_dataset_embedding_map",
     "write_dataset_map_artifacts",
     "write_calibration_report_artifacts",
+    "write_dataset_validation_report",
+    "write_threshold_tuning_report_artifacts",
     "write_benchmark_cache_result",
     "write_benchmark_report",
     "write_leaderboard_artifacts",

--- a/matheel/calibration.py
+++ b/matheel/calibration.py
@@ -1,5 +1,6 @@
 import json
 import math
+from html import escape
 from pathlib import Path
 
 import pandas as pd
@@ -456,6 +457,186 @@ def calibration_report_payload(report):
     }
 
 
+def threshold_tuning_report(
+    scores,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+    optimize="f1",
+):
+    pairs = _coerce_score_label_pairs(
+        scores,
+        labels=labels,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+    )
+    positive_count, negative_count = _class_counts(pairs)
+    sweep = threshold_sweep(
+        pairs,
+        thresholds=thresholds,
+        positive_label=True,
+        greater_is_match=greater_is_match,
+    )
+    best = calibrate_threshold(
+        pairs,
+        thresholds=thresholds,
+        positive_label=True,
+        greater_is_match=greater_is_match,
+        optimize=optimize,
+    )
+    warnings = []
+    roc = pd.DataFrame()
+    pr = pd.DataFrame()
+    auroc = None
+    average_precision = None
+    if positive_count and negative_count:
+        roc = roc_curve(pairs, positive_label=True, greater_is_match=greater_is_match)
+        pr = precision_recall_curve(pairs, positive_label=True, greater_is_match=greater_is_match)
+        auroc = float(roc.attrs["auroc"])
+        average_precision = float(pr.attrs["average_precision"])
+    else:
+        warnings.append(
+            "ROC and precision-recall summaries require at least one positive and one negative label."
+        )
+
+    summary = {
+        "pair_count": int(len(pairs)),
+        "positive_count": int(positive_count),
+        "negative_count": int(negative_count),
+        "score_key": score_key,
+        "label_key": label_key,
+        "greater_is_match": bool(greater_is_match),
+        "optimized_metric": str(optimize or "f1").strip().lower(),
+        "optimized_threshold": best,
+        "candidate_count": int(len(sweep)),
+        "auroc": auroc,
+        "average_precision": average_precision,
+        "warnings": warnings,
+    }
+    return {
+        "summary": summary,
+        "threshold_sweep": sweep,
+        "roc": roc,
+        "precision_recall": pr,
+    }
+
+
+def threshold_tuning_report_payload(report):
+    payload = {
+        "schema_version": 1,
+        "summary": _json_safe_mapping(report["summary"]),
+        "threshold_sweep": _frame_records(report["threshold_sweep"]),
+    }
+    if report["roc"] is not None and not report["roc"].empty:
+        payload["roc"] = _frame_records(report["roc"])
+    if report["precision_recall"] is not None and not report["precision_recall"].empty:
+        payload["precision_recall"] = _frame_records(report["precision_recall"])
+    return payload
+
+
+def threshold_tuning_report_html(report):
+    payload = threshold_tuning_report_payload(report)
+    summary = payload["summary"]
+    optimized = summary["optimized_threshold"]
+    warning_rows = "".join(
+        f"<li>{escape(str(warning))}</li>" for warning in summary.get("warnings", [])
+    )
+    if not warning_rows:
+        warning_rows = "<li>None</li>"
+    preview_rows = []
+    for row in payload.get("threshold_sweep", [])[:50]:
+        preview_rows.append(
+            "<tr><td>{threshold:.6g}</td><td>{precision:.4f}</td><td>{recall:.4f}</td>"
+            "<td>{f1:.4f}</td><td>{accuracy:.4f}</td></tr>".format(**row)
+        )
+    if not preview_rows:
+        preview_rows.append('<tr><td colspan="5">No threshold rows</td></tr>')
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Matheel Threshold Tuning</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 24px; color: #1f2328; }}
+    h1 {{ font-size: 1.4rem; margin-bottom: 0.4rem; }}
+    h2 {{ font-size: 1.05rem; margin-top: 1.4rem; }}
+    table {{ border-collapse: collapse; width: 100%; margin-top: 0.6rem; }}
+    th, td {{ border: 1px solid #d6d9df; padding: 6px 8px; text-align: left; }}
+    th {{ background: #f6f8fa; }}
+  </style>
+</head>
+<body>
+  <h1>Threshold Tuning</h1>
+  <p>Pairs: {summary['pair_count']}. Positives: {summary['positive_count']}. Negatives: {summary['negative_count']}.</p>
+  <p>Best threshold by {escape(str(summary['optimized_metric']))}: {float(optimized['threshold']):.6g}
+     with F1 {float(optimized['f1']):.4f}, precision {float(optimized['precision']):.4f},
+     recall {float(optimized['recall']):.4f}, and accuracy {float(optimized['accuracy']):.4f}.</p>
+  <h2>Warnings</h2>
+  <ul>{warning_rows}</ul>
+  <h2>Threshold Preview</h2>
+  <table>
+    <thead><tr><th>Threshold</th><th>Precision</th><th>Recall</th><th>F1</th><th>Accuracy</th></tr></thead>
+    <tbody>{''.join(preview_rows)}</tbody>
+  </table>
+</body>
+</html>
+"""
+
+
+def write_threshold_tuning_report_artifacts(
+    scores,
+    output_dir,
+    labels=None,
+    thresholds=None,
+    score_key="score",
+    label_key="label",
+    positive_label=True,
+    greater_is_match=True,
+    optimize="f1",
+    basename="threshold_tuning",
+):
+    report = threshold_tuning_report(
+        scores,
+        labels=labels,
+        thresholds=thresholds,
+        score_key=score_key,
+        label_key=label_key,
+        positive_label=positive_label,
+        greater_is_match=greater_is_match,
+        optimize=optimize,
+    )
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    stem = _safe_artifact_basename(basename or "threshold_tuning")
+    artifacts = {
+        "threshold_sweep_csv": target / f"{stem}_threshold_sweep.csv",
+        "summary_json": target / f"{stem}_summary.json",
+        "report_json": target / f"{stem}_report.json",
+        "report_html": target / f"{stem}_report.html",
+    }
+    report["threshold_sweep"].to_csv(artifacts["threshold_sweep_csv"], index=False)
+    if report["roc"] is not None and not report["roc"].empty:
+        artifacts["roc_csv"] = target / f"{stem}_roc.csv"
+        report["roc"].to_csv(artifacts["roc_csv"], index=False)
+    if report["precision_recall"] is not None and not report["precision_recall"].empty:
+        artifacts["precision_recall_csv"] = target / f"{stem}_precision_recall.csv"
+        report["precision_recall"].to_csv(artifacts["precision_recall_csv"], index=False)
+    artifacts["summary_json"].write_text(
+        json.dumps(_json_safe_mapping(report["summary"]), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    artifacts["report_json"].write_text(
+        json.dumps(threshold_tuning_report_payload(report), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    artifacts["report_html"].write_text(threshold_tuning_report_html(report), encoding="utf-8")
+    return report, artifacts
+
+
 def write_calibration_report_artifacts(
     scores,
     output_dir,
@@ -511,6 +692,10 @@ def _json_safe_mapping(values):
     for key, value in dict(values).items():
         if isinstance(value, dict):
             payload[str(key)] = _json_safe_mapping(value)
+        elif isinstance(value, (list, tuple)):
+            payload[str(key)] = [
+                _json_safe_mapping(item) if isinstance(item, dict) else item for item in value
+            ]
         elif pd.isna(value):
             payload[str(key)] = None
         elif isinstance(value, (int, float, str, bool)) or value is None:

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from . import __version__
 from .algorithms import normalize_algorithm_options, score_source_pairs_with_algorithm
-from .calibration import write_calibration_report_artifacts
+from .calibration import write_calibration_report_artifacts, write_threshold_tuning_report_artifacts
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
 from ._progress import should_show_progress
@@ -26,6 +26,7 @@ from .datasets import (
     load_retrieval_datasets,
     load_retrieval_datasets_from_manifest,
 )
+from .dataset_validation import write_dataset_validation_report
 from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
 from .leaderboard import load_leaderboard_manifest, run_leaderboard
 from .reproducibility import collect_reproducibility_snapshot, write_reproducibility_snapshot
@@ -324,6 +325,36 @@ def _echo_calibration_report_summary(summary, output_format):
         click.echo(f"{name}={path}")
 
 
+def _echo_threshold_tuning_summary(summary, output_format):
+    if output_format == "json":
+        _echo_json(summary)
+        return
+    click.echo(f"pair_count={summary['pair_count']}")
+    click.echo(f"positive_count={summary['positive_count']}")
+    click.echo(f"negative_count={summary['negative_count']}")
+    optimized = summary["optimized_threshold"]
+    click.echo(f"optimized_threshold={optimized['threshold']:.6g}")
+    click.echo(f"optimized_metric={summary['optimized_metric']}")
+    click.echo(f"optimized_f1={optimized['f1']:.4f}")
+    for warning in summary.get("warnings", []):
+        click.echo(f"warning={warning}")
+    for name, path in summary["artifacts"].items():
+        click.echo(f"{name}={path}")
+
+
+def _echo_dataset_validation_report_summary(summary, output_format):
+    if output_format == "json":
+        _echo_json(summary)
+        return
+    click.echo(f"dataset_name={summary['dataset_name']}")
+    click.echo(f"dataset_kind={summary['dataset_kind']}")
+    click.echo(f"status={summary['status']}")
+    click.echo(f"errors={summary['error_count']}")
+    click.echo(f"warnings={summary['warning_count']}")
+    for name, path in summary["artifacts"].items():
+        click.echo(f"{name}={path}")
+
+
 def _echo_leaderboard_summary(report, artifacts, output_format):
     summary = {
         "name": report["metadata"]["name"],
@@ -345,6 +376,24 @@ def _calibration_cli_summary(report, artifacts):
     summary = dict(report["summary"])
     summary["artifacts"] = {name: str(path) for name, path in artifacts.items()}
     return summary
+
+
+def _threshold_tuning_cli_summary(report, artifacts):
+    summary = dict(report["summary"])
+    summary["artifacts"] = {name: str(path) for name, path in artifacts.items()}
+    return summary
+
+
+def _dataset_validation_cli_summary(report, artifacts):
+    return {
+        "dataset_name": report["dataset_name"],
+        "dataset_kind": report["dataset_kind"],
+        "status": report["status"],
+        "error_count": report["error_count"],
+        "warning_count": report["warning_count"],
+        "counts": report["counts"],
+        "artifacts": {name: str(path) for name, path in artifacts.items()},
+    }
 
 
 def _parse_positive_label(value):
@@ -431,9 +480,27 @@ def datasets_list(task, output_format):
     default="text",
     show_default=True,
 )
-def datasets_validate(dataset_path, kind, output_format):
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory where validation report artifacts will be written.",
+)
+@click.option("--basename", default="dataset_validation", show_default=True, help="Report artifact filename stem.")
+def datasets_validate(dataset_path, kind, output_format, output_dir, basename):
     """Validate a normalized pair or retrieval dataset."""
     dataset_kind = _dataset_kind_from_path(dataset_path, kind)
+    if output_dir is not None:
+        report, artifacts = write_dataset_validation_report(
+            dataset_path,
+            output_dir,
+            kind=dataset_kind,
+            basename=basename,
+        )
+        _echo_dataset_validation_report_summary(
+            _dataset_validation_cli_summary(report, artifacts),
+            output_format,
+        )
+        return
     if dataset_kind == "pair":
         summary = _pair_dataset_summary(load_pair_dataset(dataset_path))
     else:
@@ -748,6 +815,71 @@ def calibration_report_command(
     )
     _echo_calibration_report_summary(
         _calibration_cli_summary(report, artifacts),
+        output_format,
+    )
+
+
+@main.command(name="tune-threshold")
+@click.argument("scores_path", type=click.Path(exists=True, file_okay=True, dir_okay=False))
+@click.option("--score-column", default="similarity_score", show_default=True, help="Column containing pair scores.")
+@click.option("--label-column", default="label", show_default=True, help="Column containing pair labels.")
+@click.option(
+    "--positive-label",
+    default=None,
+    help="Positive label value. Defaults to boolean coercion, suitable for 0/1 labels.",
+)
+@click.option(
+    "--greater-is-match/--lower-is-match",
+    default=True,
+    show_default=True,
+    help="Whether larger scores mean stronger matches.",
+)
+@click.option(
+    "--optimize",
+    type=click.Choice(("f1", "accuracy", "precision", "recall")),
+    default="f1",
+    show_default=True,
+    help="Metric used for the recommended threshold.",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, dir_okay=True),
+    required=True,
+    help="Directory where threshold tuning artifacts will be written.",
+)
+@click.option("--basename", default="threshold_tuning", show_default=True, help="Artifact filename stem.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def tune_threshold_command(
+    scores_path,
+    score_column,
+    label_column,
+    positive_label,
+    greater_is_match,
+    optimize,
+    output_dir,
+    basename,
+    output_format,
+):
+    """Write a threshold sweep and selected best threshold for scored pair rows."""
+    scored_pairs = pd.read_csv(scores_path)
+    report, artifacts = write_threshold_tuning_report_artifacts(
+        scored_pairs,
+        output_dir,
+        score_key=score_column,
+        label_key=label_column,
+        positive_label=_parse_positive_label(positive_label),
+        greater_is_match=greater_is_match,
+        optimize=optimize,
+        basename=basename,
+    )
+    _echo_threshold_tuning_summary(
+        _threshold_tuning_cli_summary(report, artifacts),
         output_format,
     )
 

--- a/matheel/dataset_validation.py
+++ b/matheel/dataset_validation.py
@@ -1,0 +1,501 @@
+import csv
+import json
+from html import escape
+from pathlib import Path
+
+import pandas as pd
+
+
+PAIR_KIND = "pair_classification"
+RETRIEVAL_KIND = "retrieval"
+
+
+def validate_dataset_report(dataset_root, kind="auto"):
+    """Inspect a normalized Matheel dataset without mutating it."""
+    root = Path(dataset_root).expanduser().resolve()
+    issues = []
+    counts = {}
+    metadata = _read_metadata(root, issues)
+    dataset_kind = _resolve_dataset_kind(root, kind, metadata, issues)
+
+    if dataset_kind == PAIR_KIND:
+        _inspect_pair_dataset(root, metadata, counts, issues)
+    elif dataset_kind == RETRIEVAL_KIND:
+        _inspect_retrieval_dataset(root, metadata, counts, issues)
+    else:
+        _add_issue(
+            issues,
+            "error",
+            "unknown_dataset_kind",
+            "Could not determine dataset kind from manifests. Use kind='pair' or kind='retrieval'.",
+        )
+
+    error_count = sum(1 for issue in issues if issue["severity"] == "error")
+    warning_count = sum(1 for issue in issues if issue["severity"] == "warning")
+    status = "error" if error_count else "warning" if warning_count else "pass"
+    return {
+        "schema_version": 1,
+        "dataset_kind": dataset_kind or "unknown",
+        "dataset_name": str(metadata.get("name") or root.name),
+        "root_name": root.name,
+        "status": status,
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "counts": counts,
+        "metadata": metadata,
+        "issues": issues,
+    }
+
+
+def dataset_validation_report_payload(report):
+    return _json_safe(report)
+
+
+def dataset_validation_report_html(report):
+    payload = dataset_validation_report_payload(report)
+    title = escape(str(payload.get("dataset_name") or "dataset"))
+    status = escape(str(payload.get("status") or "unknown"))
+    counts_rows = "\n".join(
+        "<tr><th>{}</th><td>{}</td></tr>".format(escape(str(key)), escape(str(value)))
+        for key, value in sorted((payload.get("counts") or {}).items())
+    )
+    if not counts_rows:
+        counts_rows = '<tr><td colspan="2">No counts available</td></tr>'
+
+    issue_rows = []
+    for issue in payload.get("issues") or []:
+        issue_rows.append(
+            "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>".format(
+                escape(str(issue.get("severity", ""))),
+                escape(str(issue.get("code", ""))),
+                escape(str(issue.get("count", ""))),
+                escape(str(issue.get("message", ""))),
+            )
+        )
+    if not issue_rows:
+        issue_rows.append('<tr><td colspan="4">No validation issues</td></tr>')
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Matheel Dataset Validation</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 24px; color: #1f2328; }}
+    h1 {{ font-size: 1.4rem; margin-bottom: 0.4rem; }}
+    h2 {{ font-size: 1.05rem; margin-top: 1.4rem; }}
+    table {{ border-collapse: collapse; width: 100%; margin-top: 0.6rem; }}
+    th, td {{ border: 1px solid #d6d9df; padding: 6px 8px; text-align: left; vertical-align: top; }}
+    th {{ background: #f6f8fa; }}
+    .status {{ display: inline-block; border: 1px solid #d6d9df; border-radius: 6px; padding: 2px 8px; background: #f6f8fa; }}
+  </style>
+</head>
+<body>
+  <h1>{title}</h1>
+  <p>Dataset kind: {escape(str(payload.get("dataset_kind", "unknown")))}. Status: <span class="status">{status}</span>.</p>
+  <h2>Counts</h2>
+  <table><tbody>{counts_rows}</tbody></table>
+  <h2>Issues</h2>
+  <table>
+    <thead><tr><th>Severity</th><th>Code</th><th>Count</th><th>Message</th></tr></thead>
+    <tbody>{''.join(issue_rows)}</tbody>
+  </table>
+</body>
+</html>
+"""
+
+
+def write_dataset_validation_report(dataset_root, output_dir, kind="auto", basename="dataset_validation"):
+    report = validate_dataset_report(dataset_root, kind=kind)
+    target = Path(output_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    stem = _safe_artifact_basename(basename or "dataset_validation")
+    artifacts = {
+        "summary_json": target / f"{stem}_summary.json",
+        "issues_csv": target / f"{stem}_issues.csv",
+        "report_html": target / f"{stem}_report.html",
+        "report_json": target / f"{stem}_report.json",
+    }
+    payload = dataset_validation_report_payload(report)
+    artifacts["summary_json"].write_text(
+        json.dumps(
+            {
+                key: value
+                for key, value in payload.items()
+                if key not in {"issues", "metadata"}
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    _write_issues_csv(payload.get("issues") or [], artifacts["issues_csv"])
+    artifacts["report_html"].write_text(dataset_validation_report_html(payload), encoding="utf-8")
+    artifacts["report_json"].write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return report, artifacts
+
+
+def _inspect_pair_dataset(root, metadata, counts, issues):
+    _inspect_metadata(metadata, PAIR_KIND, issues)
+    files = _read_csv_manifest(root, "files.csv", ("file_id", "file_path"), issues)
+    pairs = _read_csv_manifest(root, "pairs.csv", ("left_id", "right_id", "label"), issues)
+    counts["files"] = int(len(files)) if files is not None else 0
+    counts["pairs"] = int(len(pairs)) if pairs is not None else 0
+
+    file_ids = _inspect_files_manifest(root, files, counts, issues)
+    if pairs is None:
+        return
+
+    _add_duplicate_issue(pairs, ("left_id", "right_id"), issues, "duplicate_pairs", "pairs.csv contains duplicate pair rows.")
+    if "label" in pairs.columns:
+        labels = pairs["label"]
+        missing_labels = int(labels.isna().sum())
+        if missing_labels:
+            _add_issue(issues, "error", "missing_pair_labels", "pairs.csv contains missing label values.", missing_labels)
+        normalized_labels = labels.dropna().map(_coerce_binary_label)
+        invalid_count = int(normalized_labels.isna().sum())
+        if invalid_count:
+            _add_issue(issues, "error", "invalid_pair_labels", "pairs.csv labels must be binary values.", invalid_count)
+        valid_labels = normalized_labels.dropna().astype(int)
+        positive_count = int(valid_labels.sum())
+        negative_count = int(len(valid_labels) - positive_count)
+        counts["positive_pairs"] = positive_count
+        counts["negative_pairs"] = negative_count
+        if len(valid_labels) and (positive_count == 0 or negative_count == 0):
+            _add_issue(
+                issues,
+                "warning",
+                "single_class_labels",
+                "pairs.csv contains only one label class; threshold tuning and resampling will be limited.",
+            )
+
+    if file_ids is None or not {"left_id", "right_id"}.issubset(pairs.columns):
+        return
+    missing = sorted(
+        {
+            str(value)
+            for value in pd.concat([pairs["left_id"], pairs["right_id"]], ignore_index=True).dropna()
+            if str(value) not in file_ids
+        }
+    )
+    if missing:
+        _add_issue(
+            issues,
+            "error",
+            "unknown_pair_file_ids",
+            f"pairs.csv references unknown file ids: {', '.join(missing[:8])}.",
+            len(missing),
+        )
+
+
+def _inspect_retrieval_dataset(root, metadata, counts, issues):
+    _inspect_metadata(metadata, RETRIEVAL_KIND, issues)
+    files = _read_csv_manifest(root, "files.csv", ("file_id", "file_path"), issues)
+    queries = _read_csv_manifest(root, "queries.csv", ("query_id", "file_id"), issues)
+    corpus = _read_csv_manifest(root, "corpus.csv", ("document_id", "file_id"), issues)
+    qrels = _read_csv_manifest(root, "qrels.csv", ("query_id", "document_id", "relevance"), issues)
+    counts.update(
+        {
+            "files": int(len(files)) if files is not None else 0,
+            "queries": int(len(queries)) if queries is not None else 0,
+            "documents": int(len(corpus)) if corpus is not None else 0,
+            "qrels": int(len(qrels)) if qrels is not None else 0,
+        }
+    )
+
+    file_ids = _inspect_files_manifest(root, files, counts, issues)
+    query_ids = _inspect_id_manifest(queries, "query_id", "queries.csv", issues)
+    document_ids = _inspect_id_manifest(corpus, "document_id", "corpus.csv", issues)
+    _add_duplicate_issue(qrels, ("query_id", "document_id"), issues, "duplicate_qrels", "qrels.csv contains duplicate query/document judgments.")
+
+    if file_ids is not None and queries is not None and "file_id" in queries:
+        missing = sorted({str(value) for value in queries["file_id"].dropna() if str(value) not in file_ids})
+        if missing:
+            _add_issue(
+                issues,
+                "error",
+                "unknown_query_file_ids",
+                f"queries.csv references unknown file ids: {', '.join(missing[:8])}.",
+                len(missing),
+            )
+    if file_ids is not None and corpus is not None and "file_id" in corpus:
+        missing = sorted({str(value) for value in corpus["file_id"].dropna() if str(value) not in file_ids})
+        if missing:
+            _add_issue(
+                issues,
+                "error",
+                "unknown_corpus_file_ids",
+                f"corpus.csv references unknown file ids: {', '.join(missing[:8])}.",
+                len(missing),
+            )
+    if qrels is not None:
+        if query_ids is not None and "query_id" in qrels:
+            missing = sorted({str(value) for value in qrels["query_id"].dropna() if str(value) not in query_ids})
+            if missing:
+                _add_issue(
+                    issues,
+                    "error",
+                    "unknown_qrel_query_ids",
+                    f"qrels.csv references unknown query ids: {', '.join(missing[:8])}.",
+                    len(missing),
+                )
+        if document_ids is not None and "document_id" in qrels:
+            missing = sorted({str(value) for value in qrels["document_id"].dropna() if str(value) not in document_ids})
+            if missing:
+                _add_issue(
+                    issues,
+                    "error",
+                    "unknown_qrel_document_ids",
+                    f"qrels.csv references unknown document ids: {', '.join(missing[:8])}.",
+                    len(missing),
+                )
+        if "relevance" in qrels:
+            relevance = pd.to_numeric(qrels["relevance"], errors="coerce")
+            invalid_count = int(relevance.isna().sum() + (relevance < 0).sum())
+            if invalid_count:
+                _add_issue(
+                    issues,
+                    "error",
+                    "invalid_qrel_relevance",
+                    "qrels.csv relevance values must be non-negative numbers.",
+                    invalid_count,
+                )
+            counts["positive_qrels"] = int((relevance > 0).sum())
+            if len(qrels) and int((relevance > 0).sum()) == 0:
+                _add_issue(
+                    issues,
+                    "warning",
+                    "no_positive_qrels",
+                    "qrels.csv does not contain any positive relevance judgments.",
+                )
+
+
+def _read_metadata(root, issues):
+    path = root / "metadata.json"
+    if not path.exists():
+        _add_issue(issues, "error", "missing_metadata", "metadata.json is missing.")
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        _add_issue(issues, "error", "invalid_metadata_json", f"metadata.json is not valid JSON: {exc.msg}.")
+        return {}
+    if not isinstance(payload, dict):
+        _add_issue(issues, "error", "invalid_metadata", "metadata.json must contain a JSON object.")
+        return {}
+    return payload
+
+
+def _resolve_dataset_kind(root, requested_kind, metadata, issues):
+    requested = str(requested_kind or "auto").strip().lower()
+    if requested in {"pair", "pairs", PAIR_KIND, "pair-classification"}:
+        return PAIR_KIND
+    if requested in {"retrieval", "ranking"}:
+        return RETRIEVAL_KIND
+    if requested not in {"auto", ""}:
+        _add_issue(issues, "error", "invalid_requested_kind", f"Unsupported dataset kind: {requested_kind}.")
+        return None
+
+    metadata_kind = str(metadata.get("dataset_kind") or "").strip().lower()
+    has_pair_files = (root / "files.csv").exists() and (root / "pairs.csv").exists()
+    has_retrieval_files = all((root / name).exists() for name in ("files.csv", "queries.csv", "corpus.csv", "qrels.csv"))
+    if metadata_kind == PAIR_KIND:
+        return PAIR_KIND
+    if metadata_kind == RETRIEVAL_KIND:
+        return RETRIEVAL_KIND
+    if has_pair_files and has_retrieval_files:
+        _add_issue(issues, "error", "ambiguous_dataset_kind", "Dataset contains both pair and retrieval manifests.")
+        return None
+    if has_pair_files:
+        return PAIR_KIND
+    if has_retrieval_files:
+        return RETRIEVAL_KIND
+    return None
+
+
+def _inspect_metadata(metadata, expected_kind, issues):
+    if not metadata:
+        return
+    dataset_kind = str(metadata.get("dataset_kind") or "").strip()
+    if dataset_kind and dataset_kind != expected_kind:
+        _add_issue(
+            issues,
+            "error",
+            "metadata_kind_mismatch",
+            f"metadata.json dataset_kind is {dataset_kind!r}, expected {expected_kind!r}.",
+        )
+    if not str(metadata.get("name") or "").strip():
+        _add_issue(issues, "warning", "missing_dataset_name", "metadata.json does not include a dataset name.")
+    if not str(metadata.get("task_type") or "").strip():
+        _add_issue(issues, "warning", "missing_task_type", "metadata.json does not include task_type.")
+
+
+def _read_csv_manifest(root, filename, required_columns, issues):
+    path = root / filename
+    if not path.exists():
+        _add_issue(issues, "error", "missing_manifest", f"Required manifest is missing: {filename}.")
+        return None
+    try:
+        frame = pd.read_csv(path)
+    except (pd.errors.ParserError, UnicodeDecodeError, OSError) as exc:
+        _add_issue(issues, "error", "invalid_csv", f"{filename} could not be read as CSV: {exc}.")
+        return None
+    missing = [column for column in required_columns if column not in frame.columns]
+    if missing:
+        _add_issue(
+            issues,
+            "error",
+            "missing_columns",
+            f"{filename} is missing required columns: {', '.join(missing)}.",
+            len(missing),
+        )
+        return frame
+    if frame.empty:
+        _add_issue(issues, "warning", "empty_manifest", f"{filename} has no rows.")
+    return frame
+
+
+def _inspect_files_manifest(root, files, counts, issues):
+    if files is None or not {"file_id", "file_path"}.issubset(files.columns):
+        return None
+    file_ids = _inspect_id_manifest(files, "file_id", "files.csv", issues)
+    missing_paths = int(files["file_path"].isna().sum())
+    if missing_paths:
+        _add_issue(issues, "error", "missing_file_paths", "files.csv contains missing file_path values.", missing_paths)
+
+    missing_files = []
+    unsafe_paths = []
+    empty_files = []
+    for row in files.to_dict(orient="records"):
+        raw_path = row.get("file_path")
+        if pd.isna(raw_path):
+            continue
+        relative_path = Path(str(raw_path))
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            unsafe_paths.append(str(raw_path))
+            continue
+        target = root / relative_path
+        if not target.exists():
+            missing_files.append(str(raw_path))
+            continue
+        if target.is_file():
+            try:
+                if not target.read_text(encoding="utf-8", errors="ignore").strip():
+                    empty_files.append(str(raw_path))
+            except OSError:
+                missing_files.append(str(raw_path))
+
+    if unsafe_paths:
+        _add_issue(
+            issues,
+            "error",
+            "unsafe_file_paths",
+            f"files.csv contains unsafe relative paths: {', '.join(unsafe_paths[:8])}.",
+            len(unsafe_paths),
+        )
+    if missing_files:
+        _add_issue(
+            issues,
+            "error",
+            "missing_files",
+            f"files.csv references missing files: {', '.join(missing_files[:8])}.",
+            len(missing_files),
+        )
+    if empty_files:
+        _add_issue(
+            issues,
+            "warning",
+            "empty_files",
+            f"files.csv references empty text files: {', '.join(empty_files[:8])}.",
+            len(empty_files),
+        )
+    counts["empty_files"] = len(empty_files)
+    return file_ids
+
+
+def _inspect_id_manifest(frame, id_column, filename, issues):
+    if frame is None or id_column not in frame.columns:
+        return None
+    ids = frame[id_column]
+    missing = int(ids.isna().sum())
+    if missing:
+        _add_issue(issues, "error", "missing_ids", f"{filename} contains missing {id_column} values.", missing)
+    string_ids = ids.dropna().map(str)
+    blank = int((string_ids.str.strip() == "").sum())
+    if blank:
+        _add_issue(issues, "error", "blank_ids", f"{filename} contains blank {id_column} values.", blank)
+    duplicates = string_ids[string_ids.duplicated()].tolist()
+    if duplicates:
+        _add_issue(
+            issues,
+            "error",
+            "duplicate_ids",
+            f"{filename} contains duplicate {id_column} values: {', '.join(sorted(set(duplicates))[:8])}.",
+            len(set(duplicates)),
+        )
+    return set(value for value in string_ids.tolist() if value.strip())
+
+
+def _add_duplicate_issue(frame, columns, issues, code, message):
+    if frame is None or not set(columns).issubset(frame.columns):
+        return
+    duplicate_count = int(frame.duplicated(subset=list(columns)).sum())
+    if duplicate_count:
+        _add_issue(issues, "warning", code, message, duplicate_count)
+
+
+def _coerce_binary_label(value):
+    if pd.isna(value):
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    text = str(value).strip().lower()
+    if text in {"1", "1.0", "true", "yes", "y", "positive", "plagiarized", "plagiarised", "p"}:
+        return 1
+    if text in {"0", "0.0", "false", "no", "n", "negative", "non_plagiarized", "non_plagiarised", "np"}:
+        return 0
+    return None
+
+
+def _add_issue(issues, severity, code, message, count=1):
+    issues.append(
+        {
+            "severity": severity,
+            "code": code,
+            "message": message,
+            "count": int(count),
+        }
+    )
+
+
+def _write_issues_csv(issues, path):
+    with Path(path).open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=("severity", "code", "message", "count"))
+        writer.writeheader()
+        for issue in issues:
+            writer.writerow(
+                {
+                    "severity": issue.get("severity", ""),
+                    "code": issue.get("code", ""),
+                    "message": issue.get("message", ""),
+                    "count": issue.get("count", 1),
+                }
+            )
+
+
+def _json_safe(value):
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if pd.isna(value):
+        return None
+    if hasattr(value, "item"):
+        return value.item()
+    return value
+
+
+def _safe_artifact_basename(value):
+    text = str(value or "").strip()
+    safe = "".join(character if character.isalnum() or character in "._-" else "_" for character in text)
+    return safe.strip("._") or "dataset_validation"

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -14,7 +14,10 @@ from matheel.calibration import (
     precision_recall_curve,
     roc_curve,
     threshold_sweep,
+    threshold_tuning_report,
+    threshold_tuning_report_payload,
     write_calibration_report_artifacts,
+    write_threshold_tuning_report_artifacts,
 )
 
 
@@ -46,7 +49,10 @@ def test_calibration_helpers_are_exported_from_package_root():
     assert matheel.precision_recall_curve is precision_recall_curve
     assert matheel.roc_curve is roc_curve
     assert matheel.threshold_sweep is threshold_sweep
+    assert matheel.threshold_tuning_report is threshold_tuning_report
+    assert matheel.threshold_tuning_report_payload is threshold_tuning_report_payload
     assert matheel.write_calibration_report_artifacts is write_calibration_report_artifacts
+    assert matheel.write_threshold_tuning_report_artifacts is write_threshold_tuning_report_artifacts
 
 
 def test_calibrate_threshold_finds_best_cutoff_for_tiny_labeled_dataset():
@@ -173,6 +179,32 @@ def test_roc_and_precision_recall_require_both_classes():
 
     with pytest.raises(ValueError, match="positive and one negative"):
         calibration_report([0.9], [True])
+
+
+def test_threshold_tuning_report_handles_single_class_labels(tmp_path):
+    scored_pairs = pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.9, "label": 1},
+            {"left_id": "c", "right_id": "d", "similarity_score": 0.8, "label": 1},
+        ]
+    )
+
+    report, artifacts = write_threshold_tuning_report_artifacts(
+        scored_pairs,
+        tmp_path / "thresholds",
+        score_key="similarity_score",
+        label_key="label",
+        basename="single_class",
+    )
+    payload = threshold_tuning_report_payload(report)
+
+    assert report["summary"]["positive_count"] == 2
+    assert report["summary"]["negative_count"] == 0
+    assert report["summary"]["auroc"] is None
+    assert report["summary"]["warnings"]
+    assert "roc" not in payload
+    assert artifacts["threshold_sweep_csv"].exists()
+    assert artifacts["report_html"].exists()
 
 
 def test_calibrate_threshold_supports_lower_scores_as_matches():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,6 +199,36 @@ def test_calibration_report_command_writes_artifacts(tmp_path):
     assert (output_dir / "tiny_report.json").exists()
 
 
+def test_tune_threshold_command_handles_single_class_scores(tmp_path):
+    scores_path = tmp_path / "scored_pairs.csv"
+    pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.9, "label": 1},
+            {"left_id": "c", "right_id": "d", "similarity_score": 0.8, "label": 1},
+        ]
+    ).to_csv(scores_path, index=False)
+    output_dir = tmp_path / "thresholds"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "tune-threshold",
+            str(scores_path),
+            "--output-dir",
+            str(output_dir),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = json.loads(result.output)
+    assert summary["negative_count"] == 0
+    assert summary["warnings"]
+    assert (output_dir / "threshold_tuning_threshold_sweep.csv").exists()
+    assert (output_dir / "threshold_tuning_report.html").exists()
+
+
 def test_leaderboard_command_writes_artifacts(tmp_path, monkeypatch):
     config_path = tmp_path / "leaderboard.json"
     config_path.write_text('{"datasets": [], "algorithms": []}', encoding="utf-8")
@@ -640,6 +670,42 @@ def test_datasets_validate_command_reports_pair_summary(tmp_path):
         "pairs": 2,
         "positive_pairs": 1,
     }
+
+
+def test_datasets_validate_command_writes_report_artifacts(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 0}]),
+        metadata={"name": "unit_pairs"},
+    )
+    output_dir = tmp_path / "dataset_report"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "datasets",
+            "validate",
+            str(dataset_root),
+            "--output-dir",
+            str(output_dir),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["dataset_name"] == "unit_pairs"
+    assert payload["warning_count"] == 1
+    assert (output_dir / "dataset_validation_issues.csv").exists()
+    assert (output_dir / "dataset_validation_report.html").exists()
 
 
 def test_datasets_adapt_command_writes_pair_dataset(tmp_path):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,6 +6,12 @@ from types import ModuleType
 import pandas as pd
 import pytest
 
+import matheel
+from matheel.dataset_validation import (
+    dataset_validation_report_payload,
+    validate_dataset_report,
+    write_dataset_validation_report,
+)
 from matheel.datasets import (
     adapt_pair_dataset,
     adapt_retrieval_dataset,
@@ -71,6 +77,94 @@ def test_dataset_source_registry_resolves_local_sources(tmp_path):
 
     assert "local" in available_dataset_sources()
     assert resolve_dataset_source("local", dataset_root) == dataset_root.resolve()
+
+
+def test_dataset_validation_report_exports_clean_pair_dataset(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 0}]),
+        metadata={"name": "validation_pairs"},
+    )
+
+    report, artifacts = write_dataset_validation_report(
+        dataset_root,
+        tmp_path / "validation",
+        kind="pair",
+        basename="tiny",
+    )
+    payload = dataset_validation_report_payload(report)
+
+    assert report["status"] == "warning"
+    assert report["warning_count"] == 1
+    assert report["counts"]["pairs"] == 1
+    assert any(issue["code"] == "single_class_labels" for issue in report["issues"])
+    assert payload["schema_version"] == 1
+    assert artifacts["issues_csv"].exists()
+    assert artifacts["report_html"].exists()
+    assert matheel.validate_dataset_report is validate_dataset_report
+    assert matheel.write_dataset_validation_report is write_dataset_validation_report
+
+
+def test_dataset_validation_report_finds_pair_reference_errors(tmp_path):
+    dataset_root = tmp_path / "broken_pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "", "suffix": ".py"},
+                {"file_id": "b", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+        metadata={"name": "broken_pairs"},
+    )
+    pairs_path = dataset_root / "pairs.csv"
+    pairs = pd.read_csv(pairs_path)
+    pairs.loc[0, "right_id"] = "missing"
+    pairs.to_csv(pairs_path, index=False)
+
+    report = validate_dataset_report(dataset_root, kind="pair")
+    codes = {issue["code"] for issue in report["issues"]}
+
+    assert report["status"] == "error"
+    assert "unknown_pair_file_ids" in codes
+    assert "empty_files" in codes
+
+
+def test_dataset_validation_report_finds_retrieval_reference_errors(tmp_path):
+    dataset_root = tmp_path / "broken_retrieval"
+    write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "query_a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "doc_a", "text": "print(1)", "suffix": ".py"},
+            ]
+        ),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "query_a"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "doc_a"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+        metadata={"name": "broken_retrieval"},
+    )
+    qrels_path = dataset_root / "qrels.csv"
+    qrels = pd.read_csv(qrels_path)
+    qrels.loc[0, "document_id"] = "missing"
+    qrels.loc[0, "relevance"] = -1
+    qrels.to_csv(qrels_path, index=False)
+
+    report = validate_dataset_report(dataset_root, kind="retrieval")
+    codes = {issue["code"] for issue in report["issues"]}
+
+    assert report["status"] == "error"
+    assert "unknown_qrel_document_ids" in codes
+    assert "invalid_qrel_relevance" in codes
 
 
 def test_default_dataset_sources_include_generic_resolvers():

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -478,9 +478,62 @@ def test_dataset_pair_evaluation_exports_leaderboard_artifacts(tmp_path):
         assert "pair_scored_rows.csv" in names
         assert "pair_metrics.json" in names
         assert "pair_resampling_summary.csv" in names
+        assert "pair_threshold_tuning_threshold_sweep.csv" in names
         manifest = json.loads(archive.read("leaderboard_manifest.json").decode("utf-8"))
     assert manifest["workflow"] == "gradio_dataset_evaluation"
     assert manifest["dataset_kind"] == "pair_classification"
+
+
+def test_gradio_dataset_validation_exports_report(tmp_path):
+    dataset_root = tmp_path / "pair_dataset"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)", "suffix": ".py"},
+                {"file_id": "b", "text": "print(2)", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 0}]),
+        metadata={"name": "validation_pairs"},
+    )
+    archive_path = _zip_directory(dataset_root, tmp_path / "pair_dataset.zip")
+
+    summary_html, issues_frame, report_html, artifacts_path = gradio_app.validate_dataset_gradio(
+        archive_path,
+        "Pair Classification",
+        progress=None,
+    )
+
+    assert "Dataset Validation" in summary_html
+    assert "validation_pairs" in summary_html
+    assert "single_class_labels" in issues_frame["Code"].tolist()
+    assert "Matheel Dataset Validation" in report_html
+    with zipfile.ZipFile(artifacts_path) as archive:
+        assert "dataset_validation_report.json" in archive.namelist()
+
+
+def test_gradio_threshold_tuning_uses_scored_pair_state(tmp_path):
+    _ = tmp_path
+    state = {
+        "task": "pair",
+        "scored": [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.9, "label": 1},
+            {"left_id": "c", "right_id": "d", "similarity_score": 0.2, "label": 0},
+        ],
+    }
+
+    summary_html, sweep_frame, report_html, artifacts_path = gradio_app.threshold_tuning_gradio(
+        state,
+        "f1",
+        progress=None,
+    )
+
+    assert "Threshold Tuning" in summary_html
+    assert not sweep_frame.empty
+    assert "Threshold Tuning" in report_html
+    with zipfile.ZipFile(artifacts_path) as archive:
+        assert "threshold_tuning_threshold_sweep.csv" in archive.namelist()
 
 
 def test_dataset_pair_resampling_reports_invalid_label_folds():


### PR DESCRIPTION
## Summary
- add non-mutating normalized dataset validation reports with JSON, CSV, and HTML artifacts
- add threshold tuning reports for scored pair rows, including single-class-safe summaries
- wire dataset validation and threshold tuning into the CLI, Gradio app, docs, examples, and tests

## Tests
- python -m pytest
- python -m ruff check .
- python -m mkdocs build --strict
- python examples/evaluation/dataset_validation_demo.py
- python examples/evaluation/threshold_tuning_demo.py
- git diff --check

Closes #185.
Closes #187.