### PR TITLE
Add leaderboard details and benchmark registry

### DIFF
--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -60,11 +60,28 @@ Artifacts:
 - `run_001_aggregate.csv`: mean and median metric scores per algorithm, task, and metric.
 - `run_001.json`: machine-readable metadata, manifest, and ranking rows.
 - `run_001.html`: static aggregate and per-dataset tables.
+- `run_001_details.html`: static dataset-card and algorithm-card detail page.
 - `run_001_reproducibility.json`: package versions and normalized manifest metadata.
 
 The JSON artifact also includes dataset cards and algorithm cards. Cards keep concise metadata such as task family, counts, source type, license when present, sanitized source identifiers, algorithm options, package versions, and content fingerprints. Local absolute paths and credential-like fields are not included in card fields.
 
-The HTML artifact is a static benchmark report. It bundles aggregate rankings, per-dataset rankings, dataset cards, algorithm cards, and sanitized links to the exported CSV/JSON metadata files.
+The HTML artifact is a static benchmark report. It bundles aggregate rankings, per-dataset rankings, dataset cards, algorithm cards, and sanitized links to the exported CSV/JSON metadata files. The detail HTML artifact expands each dataset and algorithm card with the sanitized card JSON used by the benchmark report.
+
+## Run Registry
+
+Use a local benchmark registry to track exported leaderboard JSON artifacts across repeated runs:
+
+```bash
+matheel benchmark-registry add benchmark_registry.json leaderboard_artifacts/run_001.json \
+  --run-name lexical_baseline
+
+matheel benchmark-registry list benchmark_registry.json
+
+matheel benchmark-registry compare benchmark_registry.json \
+  --output benchmark_comparison.csv
+```
+
+The registry stores sanitized leaderboard payloads and artifact filenames. It is intended for local experiment tracking and does not store absolute dataset paths or credentials.
 
 ## Runnable Example
 

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -114,6 +114,18 @@ matheel explain-pair \
 
 The JSON artifact stores segment offsets, line numbers, match ids, scores, thresholds, and segmentation metadata. The HTML artifact uses the same data for local inspection.
 
