### PR TITLE
Add contributor workflow scaffolding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,4 +19,6 @@ The published site is <https://fahadebrahim.github.io/matheel/>.
 - [Leaderboard](leaderboard.md)
 - [Custom algorithms](customization.md)
 - [Comparison suite](comparison_suite.md)
+- [Contributing algorithms](contributing_algorithms.md)
+- [Contributing datasets](contributing_datasets.md)
 - [Development](development.md)

--- a/docs/contributing_algorithms.md
+++ b/docs/contributing_algorithms.md
@@ -1,0 +1,91 @@
+# Contributing Similarity Algorithms
+
+Matheel supports two contribution paths:
+
+1. A custom algorithm module for local experiments.
+2. A built-in Matheel method or preset for reusable package support.
+
+Use the custom path first when prototyping. Move into package code only after the method has a stable contract, deterministic tests, and clear dependencies.
+
+## Start From A Template
+
+Generate a starter module:
+
+```bash
+matheel init-custom-algorithm my_algorithm.py
+```
+
+Then run it locally:
+
+```bash
+python examples/sample_data.py --output sample_pairs.zip --overwrite
+matheel compare sample_pairs.zip --algorithm-path my_algorithm.py
+```
+
+The generated module exposes `score_pair(code_a, code_b, dataset_context=None, row=None, **kwargs)`. It may also define `prepare_dataset(dataset, prepared_texts=None, **kwargs)` for reusable context.
+
+## Custom Algorithm Checklist
+
+- Return a finite numeric score where larger means more similar.
+- Accept `row` and `dataset_context` when useful, but do not require them for basic scoring.
+- Keep options JSON-serializable so CLI, suite, and reproducibility outputs can store them.
+- Avoid network calls and mutable global state during scoring.
+- Add tests for direct pair scoring and dataset evaluation when the method is intended for benchmarks.
+- Keep private code, credentials, and real datasets out of the repository.
+
+## Built-In Method Checklist
+
+When promoting a method into Matheel:
+
+1. Add the implementation to the smallest relevant module.
+2. Expose public helpers only when they are useful outside the implementation.
+3. Add deterministic unit tests with tiny synthetic code snippets.
+4. Document parameters, dependency requirements, and score range.
+5. Add the method to comparison or Gradio controls when it is user-facing.
+6. Add an offline leaderboard preset when the method should be benchmarked by default.
+
+## Offline Leaderboard Presets
+
+Leaderboard presets make a method available in manifests, Python, and the Gradio Ready Leaderboard tab.
+
+```python
+from matheel import register_leaderboard_algorithm_preset
+
+register_leaderboard_algorithm_preset(
+    "My Method",
+    {
+        "description": "Short benchmark-facing description.",
+        "similarity_options": {
+            "feature_weights": {"levenshtein": 1.0},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.0,
+        },
+    },
+    overwrite=True,
+)
+```
+
+Use a preset in a leaderboard manifest:
+
+```json
+{
+  "datasets": [{"name": "pairs", "task": "pair", "path": "./normalized_pairs"}],
+  "algorithms": ["My Method"]
+}
+```
+
+Built-in presets should be added with tests that verify `available_leaderboard_algorithm_presets()`, manifest normalization, and at least one tiny leaderboard run.
+
+## Pull Request Expectations
+
+- Include docs and examples for new user-facing behavior.
+- Include tests that run offline.
+- Keep optional heavy dependencies import-late or behind extras.
+- Run:
+
+```bash
+uv run python -m pytest -q
+uv run python -m ruff check .
+uv run python -m mkdocs build --strict
+git diff --check
+```

