### PR TITLE
Release v0.5.5

### DIFF
--- a/examples/notebooks/01_core_workflows.ipynb
+++ b/examples/notebooks/01_core_workflows.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.4\"\n",
+    "MATHEEL_REF = \"v0.5.5\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/02_datasets_and_reproducibility.ipynb
+++ b/examples/notebooks/02_datasets_and_reproducibility.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.4\"\n",
+    "MATHEEL_REF = \"v0.5.5\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/03_custom_algorithms.ipynb
+++ b/examples/notebooks/03_custom_algorithms.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.4\"\n",
+    "MATHEEL_REF = \"v0.5.5\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/04_gradio_app.ipynb
+++ b/examples/notebooks/04_gradio_app.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%%bash\n",
     "set -euo pipefail\n",
-    "MATHEEL_REF=\"v0.5.4\"\n",
+    "MATHEEL_REF=\"v0.5.5\"\n",
     "pip uninstall -y torchvision || true\n",
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",

--- a/examples/notebooks/05_visualization_and_leaderboard.ipynb
+++ b/examples/notebooks/05_visualization_and_leaderboard.ipynb
@@ -20,7 +20,7 @@
         "import sys\n",
         "from pathlib import Path\n",
         "\n",
-        "MATHEEL_REF = \"v0.5.4\"\n",
+        "MATHEEL_REF = \"v0.5.5\"\n",
         "\n",
         "\n",
         "def run(*args, cwd=None):\n",

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,10 +11,10 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.5.4` and includes:
+This Space is aligned with `matheel==0.5.5` and includes:
 
 - Pair, collection, comparison-suite, normalized-dataset, dataset-validation, threshold-tuning, visualization, scored-pair explanation, ready-leaderboard, and leaderboard-inspection workflows
-- Metric presets for balanced, lexical, embedding-only, and code-aware runs
+- Metric presets for balanced, lexical, embedding-only, code-aware, and individual offline baselines
 - Downloadable artifacts for dataset evaluation, validation reports, threshold sweeps, dataset maps, pair explanations, ready leaderboards, leaderboard reports, and leaderboard detail reports
 - Raw and parser-derived lexical tokenization for Winnowing and GST
 - Lexical metrics and baseline algorithms: Levenshtein, Jaro-Winkler, Winnowing, GST

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.5.4
+matheel[all]==0.5.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.5.4"
+version = "0.5.5"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
## Summary
- bump package and Space pins to 0.5.5
- refresh notebook install references for 0.5.5
- update Space README to include individual offline leaderboard baselines

## Validation
- uv run python -m pytest -q
- uv run python -m ruff check .
- uv run python -m mkdocs build --strict
- git diff --check

Closes #197