+To explain a pair selected from scored dataset rows:
+
+```bash
+matheel explain-pair \
+  --dataset normalized_pairs \
+  --scores pair_scored_rows.csv \
+  --score-row-index 0 \
+  --output-dir pair_explanations
+```
+
+The scored-row workflow records the selected row index, score column, label column, and selected scored-row fields in the explanation metadata.
+
 ```python
 from matheel.visualization import build_pair_explanation, write_pair_explanation_artifacts
 
@@ -128,6 +140,20 @@ artifacts = write_pair_explanation_artifacts(
     "pair_explanations",
 )
 
+print(artifacts["html"])
+```
+
+```python
+from matheel.visualization import write_scored_pair_explanation
+
+explanation, artifacts = write_scored_pair_explanation(
+    "pair_scored_rows.csv",
+    "normalized_pairs",
+    "pair_explanations",
+    row_index=0,
+)
+
+print(explanation["metadata"]["similarity_score"])
 print(artifacts["html"])
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Examples are grouped by workflow:
 
 - `basic/`: preprocessing, chunking, lexical scoring, vectors, code metrics, and archive ranking.
-- `evaluation/`: dataset adapters, validation reports, threshold tuning, comparison suites, calibration reports, dataset maps, pair explanations, leaderboards, and reproducible benchmark outputs.
+- `evaluation/`: dataset adapters, validation reports, threshold tuning, comparison suites, calibration reports, dataset maps, scored pair explanations, leaderboards, and reproducible benchmark outputs.
 - `custom/`: custom `score_pair` algorithm modules.
 - `notebooks/`: ordered Colab notebooks.
 - `sample_data.py`: deterministic generator for the tiny Java sample archive used by examples and docs.

--- a/examples/evaluation/visualization_demo.py
+++ b/examples/evaluation/visualization_demo.py
@@ -10,7 +10,11 @@ _MPLCONFIGDIR.mkdir(parents=True, exist_ok=True)
 os.environ.setdefault("MPLCONFIGDIR", os.fspath(_MPLCONFIGDIR))
 
 from matheel.datasets import write_pair_dataset  # noqa: E402
-from matheel.visualization import write_dataset_embedding_map, write_pair_dataset_explanation  # noqa: E402
+from matheel.visualization import (  # noqa: E402
+    write_dataset_embedding_map,
+    write_pair_dataset_explanation,
+    write_scored_pair_explanation,
+)
 
 
 def main():
@@ -55,6 +59,22 @@ def main():
 
         print("Pair matches:", len(explanation["matches"]))
         print("Pair HTML artifact:", pair_artifacts["html"])
+
+        scored_pairs = pd.DataFrame(
+            [
+                {"left_id": "a", "right_id": "b", "similarity_score": 0.94, "label": 1},
+                {"left_id": "a", "right_id": "c", "similarity_score": 0.21, "label": 0},
+            ]
+        )
+        scored_explanation, scored_artifacts = write_scored_pair_explanation(
+            scored_pairs,
+            dataset_root,
+            workspace / "scored_pair_explanations",
+            row_index=0,
+        )
+
+        print("Scored pair score:", scored_explanation["metadata"]["similarity_score"])
+        print("Scored pair HTML artifact:", scored_artifacts["html"])
 
 
 if __name__ == "__main__":

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -63,6 +63,7 @@ from matheel.visualization import (
     pair_explanation_html,
     write_dataset_map_artifacts,
     write_pair_explanation_artifacts,
+    write_scored_pair_explanation,
 )
 
 
@@ -2503,6 +2504,58 @@ def threshold_tuning_gradio(scored_state, optimize, progress=gr.Progress(track_t
     )
 
 
+def explain_scored_pair_gradio(
+    scored_state,
+    row_index,
+    segment_mode,
+    high_threshold,
+    medium_threshold,
+    low_threshold,
+    chunk_size,
+    progress=gr.Progress(track_tqdm=True),
+):
+    if not scored_state:
+        return empty_pair_explanation_summary_html(), pd.DataFrame(), "", None
+    if scored_state.get("task") != "pair":
+        raise gr.Error("Scored pair explanations are only available for pair-classification scores.")
+    dataset_root = scored_state.get("dataset_root")
+    if not dataset_root:
+        raise gr.Error("Run pair dataset evaluation before explaining a scored pair.")
+    scored = pd.DataFrame(scored_state.get("scored") or [])
+    if scored.empty:
+        return empty_pair_explanation_summary_html(), pd.DataFrame(), "", None
+    if progress is not None:
+        progress(0.35, desc="Building pair explanation")
+    export_root = Path(tempfile.mkdtemp(prefix="matheel-scored-pair-explanation-"))
+    try:
+        explanation, artifacts = write_scored_pair_explanation(
+            scored,
+            dataset_root,
+            export_root,
+            row_index=int(float(row_index or 0)),
+            segment_mode=segment_mode,
+            high_threshold=float(high_threshold),
+            medium_threshold=float(medium_threshold),
+            low_threshold=float(low_threshold),
+            chunk_size=int(float(chunk_size or 1)),
+            basename="scored_pair_explanation",
+        )
+    except ValueError as exc:
+        raise gr.Error(str(exc)) from exc
+    artifacts_zip = _zip_artifact_paths(
+        artifacts.values(),
+        export_root / "scored_pair_explanation_artifacts.zip",
+    )
+    if progress is not None:
+        progress(1.0, desc="Pair explanation complete")
+    return (
+        pair_explanation_summary_html(explanation),
+        pair_explanation_matches_frame(explanation),
+        artifacts["html"].read_text(encoding="utf-8"),
+        artifacts_zip,
+    )
+
+
 def evaluate_dataset_gradio(
     dataset_file,
     task_label,
@@ -2602,8 +2655,16 @@ def evaluate_dataset_gradio_with_state(*args, **kwargs):
     outputs = evaluate_dataset_gradio(*args, **kwargs)
     scored = outputs[2]
     task_label = args[1] if len(args) > 1 else kwargs.get("task_label", DEFAULT_DATASET_TASK)
+    dataset_file = args[0] if args else kwargs.get("dataset_file")
+    dataset_root = None
+    if dataset_file is not None:
+        try:
+            dataset_root = os.fspath(_dataset_root_from_upload(dataset_file, task_label))
+        except gr.Error:
+            dataset_root = None
     state = {
         "task": "retrieval" if str(task_label).startswith("Retrieval") else "pair",
+        "dataset_root": dataset_root,
         "scored": _state_scored_records(scored),
     }
     return (*outputs, state)
@@ -4296,6 +4357,21 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     )
                     dataset_threshold_report = gr.HTML(value="", padding=False)
                     dataset_threshold_artifacts = gr.File(label="Threshold Tuning Artifacts")
+                    dataset_pair_explain_summary = gr.HTML(
+                        value=empty_pair_explanation_summary_html(),
+                        padding=False,
+                    )
+                    dataset_pair_explain_matches = gr.Dataframe(
+                        label="Scored Pair Matches",
+                        wrap=False,
+                        interactive=False,
+                        max_height=260,
+                        row_count=1,
+                        show_search="filter",
+                        elem_classes=["matheel-table"],
+                    )
+                    dataset_pair_explain_report = gr.HTML(value="", padding=False)
+                    dataset_pair_explain_artifacts = gr.File(label="Scored Pair Explanation Artifacts")
 
                 with gr.Column(scale=5):
                     with gr.Accordion("Dataset", open=True):
@@ -4376,6 +4452,46 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                             label="Threshold Tuning Metric",
                         )
                         dataset_threshold_tune = gr.Button("Tune Pair Threshold", variant="secondary")
+                    with gr.Accordion("Scored Pair Explanation", open=False):
+                        dataset_pair_explain_row = gr.Number(
+                            value=0,
+                            precision=0,
+                            label="Scored Row",
+                        )
+                        dataset_pair_explain_segment_mode = gr.Dropdown(
+                            choices=list(available_pair_explanation_segment_modes()),
+                            value="line",
+                            label="Segment Mode",
+                        )
+                        dataset_pair_explain_high_threshold = gr.Slider(
+                            0,
+                            1,
+                            value=0.85,
+                            step=0.01,
+                            label="High Similarity Threshold",
+                        )
+                        dataset_pair_explain_medium_threshold = gr.Slider(
+                            0,
+                            1,
+                            value=0.6,
+                            step=0.01,
+                            label="Medium Similarity Threshold",
+                        )
+                        dataset_pair_explain_low_threshold = gr.Slider(
+                            0,
+                            1,
+                            value=0.3,
+                            step=0.01,
+                            label="Low Similarity Threshold",
+                        )
+                        dataset_pair_explain_chunk_size = gr.Slider(
+                            1,
+                            50,
+                            value=5,
+                            step=1,
+                            label="Chunk Lines",
+                        )
+                        dataset_pair_explain_run = gr.Button("Explain Scored Pair", variant="secondary")
 
             dataset_task.change(
                 update_dataset_task_sections,
@@ -4427,6 +4543,24 @@ with gr.Blocks(title="Matheel Framework", fill_width=True, elem_id="matheel-app"
                     dataset_threshold_sweep,
                     dataset_threshold_report,
                     dataset_threshold_artifacts,
+                ],
+            )
+            dataset_pair_explain_run.click(
+                explain_scored_pair_gradio,
+                inputs=[
+                    dataset_scored_state,
+                    dataset_pair_explain_row,
+                    dataset_pair_explain_segment_mode,
+                    dataset_pair_explain_high_threshold,
+                    dataset_pair_explain_medium_threshold,
+                    dataset_pair_explain_low_threshold,
+                    dataset_pair_explain_chunk_size,
+                ],
+                outputs=[
+                    dataset_pair_explain_summary,
+                    dataset_pair_explain_matches,
+                    dataset_pair_explain_report,
+                    dataset_pair_explain_artifacts,
                 ],
             )
 

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -31,6 +31,15 @@ from .benchmark_cards import (
     dataset_card,
     leaderboard_cards,
 )
+from .benchmark_registry import (
+    compare_benchmark_runs,
+    empty_benchmark_registry,
+    list_benchmark_runs,
+    load_benchmark_registry,
+    load_benchmark_run,
+    register_benchmark_run,
+    write_benchmark_registry,
+)
 from .chunking import chunk_text, chunker_parameter_names
 from .calibration import (
     calibrate_threshold,
@@ -132,7 +141,12 @@ from .reproducibility import (
     fingerprint_source,
     write_reproducibility_snapshot,
 )
-from .reports import benchmark_report_html, write_benchmark_report
+from .reports import (
+    benchmark_detail_report_html,
+    benchmark_report_html,
+    write_benchmark_detail_report,
+    write_benchmark_report,
+)
 from .vectors import (
     available_pooling_methods,
     available_similarity_functions,
@@ -142,6 +156,7 @@ from .visualization import (
     available_pair_explanation_segment_modes,
     available_projection_methods,
     build_pair_dataset_explanation,
+    build_scored_pair_explanation,
     build_dataset_embedding_map,
     build_embedding_projection,
     build_pair_explanation,
@@ -155,6 +170,7 @@ from .visualization import (
     write_dataset_map_artifacts,
     write_pair_explanation,
     write_pair_explanation_artifacts,
+    write_scored_pair_explanation,
 )
 from .similarity import (
     available_lexical_tokenizers,
@@ -193,6 +209,7 @@ __all__ = [
     "benchmark_cache_key_for_run",
     "benchmark_cache_paths",
     "benchmark_dependency_versions",
+    "benchmark_detail_report_html",
     "benchmark_report_html",
     "calibrate_threshold",
     "calibration_curve",
@@ -205,6 +222,7 @@ __all__ = [
     "clear_benchmark_cache",
     "codebleu_components",
     "collect_reproducibility_snapshot",
+    "compare_benchmark_runs",
     "compare_metric_samples",
     "DataSplit",
     "adapt_pair_dataset",
@@ -214,6 +232,7 @@ __all__ = [
     "dataset_validation_report_html",
     "dataset_validation_report_payload",
     "default_feature_weights",
+    "empty_benchmark_registry",
     "evaluate_threshold",
     "evaluate_pair_dataset",
     "evaluate_pair_resamples",
@@ -230,8 +249,11 @@ __all__ = [
     "leaderboard_cards",
     "leaderboard_html",
     "leaderboard_payload",
+    "list_benchmark_runs",
     "load_code_texts",
     "load_benchmark_cache_result",
+    "load_benchmark_registry",
+    "load_benchmark_run",
     "load_dataset_manifest",
     "load_leaderboard_manifest",
     "load_pair_dataset",
@@ -254,6 +276,7 @@ __all__ = [
     "preprocess_code",
     "prepare_algorithm_dataset",
     "registered_datasets",
+    "register_benchmark_run",
     "register_dataset_adapter",
     "register_dataset_entry",
     "register_dataset_preset",
@@ -287,6 +310,7 @@ __all__ = [
     "build_embedding_projection",
     "build_pair_dataset_explanation",
     "build_pair_explanation",
+    "build_scored_pair_explanation",
     "dataset_map_html",
     "dataset_map_payload",
     "pair_explanation_html",
@@ -305,9 +329,12 @@ __all__ = [
     "write_dataset_validation_report",
     "write_threshold_tuning_report_artifacts",
     "write_benchmark_cache_result",
+    "write_benchmark_detail_report",
     "write_benchmark_report",
+    "write_benchmark_registry",
     "write_leaderboard_artifacts",
     "write_pair_dataset_explanation",
     "write_pair_explanation",
     "write_pair_explanation_artifacts",
+    "write_scored_pair_explanation",
 ]

--- a/matheel/benchmark_registry.py
+++ b/matheel/benchmark_registry.py
@@ -1,0 +1,215 @@
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from .leaderboard import leaderboard_payload
+
+
+REGISTRY_SCHEMA_VERSION = 1
+
+
+def empty_benchmark_registry():
+    return {"schema_version": REGISTRY_SCHEMA_VERSION, "runs": []}
+
+
+def load_benchmark_registry(registry_path):
+    path = Path(registry_path)
+    if not path.exists():
+        return empty_benchmark_registry()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Benchmark registry must be a JSON object.")
+    runs = payload.get("runs")
+    if runs is None:
+        runs = []
+    if not isinstance(runs, list):
+        raise ValueError("Benchmark registry runs must be a list.")
+    return {
+        "schema_version": int(payload.get("schema_version") or REGISTRY_SCHEMA_VERSION),
+        "runs": [_clean_json_object(run) for run in runs],
+    }
+
+
+def write_benchmark_registry(registry_path, registry):
+    path = Path(registry_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": int(registry.get("schema_version") or REGISTRY_SCHEMA_VERSION),
+        "runs": [_clean_json_object(run) for run in registry.get("runs", [])],
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def register_benchmark_run(registry_path, report_or_path, run_name=None, artifact_paths=None):
+    registry = load_benchmark_registry(registry_path)
+    payload = _coerce_leaderboard_payload(report_or_path)
+    name = str(run_name or payload.get("metadata", {}).get("name") or "benchmark_run")
+    run_id = _run_id(name, payload)
+    entry = {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "run_id": run_id,
+        "name": name,
+        "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "metadata": _clean_json_object(payload.get("metadata", {})),
+        "manifest": _clean_json_object(payload.get("manifest", {})),
+        "cards": _clean_json_object(payload.get("cards", {})),
+        "aggregate": _clean_json_object(payload.get("aggregate", [])),
+        "per_dataset": _clean_json_object(payload.get("per_dataset", [])),
+        "artifacts": _sanitize_artifact_paths(artifact_paths),
+    }
+    registry["runs"] = [run for run in registry.get("runs", []) if run.get("run_id") != run_id]
+    registry["runs"].append(entry)
+    registry["runs"].sort(key=lambda run: (str(run.get("created_at") or ""), str(run.get("run_id") or "")))
+    write_benchmark_registry(registry_path, registry)
+    return entry
+
+
+def list_benchmark_runs(registry_path):
+    registry = load_benchmark_registry(registry_path)
+    rows = []
+    for run in registry.get("runs", []):
+        aggregate = pd.DataFrame(run.get("aggregate") or [])
+        per_dataset = pd.DataFrame(run.get("per_dataset") or [])
+        rows.append(
+            {
+                "run_id": run.get("run_id"),
+                "name": run.get("name"),
+                "created_at": run.get("created_at"),
+                "aggregate_rows": int(len(aggregate)),
+                "per_dataset_rows": int(len(per_dataset)),
+                "datasets": int(per_dataset["dataset_name"].nunique()) if "dataset_name" in per_dataset else 0,
+                "algorithms": int(aggregate["algorithm_name"].nunique()) if "algorithm_name" in aggregate else 0,
+                "metrics": int(aggregate["metric"].nunique()) if "metric" in aggregate else 0,
+            }
+        )
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "run_id",
+            "name",
+            "created_at",
+            "aggregate_rows",
+            "per_dataset_rows",
+            "datasets",
+            "algorithms",
+            "metrics",
+        ],
+    )
+
+
+def load_benchmark_run(registry_path, run_id):
+    registry = load_benchmark_registry(registry_path)
+    for run in registry.get("runs", []):
+        if str(run.get("run_id")) == str(run_id):
+            return run
+    raise KeyError(f"Benchmark run not found: {run_id}")
+
+
+def compare_benchmark_runs(registry_path, run_ids=None):
+    registry = load_benchmark_registry(registry_path)
+    selected_ids = [str(run_id) for run_id in run_ids or ()]
+    runs = [
+        run
+        for run in registry.get("runs", [])
+        if not selected_ids or str(run.get("run_id")) in selected_ids
+    ]
+    if selected_ids:
+        found = {str(run.get("run_id")) for run in runs}
+        missing = sorted(set(selected_ids).difference(found))
+        if missing:
+            raise KeyError(f"Benchmark run not found: {', '.join(missing)}")
+        runs.sort(key=lambda run: selected_ids.index(str(run.get("run_id"))))
+
+    frames = []
+    for order, run in enumerate(runs):
+        frame = pd.DataFrame(run.get("aggregate") or [])
+        if frame.empty:
+            continue
+        frame = frame.copy()
+        frame.insert(0, "run_order", order)
+        frame.insert(1, "run_id", run.get("run_id"))
+        frame.insert(2, "run_name", run.get("name"))
+        frames.append(frame)
+    if not frames:
+        return pd.DataFrame()
+
+    combined = pd.concat(frames, ignore_index=True)
+    combined["mean_score"] = pd.to_numeric(combined.get("mean_score"), errors="coerce")
+    key_columns = ["task_family", "algorithm_name", "metric"]
+    baseline = (
+        combined[combined["run_order"] == combined["run_order"].min()][key_columns + ["mean_score"]]
+        .rename(columns={"mean_score": "baseline_mean_score"})
+        .drop_duplicates(subset=key_columns)
+    )
+    compared = combined.merge(baseline, on=key_columns, how="left")
+    compared["delta_mean_score"] = compared["mean_score"] - compared["baseline_mean_score"]
+    return compared.sort_values(
+        by=["task_family", "metric", "algorithm_name", "run_order"],
+        ignore_index=True,
+    )
+
+
+def _coerce_leaderboard_payload(report_or_path):
+    if isinstance(report_or_path, (str, Path)):
+        payload = json.loads(Path(report_or_path).read_text(encoding="utf-8"))
+    elif _looks_like_payload(report_or_path):
+        payload = dict(report_or_path)
+    else:
+        payload = leaderboard_payload(report_or_path)
+    if not _looks_like_payload(payload):
+        raise ValueError("Expected a Matheel leaderboard report or JSON artifact.")
+    return _clean_json_object(payload)
+
+
+def _looks_like_payload(value):
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("metadata"), dict)
+        and isinstance(value.get("aggregate"), list)
+        and isinstance(value.get("per_dataset"), list)
+    )
+
+
+def _run_id(name, payload):
+    stem = _slugify(name)
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()[:12]
+    return f"{stem}-{digest}"
+
+
+def _slugify(value):
+    text = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "benchmark-run").strip().lower())
+    text = text.strip(".-_")
+    return text or "benchmark-run"
+
+
+def _sanitize_artifact_paths(artifact_paths):
+    if artifact_paths is None:
+        return {}
+    if isinstance(artifact_paths, dict):
+        raw = artifact_paths.items()
+    else:
+        raw = ((Path(str(path)).stem, path) for path in artifact_paths)
+    return {
+        str(name): Path(str(path)).name
+        for name, path in raw
+        if path not in (None, "")
+    }
+
+
+def _clean_json_object(value):
+    return json.loads(json.dumps(value, default=_json_default, allow_nan=False))
+
+
+def _json_default(value):
+    if isinstance(value, Path):
+        return value.name
+    if hasattr(value, "item"):
+        return value.item()
+    if pd.isna(value):
+        return None
+    return str(value)

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from . import __version__
 from .algorithms import normalize_algorithm_options, score_source_pairs_with_algorithm
+from .benchmark_registry import compare_benchmark_runs, list_benchmark_runs, register_benchmark_run
 from .calibration import write_calibration_report_artifacts, write_threshold_tuning_report_artifacts
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
@@ -50,6 +51,7 @@ from .visualization import (
     write_dataset_embedding_map,
     write_pair_dataset_explanation,
     write_pair_explanation,
+    write_scored_pair_explanation,
 )
 
 @click.group()
@@ -636,8 +638,19 @@ def visualize_dataset(dataset_path, kind, method, seed, static_vector_dim, outpu
     help="Normalized pair dataset to read the selected pair from.",
 )
 @click.option("--pair-index", default=0, show_default=True, help="Zero-based pair row for --dataset.")
+@click.option(
+    "--scores",
+    "scores_path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="Scored pair CSV/JSON rows to select a dataset pair from.",
+)
+@click.option("--score-row-index", default=0, show_default=True, help="Zero-based scored row for --scores.")
 @click.option("--left-id", help="Left file id for selecting a dataset pair.")
 @click.option("--right-id", help="Right file id for selecting a dataset pair.")
+@click.option("--left-column", default="left_id", show_default=True, help="Scored pair left-id column.")
+@click.option("--right-column", default="right_id", show_default=True, help="Scored pair right-id column.")
+@click.option("--score-column", default="similarity_score", show_default=True, help="Scored pair score column.")
+@click.option("--label-column", default="label", show_default=True, help="Scored pair label column.")
 @click.option(
     "--source",
     "source_path",
@@ -676,8 +689,14 @@ def explain_pair(
     right_path,
     dataset_path,
     pair_index,
+    scores_path,
+    score_row_index,
     left_id,
     right_id,
+    left_column,
+    right_column,
+    score_column,
+    label_column,
     source_path,
     left_name,
     right_name,
@@ -701,21 +720,43 @@ def explain_pair(
         raise click.UsageError("--dataset uses --left-id/--right-id, not --left-name/--right-name.")
     if source_path and (left_id or right_id):
         raise click.UsageError("--source uses --left-name/--right-name, not --left-id/--right-id.")
+    if scores_path and not dataset_path:
+        raise click.UsageError("--scores can only be used with --dataset.")
 
     if dataset_path:
-        explanation, artifacts = write_pair_dataset_explanation(
-            dataset_path,
-            output_dir,
-            pair_index=pair_index,
-            left_id=left_id,
-            right_id=right_id,
-            segment_mode=segment_mode,
-            high_threshold=high_threshold,
-            medium_threshold=medium_threshold,
-            low_threshold=low_threshold,
-            chunk_size=chunk_size,
-            basename=basename,
-        )
+        if scores_path:
+            explanation, artifacts = write_scored_pair_explanation(
+                scores_path,
+                dataset_path,
+                output_dir,
+                row_index=score_row_index,
+                left_id=left_id,
+                right_id=right_id,
+                left_column=left_column,
+                right_column=right_column,
+                score_column=score_column,
+                label_column=label_column,
+                segment_mode=segment_mode,
+                high_threshold=high_threshold,
+                medium_threshold=medium_threshold,
+                low_threshold=low_threshold,
+                chunk_size=chunk_size,
+                basename=basename,
+            )
+        else:
+            explanation, artifacts = write_pair_dataset_explanation(
+                dataset_path,
+                output_dir,
+                pair_index=pair_index,
+                left_id=left_id,
+                right_id=right_id,
+                segment_mode=segment_mode,
+                high_threshold=high_threshold,
+                medium_threshold=medium_threshold,
+                low_threshold=low_threshold,
+                chunk_size=chunk_size,
+                basename=basename,
+            )
     elif source_path:
         left_code, right_code = _source_pair_texts(source_path, left_name, right_name)
         explanation, artifacts = write_pair_explanation(
@@ -909,6 +950,103 @@ def leaderboard_command(config_file, output_dir, basename, output_format):
         basename=basename,
     )
     _echo_leaderboard_summary(report, artifacts, output_format)
+
+
+@main.group(name="benchmark-registry")
+def benchmark_registry_group():
+    """Track and compare exported leaderboard runs."""
+
+
+@benchmark_registry_group.command(name="add")
+@click.argument("registry_file", type=click.Path(dir_okay=False))
+@click.argument("leaderboard_json", type=click.Path(exists=True, file_okay=True, dir_okay=False))
+@click.option("--run-name", help="Human-readable run name. Defaults to the leaderboard metadata name.")
+@click.option(
+    "--artifact",
+    "artifact_paths",
+    multiple=True,
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    help="Optional exported artifact path to record by filename.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def benchmark_registry_add_command(registry_file, leaderboard_json, run_name, artifact_paths, output_format):
+    """Add or replace a leaderboard JSON artifact in a benchmark registry."""
+    entry = register_benchmark_run(
+        registry_file,
+        leaderboard_json,
+        run_name=run_name,
+        artifact_paths=artifact_paths,
+    )
+    summary = {
+        "registry": str(registry_file),
+        "run_id": entry["run_id"],
+        "name": entry["name"],
+        "aggregate_rows": len(entry.get("aggregate") or []),
+        "per_dataset_rows": len(entry.get("per_dataset") or []),
+    }
+    if output_format == "json":
+        _echo_json(summary)
+        return
+    click.echo(f"run_id={summary['run_id']}")
+    click.echo(f"name={summary['name']}")
+    click.echo(f"aggregate_rows={summary['aggregate_rows']}")
+    click.echo(f"per_dataset_rows={summary['per_dataset_rows']}")
+
+
+@benchmark_registry_group.command(name="list")
+@click.argument("registry_file", type=click.Path(exists=True, file_okay=True, dir_okay=False))
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json")),
+    default="text",
+    show_default=True,
+)
+def benchmark_registry_list_command(registry_file, output_format):
+    """List runs tracked in a benchmark registry."""
+    runs = list_benchmark_runs(registry_file)
+    if output_format == "json":
+        _echo_json(runs.to_dict(orient="records"))
+        return
+    click.echo(runs.to_string(index=False) if not runs.empty else "No benchmark runs.")
+
+
+@benchmark_registry_group.command(name="compare")
+@click.argument("registry_file", type=click.Path(exists=True, file_okay=True, dir_okay=False))
+@click.option("--run-id", "run_ids", multiple=True, help="Run id to include. Repeat to choose order.")
+@click.option("--output", "output_path", type=click.Path(dir_okay=False), help="Optional CSV or JSON output path.")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(("text", "json", "csv")),
+    default="text",
+    show_default=True,
+)
+def benchmark_registry_compare_command(registry_file, run_ids, output_path, output_format):
+    """Compare aggregate leaderboard metrics across registry runs."""
+    comparison = compare_benchmark_runs(registry_file, run_ids=run_ids or None)
+    if output_path:
+        target = Path(output_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.suffix.lower() == ".json" or output_format == "json":
+            target.write_text(json.dumps(comparison.to_dict(orient="records"), indent=2, sort_keys=True), encoding="utf-8")
+        else:
+            comparison.to_csv(target, index=False)
+        click.echo(f"output={target}")
+        return
+    if output_format == "json":
+        _echo_json(comparison.to_dict(orient="records"))
+        return
+    if output_format == "csv":
+        click.echo(comparison.to_csv(index=False))
+        return
+    click.echo(comparison.to_string(index=False) if not comparison.empty else "No benchmark comparison rows.")
 
 
 @main.command()

--- a/matheel/leaderboard.py
+++ b/matheel/leaderboard.py
@@ -169,13 +169,14 @@ def write_leaderboard_artifacts(report, output_dir, basename="leaderboard"):
         "aggregate_csv": target / f"{stem}_aggregate.csv",
         "json": target / f"{stem}.json",
         "html": target / f"{stem}.html",
+        "details_html": target / f"{stem}_details.html",
         "reproducibility_json": target / f"{stem}_reproducibility.json",
     }
     payload = leaderboard_payload(report)
     report["per_dataset"].to_csv(artifacts["per_dataset_csv"], index=False)
     report["aggregate"].to_csv(artifacts["aggregate_csv"], index=False)
     artifacts["json"].write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-    from .reports import benchmark_report_html
+    from .reports import benchmark_detail_report_html, benchmark_report_html
 
     artifacts["html"].write_text(
         benchmark_report_html(
@@ -185,6 +186,18 @@ def write_leaderboard_artifacts(report, output_dir, basename="leaderboard"):
                 name: path
                 for name, path in artifacts.items()
                 if name != "html"
+            },
+        ),
+        encoding="utf-8",
+    )
+    artifacts["details_html"].write_text(
+        benchmark_detail_report_html(
+            report,
+            title=f"{report['metadata'].get('name') or 'Matheel Leaderboard'} Details",
+            artifact_links={
+                name: path
+                for name, path in artifacts.items()
+                if name != "details_html"
             },
         ),
         encoding="utf-8",

--- a/matheel/reports.py
+++ b/matheel/reports.py
@@ -1,4 +1,5 @@
 import html
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -81,6 +82,80 @@ def write_benchmark_report(report, output_path, title=None, artifact_links=None)
     return target
 
 
+def benchmark_detail_report_html(report, title=None, artifact_links=None):
+    payload = leaderboard_payload(report)
+    report_title = str(title or payload["metadata"].get("name") or "Matheel Benchmark Details")
+    cards = payload.get("cards", {})
+    links = _sanitize_artifact_links(artifact_links or {})
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{html.escape(report_title)}</title>
+  <style>
+    :root {{ color-scheme: light; }}
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #111827; background: #ffffff; }}
+    header {{ padding: 24px 28px; border-bottom: 1px solid #d1d5db; background: #f9fafb; }}
+    main {{ padding: 20px 28px 32px; }}
+    h1 {{ font-size: 1.6rem; margin: 0 0 8px; }}
+    h2 {{ font-size: 1.15rem; margin: 28px 0 10px; }}
+    h3 {{ font-size: 1rem; margin: 0; }}
+    .meta {{ color: #4b5563; margin: 0; }}
+    details {{ border: 1px solid #d1d5db; border-radius: 8px; margin-bottom: 12px; background: #ffffff; }}
+    summary {{ cursor: pointer; padding: 12px 14px; background: #f3f4f6; }}
+    .detail-body {{ padding: 12px 14px; }}
+    dl {{ display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 6px 12px; margin: 0 0 12px; }}
+    dt {{ color: #4b5563; font-weight: 600; }}
+    dd {{ margin: 0; overflow-wrap: anywhere; }}
+    pre {{ white-space: pre-wrap; overflow-x: auto; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 10px; }}
+    table {{ border-collapse: collapse; width: 100%; font-size: 0.9rem; margin-bottom: 12px; }}
+    th, td {{ border: 1px solid #e5e7eb; padding: 6px 8px; text-align: left; }}
+    th {{ background: #f3f4f6; }}
+    code {{ background: #f3f4f6; padding: 1px 4px; border-radius: 4px; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{html.escape(report_title)}</h1>
+    <p class="meta">schema={payload.get("schema_version", 1)}; seed={html.escape(str(payload["metadata"].get("seed") or ""))}</p>
+  </header>
+  <main>
+    <section>
+      <h2>Dataset Details</h2>
+      {_detail_cards_html(cards.get("datasets", []))}
+    </section>
+    <section>
+      <h2>Algorithm Details</h2>
+      {_detail_cards_html(cards.get("algorithms", []))}
+    </section>
+    <section>
+      <h2>Aggregate Rows</h2>
+      {_table_html(pd.DataFrame(payload["aggregate"]))}
+    </section>
+    <section>
+      <h2>Per-Dataset Rows</h2>
+      {_table_html(pd.DataFrame(payload["per_dataset"]))}
+    </section>
+    <section>
+      <h2>Artifacts</h2>
+      {_artifact_links_html(links)}
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def write_benchmark_detail_report(report, output_path, title=None, artifact_links=None):
+    target = Path(output_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        benchmark_detail_report_html(report, title=title, artifact_links=artifact_links),
+        encoding="utf-8",
+    )
+    return target
+
+
 def _table_html(frame):
     if frame.empty:
         return "<p>No rows.</p>"
@@ -91,6 +166,12 @@ def _cards_html(cards):
     if not cards:
         return '<p class="card">No cards.</p>'
     return "\n".join(_card_html(card) for card in cards)
+
+
+def _detail_cards_html(cards):
+    if not cards:
+        return "<p>No cards.</p>"
+    return "\n".join(_detail_card_html(card) for card in cards)
 
 
 def _card_html(card):
@@ -119,6 +200,22 @@ def _card_html(card):
     if not rows:
         rows.append("<dt>card</dt><dd>empty</dd>")
     return f'<article class="card"><dl>{"".join(rows)}</dl></article>'
+
+
+def _detail_card_html(card):
+    title = str(card.get("name") or card.get("card_type") or "card")
+    summary = html.escape(title)
+    rows = []
+    for key, value in card.items():
+        if isinstance(value, (dict, list, tuple)):
+            continue
+        if value not in (None, ""):
+            rows.append(f"<dt>{html.escape(str(key))}</dt><dd>{html.escape(str(value))}</dd>")
+    json_payload = html.escape(json.dumps(card, indent=2, sort_keys=True))
+    return (
+        f"<details><summary><h3>{summary}</h3></summary>"
+        f'<div class="detail-body"><dl>{"".join(rows)}</dl><pre><code>{json_payload}</code></pre></div></details>'
+    )
 
 
 def _artifact_links_html(links):

--- a/matheel/visualization.py
+++ b/matheel/visualization.py
@@ -448,6 +448,146 @@ def write_pair_dataset_explanation(
     return explanation, artifacts
 
 
+def build_scored_pair_explanation(
+    scored_pairs,
+    dataset,
+    row_index=0,
+    left_id=None,
+    right_id=None,
+    left_column="left_id",
+    right_column="right_id",
+    score_column="similarity_score",
+    label_column="label",
+    segment_mode="line",
+    high_threshold=0.85,
+    medium_threshold=0.6,
+    low_threshold=0.3,
+    chunk_size=5,
+):
+    frame = _coerce_scored_pairs(scored_pairs)
+    row = _select_scored_pair_row(
+        frame,
+        row_index=row_index,
+        left_id=left_id,
+        right_id=right_id,
+        left_column=left_column,
+        right_column=right_column,
+    )
+    explanation = build_pair_dataset_explanation(
+        dataset,
+        left_id=row[left_column],
+        right_id=row[right_column],
+        segment_mode=segment_mode,
+        high_threshold=high_threshold,
+        medium_threshold=medium_threshold,
+        low_threshold=low_threshold,
+        chunk_size=chunk_size,
+    )
+    explanation["metadata"]["scored_row_index"] = int(row.name) if getattr(row, "name", None) is not None else int(row_index)
+    if score_column in row.index and pd.notna(row[score_column]):
+        explanation["metadata"]["similarity_score"] = float(row[score_column])
+        explanation["metadata"]["score_column"] = str(score_column)
+    if label_column in row.index and pd.notna(row[label_column]):
+        explanation["metadata"]["scored_label"] = _json_safe_dict({"value": row[label_column]})["value"]
+        explanation["metadata"]["label_column"] = str(label_column)
+    explanation["metadata"]["scored_pair"] = _json_safe_dict(row.to_dict())
+    return explanation
+
+
+def write_scored_pair_explanation(
+    scored_pairs,
+    dataset,
+    output_dir,
+    row_index=0,
+    left_id=None,
+    right_id=None,
+    left_column="left_id",
+    right_column="right_id",
+    score_column="similarity_score",
+    label_column="label",
+    segment_mode="line",
+    high_threshold=0.85,
+    medium_threshold=0.6,
+    low_threshold=0.3,
+    chunk_size=5,
+    basename=None,
+    title=None,
+):
+    explanation = build_scored_pair_explanation(
+        scored_pairs,
+        dataset,
+        row_index=row_index,
+        left_id=left_id,
+        right_id=right_id,
+        left_column=left_column,
+        right_column=right_column,
+        score_column=score_column,
+        label_column=label_column,
+        segment_mode=segment_mode,
+        high_threshold=high_threshold,
+        medium_threshold=medium_threshold,
+        low_threshold=low_threshold,
+        chunk_size=chunk_size,
+    )
+    metadata = explanation["metadata"]
+    resolved_basename = basename or f"{metadata['left_id']}_vs_{metadata['right_id']}_scored"
+    artifacts = write_pair_explanation_artifacts(
+        explanation,
+        output_dir,
+        basename=resolved_basename,
+        title=title,
+    )
+    return explanation, artifacts
+
+
+def _coerce_scored_pairs(scored_pairs):
+    if isinstance(scored_pairs, pd.DataFrame):
+        frame = scored_pairs.copy()
+    elif isinstance(scored_pairs, (str, Path)):
+        path = Path(scored_pairs)
+        if path.suffix.lower() == ".json":
+            frame = pd.read_json(path)
+        else:
+            frame = pd.read_csv(path)
+    else:
+        frame = pd.DataFrame(scored_pairs)
+    if frame.empty:
+        raise ValueError("scored_pairs must contain at least one row.")
+    return frame
+
+
+def _select_scored_pair_row(
+    scored_pairs,
+    row_index=0,
+    left_id=None,
+    right_id=None,
+    left_column="left_id",
+    right_column="right_id",
+):
+    frame = scored_pairs.copy()
+    missing = [column for column in (left_column, right_column) if column not in frame.columns]
+    if missing:
+        raise ValueError(f"scored_pairs is missing required columns: {', '.join(missing)}")
+    if left_id is not None or right_id is not None:
+        if left_id is None or right_id is None:
+            raise ValueError("Both left_id and right_id are required when selecting a scored pair by id.")
+        mask = (frame[left_column].astype(str) == str(left_id)) & (frame[right_column].astype(str) == str(right_id))
+        if not mask.any():
+            reverse_mask = (frame[left_column].astype(str) == str(right_id)) & (
+                frame[right_column].astype(str) == str(left_id)
+            )
+            if reverse_mask.any():
+                mask = reverse_mask
+        matches = frame[mask]
+        if matches.empty:
+            raise ValueError(f"Scored pairs do not contain pair: {left_id} vs {right_id}")
+        return matches.iloc[0]
+    resolved_index = int(row_index or 0)
+    if resolved_index < 0 or resolved_index >= len(frame):
+        raise ValueError(f"row_index must be between 0 and {len(frame) - 1}. Got: {row_index}")
+    return frame.iloc[resolved_index]
+
+
 def _normalize_pair_segment_mode(segment_mode):
     selected = str(segment_mode or "line").strip().lower().replace("-", "_")
     if selected not in _PAIR_SEGMENT_MODES:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,6 +134,53 @@ def test_explain_pair_command_accepts_dataset_pair_ids(tmp_path):
     assert payload["metadata"]["label"] == 1
 
 
+def test_explain_pair_command_accepts_scored_pair_rows(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "same\nleft", "suffix": ".py"},
+                {"file_id": "b", "text": "same\nright", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+        metadata={"name": "tiny_pairs"},
+    )
+    scores_path = tmp_path / "scores.csv"
+    pd.DataFrame([{"left_id": "a", "right_id": "b", "similarity_score": 0.91, "label": 1}]).to_csv(
+        scores_path,
+        index=False,
+    )
+    output_dir = tmp_path / "pair_viz"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "explain-pair",
+            "--dataset",
+            str(dataset_root),
+            "--scores",
+            str(scores_path),
+            "--score-row-index",
+            "0",
+            "--output-dir",
+            str(output_dir),
+            "--basename",
+            "scored_pair",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    summary = json.loads(result.output)
+    assert summary["left_id"] == "a"
+    payload = json.loads((output_dir / "scored_pair.json").read_text(encoding="utf-8"))
+    assert payload["metadata"]["similarity_score"] == 0.91
+    assert payload["metadata"]["scored_pair"]["label"] == 1
+
+
 def test_explain_pair_command_accepts_source_archive_names(tmp_path):
     archive_path = tmp_path / "codes.zip"
     with ZipFile(archive_path, "w") as archive:
@@ -280,6 +327,78 @@ def test_leaderboard_command_writes_artifacts(tmp_path, monkeypatch):
     assert summary["aggregate_rows"] == 1
     assert summary["per_dataset_rows"] == 1
     assert (output_dir / "tiny.json").exists()
+
+
+def test_benchmark_registry_commands_add_list_and_compare(tmp_path):
+    leaderboard_json = tmp_path / "leaderboard.json"
+    leaderboard_json.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "metadata": {"name": "tiny"},
+                "aggregate": [
+                    {
+                        "task_family": "pair",
+                        "algorithm_name": "exact",
+                        "metric": "f1",
+                        "mean_score": 1.0,
+                        "median_score": 1.0,
+                        "dataset_count": 1,
+                        "sample_count": 2,
+                        "rank": 1,
+                    }
+                ],
+                "per_dataset": [
+                    {
+                        "task_family": "pair",
+                        "dataset_name": "pairs",
+                        "algorithm_name": "exact",
+                        "metric": "f1",
+                        "score": 1.0,
+                        "sample_count": 2,
+                        "dataset_source": "local",
+                        "algorithm_kind": "custom",
+                        "rank": 1,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry_path = tmp_path / "registry.json"
+    runner = CliRunner()
+
+    add_result = runner.invoke(
+        main,
+        [
+            "benchmark-registry",
+            "add",
+            str(registry_path),
+            str(leaderboard_json),
+            "--format",
+            "json",
+        ],
+    )
+    run_id = json.loads(add_result.output)["run_id"]
+    list_result = runner.invoke(main, ["benchmark-registry", "list", str(registry_path), "--format", "json"])
+    compare_result = runner.invoke(
+        main,
+        [
+            "benchmark-registry",
+            "compare",
+            str(registry_path),
+            "--run-id",
+            run_id,
+            "--format",
+            "json",
+        ],
+    )
+
+    assert add_result.exit_code == 0
+    assert list_result.exit_code == 0
+    assert compare_result.exit_code == 0
+    assert json.loads(list_result.output)[0]["run_id"] == run_id
+    assert json.loads(compare_result.output)[0]["delta_mean_score"] == 0.0
 
 
 def test_compare_command_accepts_new_options(tmp_path, monkeypatch):

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -536,6 +536,45 @@ def test_gradio_threshold_tuning_uses_scored_pair_state(tmp_path):
         assert "threshold_tuning_threshold_sweep.csv" in archive.namelist()
 
 
+def test_gradio_scored_pair_explanation_uses_dataset_state(tmp_path):
+    dataset_root = tmp_path / "pair_dataset"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "same\nleft", "suffix": ".py"},
+                {"file_id": "b", "text": "same\nright", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+        metadata={"name": "scored_pairs"},
+    )
+    state = {
+        "task": "pair",
+        "dataset_root": str(dataset_root),
+        "scored": [
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.9, "label": 1},
+        ],
+    }
+
+    summary_html, matches_frame, report_html, artifacts_path = gradio_app.explain_scored_pair_gradio(
+        state,
+        0,
+        "line",
+        0.85,
+        0.6,
+        0.3,
+        5,
+        progress=None,
+    )
+
+    assert "Pair Explanation" in summary_html
+    assert not matches_frame.empty
+    assert "a vs b" in report_html
+    with zipfile.ZipFile(artifacts_path) as archive:
+        assert "scored_pair_explanation.html" in archive.namelist()
+
+
 def test_dataset_pair_resampling_reports_invalid_label_folds():
     scored = pd.DataFrame(
         {
@@ -769,6 +808,7 @@ def test_gradio_leaderboard_inspection_renders_uploaded_zip(tmp_path):
             "leaderboard_report.html",
             "leaderboard_report.json",
             "leaderboard_report_aggregate.csv",
+            "leaderboard_report_details.html",
             "leaderboard_report_per_dataset.csv",
             "leaderboard_report_reproducibility.json",
         ]
@@ -880,5 +920,6 @@ def test_gradio_ready_leaderboard_runs_pair_and_retrieval_uploads(tmp_path):
         names = archive.namelist()
         assert "ready_leaderboard.json" in names
         assert "ready_leaderboard_aggregate.csv" in names
+        assert "ready_leaderboard_details.html" in names
         assert "ready_leaderboard_per_dataset.csv" in names
         assert "ready_leaderboard_reproducibility.json" in names

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -3,6 +3,12 @@ import json
 import pandas as pd
 
 import matheel
+from matheel.benchmark_registry import (
+    compare_benchmark_runs,
+    list_benchmark_runs,
+    load_benchmark_run,
+    register_benchmark_run,
+)
 from matheel.datasets import write_pair_dataset, write_retrieval_dataset
 from matheel.leaderboard import (
     available_leaderboard_metrics,
@@ -13,6 +19,7 @@ from matheel.leaderboard import (
     run_leaderboard,
     write_leaderboard_artifacts,
 )
+from matheel.reports import benchmark_detail_report_html
 
 
 def test_leaderboard_helpers_are_exported_from_package_root():
@@ -23,6 +30,8 @@ def test_leaderboard_helpers_are_exported_from_package_root():
     assert matheel.normalize_leaderboard_manifest is normalize_leaderboard_manifest
     assert matheel.run_leaderboard is run_leaderboard
     assert matheel.write_leaderboard_artifacts is write_leaderboard_artifacts
+    assert matheel.benchmark_detail_report_html is benchmark_detail_report_html
+    assert matheel.register_benchmark_run is register_benchmark_run
 
 
 def test_leaderboard_runs_pair_and_retrieval_datasets(tmp_path):
@@ -53,6 +62,7 @@ def test_leaderboard_runs_pair_and_retrieval_datasets(tmp_path):
     assert artifacts["aggregate_csv"].exists()
     assert artifacts["json"].exists()
     assert artifacts["html"].exists()
+    assert artifacts["details_html"].exists()
     assert artifacts["reproducibility_json"].exists()
     payload = json.loads(artifacts["json"].read_text(encoding="utf-8"))
     reproducibility = json.loads(artifacts["reproducibility_json"].read_text(encoding="utf-8"))
@@ -82,6 +92,10 @@ def test_leaderboard_runs_pair_and_retrieval_datasets(tmp_path):
     assert retrieval_map.loc["exact", "score"] == 1.0
     assert retrieval_map.loc["inverse", "score"] < 1.0
     assert set(aggregate["algorithm_name"]) == {"exact", "inverse"}
+    details_html = artifacts["details_html"].read_text(encoding="utf-8")
+    assert str(tmp_path) not in details_html
+    assert "Dataset Details" in details_html
+    assert "Algorithm Details" in details_html
 
 
 def test_leaderboard_manifest_resolves_relative_paths(tmp_path):
@@ -131,6 +145,63 @@ def test_leaderboard_payload_and_html_escape_values(tmp_path):
     assert "<unsafe>" not in output
     assert "&lt;unsafe&gt;" in output
     assert "<exact>" not in output
+
+
+def test_benchmark_detail_report_escapes_values(tmp_path):
+    pair_root = _write_pair_fixture(tmp_path)
+    exact_path, _ = _write_algorithm_fixtures(tmp_path)
+    report, _ = run_leaderboard(
+        {
+            "name": "<unsafe>",
+            "datasets": [{"name": "<pairs>", "task": "pair", "path": str(pair_root)}],
+            "algorithms": [{"name": "<exact>", "algorithm_path": str(exact_path)}],
+        }
+    )
+
+    output = benchmark_detail_report_html(report, title="<unsafe>")
+
+    assert str(tmp_path) not in output
+    assert "<unsafe>" not in output
+    assert "&lt;unsafe&gt;" in output
+    assert "<exact>" not in output
+    assert "&lt;exact&gt;" in output
+
+
+def test_benchmark_registry_tracks_and_compares_runs(tmp_path):
+    pair_root = _write_pair_fixture(tmp_path)
+    exact_path, inverse_path = _write_algorithm_fixtures(tmp_path)
+    first_report, first_artifacts = run_leaderboard(
+        {
+            "name": "first",
+            "datasets": [{"name": "pairs", "task": "pair", "path": str(pair_root)}],
+            "algorithms": [{"name": "exact", "algorithm_path": str(exact_path)}],
+        },
+        output_dir=tmp_path / "first",
+        basename="first",
+    )
+    second_report, _ = run_leaderboard(
+        {
+            "name": "second",
+            "datasets": [{"name": "pairs", "task": "pair", "path": str(pair_root)}],
+            "algorithms": [{"name": "inverse", "algorithm_path": str(inverse_path)}],
+        },
+        output_dir=tmp_path / "second",
+        basename="second",
+    )
+    registry_path = tmp_path / "registry.json"
+
+    first_entry = register_benchmark_run(registry_path, first_report, artifact_paths=first_artifacts)
+    second_entry = register_benchmark_run(registry_path, second_report)
+    runs = list_benchmark_runs(registry_path)
+    loaded = load_benchmark_run(registry_path, first_entry["run_id"])
+    comparison = compare_benchmark_runs(registry_path, run_ids=[first_entry["run_id"], second_entry["run_id"]])
+    registry_text = registry_path.read_text(encoding="utf-8")
+
+    assert list(runs["run_id"]) == [first_entry["run_id"], second_entry["run_id"]]
+    assert loaded["artifacts"]["html"] == "first.html"
+    assert str(tmp_path) not in registry_text
+    assert set(comparison["run_id"]) == {first_entry["run_id"], second_entry["run_id"]}
+    assert "delta_mean_score" in comparison
 
 
 def test_leaderboard_payload_keeps_remote_identifiers():

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -12,6 +12,7 @@ from matheel.visualization import (
     build_dataset_embedding_map,
     build_embedding_projection,
     build_pair_explanation,
+    build_scored_pair_explanation,
     dataset_map_html,
     dataset_map_payload,
     pair_explanation_html,
@@ -20,6 +21,7 @@ from matheel.visualization import (
     write_dataset_embedding_map,
     write_dataset_map_artifacts,
     write_pair_explanation_artifacts,
+    write_scored_pair_explanation,
 )
 
 
@@ -30,6 +32,7 @@ def test_visualization_helpers_are_exported_from_package_root():
     assert matheel.build_dataset_embedding_map is build_dataset_embedding_map
     assert matheel.write_dataset_embedding_map is write_dataset_embedding_map
     assert matheel.build_pair_explanation is build_pair_explanation
+    assert matheel.build_scored_pair_explanation is build_scored_pair_explanation
 
 
 def test_project_embeddings_pca_is_deterministic():
@@ -335,3 +338,47 @@ def test_build_pair_dataset_explanation_selects_pair_by_index_and_ids(tmp_path):
     assert by_index["metadata"]["label"] == 1
     assert by_id["metadata"]["left_id"] == "a"
     assert artifacts["json"].exists()
+
+
+def test_scored_pair_explanation_selects_scored_row(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "same\nleft", "suffix": ".py"},
+                {"file_id": "b", "text": "same\nright", "suffix": ".py"},
+                {"file_id": "c", "text": "different", "suffix": ".py"},
+            ]
+        ),
+        pairs=pd.DataFrame(
+            [
+                {"left_id": "a", "right_id": "c", "label": 0},
+                {"left_id": "a", "right_id": "b", "label": 1},
+            ]
+        ),
+        metadata={"name": "tiny_pairs"},
+    )
+    scored = pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "c", "similarity_score": 0.1, "label": 0},
+            {"left_id": "a", "right_id": "b", "similarity_score": 0.95, "label": 1},
+        ]
+    )
+
+    explanation = build_scored_pair_explanation(scored, dataset_root, row_index=1)
+    written, artifacts = write_scored_pair_explanation(
+        scored,
+        dataset_root,
+        tmp_path / "scored_pair_viz",
+        left_id="a",
+        right_id="b",
+    )
+
+    assert explanation["metadata"]["left_id"] == "a"
+    assert explanation["metadata"]["right_id"] == "b"
+    assert explanation["metadata"]["scored_row_index"] == 1
+    assert explanation["metadata"]["similarity_score"] == 0.95
+    assert explanation["metadata"]["scored_pair"]["label"] == 1
+    assert written["metadata"]["dataset_name"] == "tiny_pairs"
+    assert artifacts["json"].name == "a_vs_b_scored.json"


### PR DESCRIPTION
## Summary
- add leaderboard detail HTML artifacts for dataset and algorithm cards
- add benchmark registry APIs and CLI commands for tracking and comparing leaderboard runs
- add scored pair explanation workflows in Python, CLI, and Gradio
- update docs, examples, and tests

## Validation
- uv run python -m pytest -q
- uv run python -m ruff check .
- uv run python -m mkdocs build --strict
- git diff --check

Closes #182
Closes #183
Closes #184