--- a/docs/contributing_datasets.md
+++ b/docs/contributing_datasets.md
@@ -1,0 +1,87 @@
+# Contributing Dataset Support
+
+Dataset support is split into source resolvers, adapters, and presets.
+
+- A **source resolver** locates or downloads raw files.
+- An **adapter** converts a raw layout into normalized Matheel pair or retrieval manifests.
+- A **preset** records an approved public dataset source plus its adapter.
+
+Keep these pieces separate so custom users can reuse generic sources and adapters without treating every source as an endorsed dataset.
+
+## Dataset Contribution Checklist
+
+- Confirm the task family: `pair`, `retrieval`, or both.
+- Confirm license, provenance, access requirements, and citation information.
+- Do not commit real dataset files.
+- Do not commit credentials or credential-like fields in manifests.
+- Use tiny synthetic fixtures in tests.
+- Keep source resolvers deterministic and safe. Archive extraction must reject path traversal.
+- Add docs that explain user-provided downloads and source terms.
+
+## Adapter Shape
+
+Adapters should write normalized datasets with existing helpers:
+
+```python
+from matheel.datasets import write_pair_dataset
+
+
+def adapt_my_pairs(source_root, destination, **options):
+    files = ...
+    pairs = ...
+    return write_pair_dataset(
+        destination,
+        files=files,
+        pairs=pairs,
+        metadata={
+            "name": options.get("name", "my_pairs"),
+            "task_type": "plagiarism",
+            "dataset_kind": "pair_classification",
+        },
+    )
+```
+
+Prefer `write_retrieval_dataset` for retrieval layouts. Use `document_id` for retrieval documents and keep normalized metadata aligned with existing schemas.
+
+## Registering Custom Pieces
+
+```python
+from matheel.datasets import register_dataset_adapter, register_dataset_preset, register_dataset_source
+
+register_dataset_source("internal", resolve_internal_dataset, overwrite=True)
+register_dataset_adapter("internal_pair", adapt_my_pairs, overwrite=True)
+register_dataset_preset(
+    "internal_pairs",
+    {
+        "source": "internal",
+        "identifier": "raw_pairs",
+        "adapter": "internal_pair",
+        "task_families": ("pair",),
+    },
+    overwrite=True,
+)
+```
+
+Built-in presets should be added only for approved datasets. Generic resolvers such as GitHub, Zenodo, Hugging Face, and Kaggle are source mechanisms, not endorsements by themselves.
+
+## Tests
+
+Use synthetic layouts that mirror the expected file structure:
+
+- Adapter test: raw fixture in a temporary directory, run adapter, load the normalized dataset, assert counts and labels.
+- Preset test: resolve through a local fake source or monkeypatched resolver, never the network.
+- Manifest test: relative paths resolve from the manifest location.
+- Security test: unsafe archives or credential fields are rejected when relevant.
+
+## Pull Request Expectations
+
+- Add docs for source terms and user-provided downloads.
+- Add a small runnable example only when it does not require real dataset files.
+- Run:
+
+```bash
+uv run python -m pytest -q
+uv run python -m ruff check .
+uv run python -m mkdocs build --strict
+git diff --check
+```

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -4,7 +4,11 @@ Matheel supports custom pair scorers without editing package internals. A custom
 
 ## Contract
 
-Create a Python module with a callable `score_pair`:
+Generate a starter module, or create a Python module with a callable `score_pair`:
+
+```bash
+matheel init-custom-algorithm my_algorithm.py
+```
 
 ```python
 # my_algorithm.py
@@ -148,6 +152,8 @@ scored, metrics = evaluate_pair_dataset(
 ```
 
 See `examples/custom/custom_algorithm_demo.py` for a runnable local example.
+
+For package-level contributions, use the [contributing similarity algorithms](contributing_algorithms.md) guide. It covers tests, docs, and offline leaderboard presets for new methods.
 
 ## Reproducibility
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -204,6 +204,8 @@ register_dataset_preset(
 )
 ```
 
+For package-level dataset support, use the [contributing dataset support](contributing_datasets.md) guide. It covers source/adapters/presets, fixture expectations, and reproducibility requirements.
+
 ## Dataset CLI Utilities
 
 Use `matheel datasets list` to inspect registered sources, adapters, and presets:

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,8 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 - [Reproducible benchmark demo](reproducible_benchmark.md)
 - [Custom algorithms](customization.md)
 - [Comparison suite](comparison_suite.md)
+- [Contributing algorithms](contributing_algorithms.md)
+- [Contributing datasets](contributing_datasets.md)
 - [Development](development.md)
 
 ## Demos and Examples
@@ -50,3 +52,4 @@ Start with the [usage guide](usage.md) for installation, optional extras, quick 
 7. Run the [reproducible benchmark demo](reproducible_benchmark.md) for a small auditable workflow.
 8. Use [Custom algorithms](customization.md) for project-specific scorers.
 9. Use [Comparison suite](comparison_suite.md) for repeatable multi-run experiments.
+10. Use the contribution guides for [algorithms](contributing_algorithms.md) and [datasets](contributing_datasets.md) before opening benchmark-facing PRs.

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -32,6 +32,7 @@ Create a JSON manifest with datasets, algorithms, and metrics:
     }
   ],
   "algorithms": [
+    "Lexical Only",
     {
       "name": "levenshtein",
       "feature_weights": {"levenshtein": 1.0}
@@ -45,6 +46,8 @@ Create a JSON manifest with datasets, algorithms, and metrics:
 ```
 
 Relative dataset paths and custom algorithm paths are resolved from the manifest file location.
+
+Algorithm entries can be full option objects or built-in preset names. Built-in presets include `Balanced`, `Lexical Only`, `Embedding Only`, `Code-Aware`, `Jaro-Winkler`, `Winnowing`, `GST`, and `CodeBLEU`.
 
 ## CLI
 
@@ -108,8 +111,11 @@ The ranked algorithm table is sorted by task, metric, rank, and algorithm name. 
 ## Python
 
 ```python
+from matheel import available_leaderboard_algorithm_presets
 from matheel.leaderboard import load_leaderboard_manifest, run_leaderboard
 from matheel.reports import write_benchmark_report
+
+print(available_leaderboard_algorithm_presets())
 
 manifest = load_leaderboard_manifest("leaderboard.json")
 report, artifacts = run_leaderboard(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,6 +120,8 @@ print(results.head())
 - [Reproducible benchmark demo](reproducible_benchmark.md)
 - [Custom algorithms](customization.md)
 - [Comparison suite](comparison_suite.md)
+- [Contributing algorithms](contributing_algorithms.md)
+- [Contributing datasets](contributing_datasets.md)
 - [Development](development.md)
 
 ## Interface Notes

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,12 @@ Then run any archive-based example:
 python examples/basic/sample_pairs_demo.py
 ```
 
+Generate a starter custom algorithm module:
+
+```bash
+matheel init-custom-algorithm my_algorithm.py
+```
+
 Run the local visualization and leaderboard examples when you want generated artifacts to inspect:
 
 ```bash

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -36,6 +36,7 @@ from matheel.evaluation import (
     evaluate_retrieval_resamples,
 )
 from matheel.leaderboard import run_leaderboard, write_leaderboard_artifacts
+from matheel.leaderboard_presets import available_leaderboard_algorithm_presets, get_leaderboard_algorithm_preset
 from matheel.model_routing import available_vector_backends
 from matheel.preprocessing import available_preprocess_modes
 from matheel.reports import benchmark_report_html
@@ -99,31 +100,36 @@ FEATURE_UI_CHOICES = [
     "Code Metric",
 ]
 DEFAULT_FEATURE_SELECTION = ["Embedding", "Levenshtein"]
+
+
+def _metric_preset_from_leaderboard_preset(name):
+    preset = get_leaderboard_algorithm_preset(name)
+    options = dict(preset["similarity_options"])
+    weights = dict(options.get("feature_weights") or {})
+    features = []
+    if weights.get("semantic", 0.0) > 0:
+        features.append("Embedding")
+    if weights.get("levenshtein", 0.0) > 0:
+        features.append("Levenshtein")
+    if weights.get("jaro_winkler", 0.0) > 0:
+        features.append("Jaro-Winkler")
+    if weights.get("winnowing", 0.0) > 0:
+        features.append("Winnowing")
+    if weights.get("gst", 0.0) > 0:
+        features.append("GST")
+    if weights.get("code_metric", 0.0) > 0:
+        features.append("Code Metric")
+    return {
+        "features": features or list(DEFAULT_FEATURE_SELECTION),
+        "weights": weights,
+        "code_metric": str(options.get("code_metric") or "codebleu"),
+        "code_metric_weight": float(options.get("code_metric_weight") or weights.get("code_metric", 0.0)),
+    }
+
+
 METRIC_PRESETS = {
-    "Balanced": {
-        "features": ["Embedding", "Levenshtein"],
-        "weights": {"semantic": 0.7, "levenshtein": 0.3},
-        "code_metric": "codebleu",
-        "code_metric_weight": 0.0,
-    },
-    "Lexical Only": {
-        "features": ["Levenshtein", "Winnowing", "GST"],
-        "weights": {"levenshtein": 0.5, "winnowing": 0.25, "gst": 0.25},
-        "code_metric": "codebleu",
-        "code_metric_weight": 0.0,
-    },
-    "Embedding Only": {
-        "features": ["Embedding"],
-        "weights": {"semantic": 1.0},
-        "code_metric": "codebleu",
-        "code_metric_weight": 0.0,
-    },
-    "Code-Aware": {
-        "features": ["Embedding", "Levenshtein", "Code Metric"],
-        "weights": {"semantic": 0.5, "levenshtein": 0.25, "code_metric": 0.25},
-        "code_metric": "codebleu",
-        "code_metric_weight": 0.25,
-    },
+    name: _metric_preset_from_leaderboard_preset(name)
+    for name in available_leaderboard_algorithm_presets()
 }
 DATASET_TASK_CHOICES = ("Pair Classification", "Retrieval")
 DEFAULT_DATASET_TASK = DATASET_TASK_CHOICES[0]

--- a/matheel/__init__.py
+++ b/matheel/__init__.py
@@ -64,6 +64,7 @@ from .code_metrics import (
     codebleu_components,
     score_code_metric_pair,
 )
+from .custom_templates import custom_algorithm_template, write_custom_algorithm_template
 from .datasets import (
     PairDataset,
     RetrievalDataset,
@@ -122,6 +123,12 @@ from .leaderboard import (
     normalize_leaderboard_manifest,
     run_leaderboard,
     write_leaderboard_artifacts,
+)
+from .leaderboard_presets import (
+    available_leaderboard_algorithm_presets,
+    get_leaderboard_algorithm_preset,
+    leaderboard_algorithm_preset_configs,
+    register_leaderboard_algorithm_preset,
 )
 from .model_routing import infer_model_backend, infer_model_capabilities, available_vector_backends
 from .preprocessing import preprocess_code
@@ -195,6 +202,7 @@ __all__ = [
     "available_dataset_sources",
     "available_dataset_task_types",
     "available_leaderboard_metrics",
+    "available_leaderboard_algorithm_presets",
     "available_lexical_tokenizers",
     "available_pooling_methods",
     "available_pair_explanation_segment_modes",
@@ -224,6 +232,7 @@ __all__ = [
     "collect_reproducibility_snapshot",
     "compare_benchmark_runs",
     "compare_metric_samples",
+    "custom_algorithm_template",
     "DataSplit",
     "adapt_pair_dataset",
     "adapt_retrieval_dataset",
@@ -243,10 +252,12 @@ __all__ = [
     "get_sim_list",
     "get_dataset_entry",
     "get_dataset_preset",
+    "get_leaderboard_algorithm_preset",
     "infer_model_backend",
     "infer_model_capabilities",
     "inspect_model_settings",
     "leaderboard_cards",
+    "leaderboard_algorithm_preset_configs",
     "leaderboard_html",
     "leaderboard_payload",
     "list_benchmark_runs",
@@ -281,6 +292,7 @@ __all__ = [
     "register_dataset_entry",
     "register_dataset_preset",
     "register_dataset_source",
+    "register_leaderboard_algorithm_preset",
     "repeated_kfold_splits",
     "RetrievalDataset",
     "retrieval_ranking_metrics",
@@ -332,6 +344,7 @@ __all__ = [
     "write_benchmark_detail_report",
     "write_benchmark_report",
     "write_benchmark_registry",
+    "write_custom_algorithm_template",
     "write_leaderboard_artifacts",
     "write_pair_dataset_explanation",
     "write_pair_explanation",

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -11,6 +11,7 @@ from .benchmark_registry import compare_benchmark_runs, list_benchmark_runs, reg
 from .calibration import write_calibration_report_artifacts, write_threshold_tuning_report_artifacts
 from .comparison_suite import load_run_configs, run_comparison_suite
 from .code_metrics import available_code_metrics
+from .custom_templates import write_custom_algorithm_template
 from ._progress import should_show_progress
 from .datasets import (
     adapt_pair_dataset,
@@ -59,6 +60,29 @@ from .visualization import (
 def main():
     """Matheel CLI - Compute Code Similarity"""
     pass
+
+
+@main.command(name="init-custom-algorithm")
+@click.argument("output_path", type=click.Path(dir_okay=False))
+@click.option("--name", help="Algorithm name used in the generated template metadata.")
+@click.option("--overwrite", is_flag=True, help="Overwrite the output file if it already exists.")
+@click.option(
+    "--without-prepare",
+    is_flag=True,
+    help="Generate only score_pair without a prepare_dataset hook.",
+)
+def init_custom_algorithm_command(output_path, name, overwrite, without_prepare):
+    """Write a starter custom score_pair algorithm module."""
+    try:
+        target = write_custom_algorithm_template(
+            output_path,
+            name=name,
+            overwrite=overwrite,
+            include_prepare=not without_prepare,
+        )
+    except FileExistsError as exc:
+        raise click.UsageError(str(exc)) from exc
+    click.echo(f"output={target}")
 
 
 def _parse_dataset_adapter_options(entries):

--- a/matheel/custom_templates.py
+++ b/matheel/custom_templates.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+
+def custom_algorithm_template(name="custom_similarity", include_prepare=True):
+    module_name = _safe_identifier(name or "custom_similarity")
+    prepare_block = ""
+    context_note = "dataset_context=None, "
+    if include_prepare:
+        prepare_block = f'''def prepare_dataset(dataset, prepared_texts=None, **kwargs):
+    """Build optional reusable context before dataset scoring."""
+    _ = kwargs
+    files = getattr(dataset, "files", None)
+    return {{
+        "algorithm": "{module_name}",
+        "file_count": len(files) if files is not None else 0,
+        "prepared_texts": dict(prepared_texts or {{}}),
+    }}
+
+
+'''
+    return f'''"""Matheel custom similarity algorithm template.
+
+Edit score_pair, keep the function importable, and run it with:
+
+    matheel compare sample_pairs.zip --algorithm-path this_file.py
+
+The function must return a finite numeric score where larger means more similar.
+"""
+
+from __future__ import annotations
+
+
+{prepare_block}def score_pair(code_a, code_b, {context_note}row=None, **kwargs):
+    """Return a similarity score for two source-code strings."""
+    _ = (dataset_context, row, kwargs)
+    left = str(code_a or "").strip()
+    right = str(code_b or "").strip()
+    if not left and not right:
+        return 1.0
+    if not left or not right:
+        return 0.0
+    return 1.0 if left == right else 0.0
+'''
+
+
+def write_custom_algorithm_template(output_path, name=None, overwrite=False, include_prepare=True):
+    target = Path(output_path)
+    if target.exists() and not overwrite:
+        raise FileExistsError(f"Custom algorithm template already exists: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        custom_algorithm_template(
+            name=name or target.stem,
+            include_prepare=include_prepare,
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _safe_identifier(value):
+    text = "".join(character if character.isalnum() or character == "_" else "_" for character in str(value))
+    text = text.strip("_")
+    if not text or text[0].isdigit():
+        text = f"algorithm_{text}"
+    return text

--- a/matheel/leaderboard.py
+++ b/matheel/leaderboard.py
@@ -9,6 +9,7 @@ from .benchmark_cards import leaderboard_cards
 from .calibration import calibration_report
 from .datasets import load_pair_datasets, load_retrieval_datasets
 from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
+from .leaderboard_presets import get_leaderboard_algorithm_preset
 from .reproducibility import collect_reproducibility_snapshot, write_reproducibility_snapshot
 
 
@@ -342,16 +343,28 @@ def _normalize_leaderboard_dataset(item, index=1, base_dir=None):
 
 
 def _normalize_leaderboard_algorithm(item, index=1, base_dir=None):
+    if isinstance(item, str):
+        item = {"preset": item}
     if not isinstance(item, dict):
         raise ValueError("Leaderboard algorithms must be JSON objects.")
     payload = dict(item)
+    preset_name = payload.pop("preset", None) or payload.pop("algorithm_preset", None)
+    preset_options = {}
+    preset_display_name = None
+    if preset_name is not None:
+        preset = get_leaderboard_algorithm_preset(preset_name)
+        preset_options = dict(preset.get("similarity_options") or {})
+        preset_display_name = preset.get("name")
+        if payload.get("algorithm_path"):
+            raise ValueError("Leaderboard algorithm presets cannot be combined with algorithm_path.")
     options = dict(payload.pop("options", {}))
+    options = {**preset_options, **options}
     options.update(payload.pop("similarity_options", {}))
     for key in list(payload):
         if key not in {"name", "algorithm_path", "algorithm_options", "threshold", "k"}:
             options[key] = payload.pop(key)
     payload = _resolve_relative_paths(payload, base_dir=base_dir)
-    name = str(payload.get("name") or f"algorithm_{index}")
+    name = str(payload.get("name") or preset_display_name or f"algorithm_{index}")
     return {
         "name": name,
         "algorithm_path": payload.get("algorithm_path"),

--- a/matheel/leaderboard_presets.py
+++ b/matheel/leaderboard_presets.py
@@ -1,0 +1,133 @@
+from copy import deepcopy
+
+
+_LEADERBOARD_ALGORITHM_PRESETS = {
+    "Balanced": {
+        "name": "Balanced",
+        "description": "Embedding-heavy default with a lexical stabilizer.",
+        "similarity_options": {
+            "feature_weights": {"semantic": 0.7, "levenshtein": 0.3},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.0,
+        },
+    },
+    "Lexical Only": {
+        "name": "Lexical Only",
+        "description": "Offline lexical baseline combining edit distance, Winnowing, and GST.",
+        "similarity_options": {
+            "feature_weights": {"levenshtein": 0.5, "winnowing": 0.25, "gst": 0.25},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.0,
+        },
+    },
+    "Embedding Only": {
+        "name": "Embedding Only",
+        "description": "Semantic embedding score only.",
+        "similarity_options": {
+            "feature_weights": {"semantic": 1.0},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.0,
+        },
+    },
+    "Code-Aware": {
+        "name": "Code-Aware",
+        "description": "Embedding, edit distance, and code metric blend.",
+        "similarity_options": {
+            "feature_weights": {"semantic": 0.5, "levenshtein": 0.25, "code_metric": 0.25},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.25,
+        },
+    },
+    "Jaro-Winkler": {
+        "name": "Jaro-Winkler",
+        "description": "String-similarity baseline focused on short edits and reordered names.",
+        "similarity_options": {
+            "feature_weights": {"jaro_winkler": 1.0},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.0,
+        },
+    },
+    "Winnowing": {
+        "name": "Winnowing",
+        "description": "Token fingerprint baseline for shared local fragments.",
+        "similarity_options": {
+            "feature_weights": {"winnowing": 1.0},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.0,
+        },
+    },
+    "GST": {
+        "name": "GST",
+        "description": "Greedy String Tiling token-overlap baseline.",
+        "similarity_options": {
+            "feature_weights": {"gst": 1.0},
+            "code_metric": "codebleu",
+            "code_metric_weight": 0.0,
+        },
+    },
+    "CodeBLEU": {
+        "name": "CodeBLEU",
+        "description": "CodeBLEU-only code-aware baseline.",
+        "similarity_options": {
+            "feature_weights": {"code_metric": 1.0},
+            "code_metric": "codebleu",
+            "code_metric_weight": 1.0,
+        },
+    },
+}
+
+
+def available_leaderboard_algorithm_presets():
+    return tuple(_LEADERBOARD_ALGORITHM_PRESETS)
+
+
+def get_leaderboard_algorithm_preset(name):
+    key = _resolve_preset_key(name)
+    return deepcopy(_LEADERBOARD_ALGORITHM_PRESETS[key])
+
+
+def register_leaderboard_algorithm_preset(name, preset, overwrite=False):
+    key = _normalize_preset_name(name)
+    if not overwrite and key in _LEADERBOARD_ALGORITHM_PRESETS:
+        raise ValueError(f"Leaderboard algorithm preset already exists: {key}")
+    payload = _normalize_preset_payload(key, preset)
+    _LEADERBOARD_ALGORITHM_PRESETS[key] = payload
+    return deepcopy(payload)
+
+
+def leaderboard_algorithm_preset_configs(names=None):
+    selected = available_leaderboard_algorithm_presets() if names is None else tuple(names)
+    configs = []
+    for name in selected:
+        preset = get_leaderboard_algorithm_preset(name)
+        configs.append({"name": preset["name"], **deepcopy(preset["similarity_options"])})
+    return configs
+
+
+def _resolve_preset_key(name):
+    requested = _normalize_preset_name(name)
+    for key in _LEADERBOARD_ALGORITHM_PRESETS:
+        if key.lower() == requested.lower():
+            return key
+    supported = ", ".join(available_leaderboard_algorithm_presets())
+    raise KeyError(f"Unknown leaderboard algorithm preset: {name}. Supported presets: {supported}")
+
+
+def _normalize_preset_name(name):
+    text = str(name or "").strip()
+    if not text:
+        raise ValueError("Leaderboard algorithm preset name must be non-empty.")
+    return text
+
+
+def _normalize_preset_payload(name, preset):
+    if not isinstance(preset, dict):
+        raise ValueError("Leaderboard algorithm preset must be a mapping.")
+    options = dict(preset.get("similarity_options") or preset.get("options") or {})
+    if not options:
+        raise ValueError("Leaderboard algorithm preset must define similarity_options.")
+    return {
+        "name": str(preset.get("name") or name),
+        "description": str(preset.get("description") or ""),
+        "similarity_options": deepcopy(options),
+    }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,8 @@ nav:
       - Custom algorithms: customization.md
       - Comparison suite: comparison_suite.md
   - Project:
+      - Contributing algorithms: contributing_algorithms.md
+      - Contributing datasets: contributing_datasets.md
       - Development: development.md
 
 exclude_docs: |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import os
 from importlib.metadata import version
@@ -58,6 +59,32 @@ def test_visualize_dataset_command_writes_artifacts(tmp_path):
     assert (output_dir / "dataset_map.csv").exists()
     assert (output_dir / "dataset_map.json").exists()
     assert (output_dir / "dataset_map.html").exists()
+
+
+def test_init_custom_algorithm_command_writes_importable_template(tmp_path):
+    output_path = tmp_path / "my_algorithm.py"
+
+    assert callable(matheel.custom_algorithm_template)
+    assert callable(matheel.write_custom_algorithm_template)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "init-custom-algorithm",
+            str(output_path),
+            "--name",
+            "demo algorithm",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert output_path.exists()
+    assert "score_pair" in output_path.read_text(encoding="utf-8")
+    spec = importlib.util.spec_from_file_location("generated_algorithm", output_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.score_pair("print(1)", "print(1)") == 1.0
+    assert module.score_pair("print(1)", "print(2)") == 0.0
 
 
 def test_explain_pair_command_writes_file_pair_artifacts(tmp_path):

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -250,12 +250,16 @@ def test_score_card_html_displays_elapsed_time():
 def test_metric_presets_resolve_common_workflows():
     lexical = gradio_app.metric_preset_options("Lexical Only")
     code_aware = gradio_app.metric_preset_options("Code-Aware")
+    jaro = gradio_app.metric_preset_options("Jaro-Winkler")
 
     assert lexical["features"] == ["Levenshtein", "Winnowing", "GST"]
     assert lexical["semantic_weight"] == 0.0
     assert code_aware["features"] == ["Embedding", "Levenshtein", "Code Metric"]
     assert code_aware["code_metric"] == "codebleu"
     assert code_aware["code_metric_weight"] == 0.25
+    assert jaro["features"] == ["Jaro-Winkler"]
+    assert "Winnowing" in gradio_app.READY_LEADERBOARD_ALGORITHM_CHOICES
+    assert "CodeBLEU" in gradio_app.READY_LEADERBOARD_ALGORITHM_CHOICES
 
 
 def test_empty_result_panels_use_readable_states():

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -19,6 +19,12 @@ from matheel.leaderboard import (
     run_leaderboard,
     write_leaderboard_artifacts,
 )
+from matheel.leaderboard_presets import (
+    available_leaderboard_algorithm_presets,
+    get_leaderboard_algorithm_preset,
+    leaderboard_algorithm_preset_configs,
+    register_leaderboard_algorithm_preset,
+)
 from matheel.reports import benchmark_detail_report_html
 
 
@@ -30,8 +36,46 @@ def test_leaderboard_helpers_are_exported_from_package_root():
     assert matheel.normalize_leaderboard_manifest is normalize_leaderboard_manifest
     assert matheel.run_leaderboard is run_leaderboard
     assert matheel.write_leaderboard_artifacts is write_leaderboard_artifacts
+    assert matheel.available_leaderboard_algorithm_presets is available_leaderboard_algorithm_presets
+    assert matheel.get_leaderboard_algorithm_preset is get_leaderboard_algorithm_preset
+    assert matheel.leaderboard_algorithm_preset_configs is leaderboard_algorithm_preset_configs
+    assert matheel.register_leaderboard_algorithm_preset is register_leaderboard_algorithm_preset
     assert matheel.benchmark_detail_report_html is benchmark_detail_report_html
     assert matheel.register_benchmark_run is register_benchmark_run
+
+
+def test_leaderboard_algorithm_presets_include_offline_baselines():
+    names = available_leaderboard_algorithm_presets()
+    configs = leaderboard_algorithm_preset_configs(["Lexical Only", "Jaro-Winkler"])
+    preset = get_leaderboard_algorithm_preset("jaro-winkler")
+
+    assert "Jaro-Winkler" in names
+    assert "Winnowing" in names
+    assert "GST" in names
+    assert "CodeBLEU" in names
+    assert configs[0]["name"] == "Lexical Only"
+    assert configs[1]["feature_weights"] == {"jaro_winkler": 1.0}
+    assert preset["name"] == "Jaro-Winkler"
+
+
+def test_register_leaderboard_algorithm_preset_for_custom_method():
+    registered = register_leaderboard_algorithm_preset(
+        "Jaro-Winkler",
+        {
+            "description": "test overwrite for same built-in preset",
+            "similarity_options": {
+                "feature_weights": {"jaro_winkler": 1.0},
+                "code_metric": "codebleu",
+                "code_metric_weight": 0.0,
+            },
+        },
+        overwrite=True,
+    )
+
+    assert registered["name"] == "Jaro-Winkler"
+    assert get_leaderboard_algorithm_preset("Jaro-Winkler")["similarity_options"]["feature_weights"] == {
+        "jaro_winkler": 1.0
+    }
 
 
 def test_leaderboard_runs_pair_and_retrieval_datasets(tmp_path):
@@ -96,6 +140,27 @@ def test_leaderboard_runs_pair_and_retrieval_datasets(tmp_path):
     assert str(tmp_path) not in details_html
     assert "Dataset Details" in details_html
     assert "Algorithm Details" in details_html
+
+
+def test_leaderboard_manifest_accepts_algorithm_presets(tmp_path):
+    pair_root = _write_pair_fixture(tmp_path)
+    manifest = {
+        "name": "preset_leaderboard",
+        "datasets": [{"name": "pairs", "task": "pair", "path": str(pair_root)}],
+        "algorithms": [
+            "Lexical Only",
+            {"preset": "Jaro-Winkler", "name": "jw"},
+        ],
+    }
+
+    report, _ = run_leaderboard(manifest)
+    payload = leaderboard_payload(report)
+
+    assert set(report["aggregate"]["algorithm_name"]) == {"Lexical Only", "jw"}
+    assert payload["manifest"]["algorithms"][0]["name"] == "Lexical Only"
+    assert payload["manifest"]["algorithms"][1]["similarity_options"]["feature_weights"] == {
+        "jaro_winkler": 1.0
+    }
 
 
 def test_leaderboard_manifest_resolves_relative_paths(tmp_path):


### PR DESCRIPTION
## Summary
- add shared offline leaderboard algorithm presets and manifest preset support
- add a custom algorithm template generator CLI and Python helper
- add contribution guides for similarity algorithms and dataset support
- wire Ready Leaderboard presets to the shared preset registry

## Validation
- uv run python -m pytest -q
- uv run python -m ruff check .
- uv run python -m mkdocs build --strict
- git diff --check

Closes #179
Closes #180
Closes #181
Closes #186