### PR TITLE
Fix non-UI review issues

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include LICENSE
+include README.md
+include mkdocs.yml
+include pyproject.toml
+recursive-include docs *.md
+recursive-include examples *
+recursive-include gradio_app *
+recursive-include scripts *.py
+recursive-include tests *.py
+global-exclude __pycache__ *.py[cod] .DS_Store

--- a/README.md
+++ b/README.md
@@ -29,12 +29,24 @@ Installation options are covered in the [usage guide](https://fahadebrahim.githu
 
 ## Quick Start
 
+Create a tiny archive and compare it with the CLI:
+
 ```bash
-python examples/sample_data.py --output sample_pairs.zip --overwrite
+python - <<'PY'
+from zipfile import ZipFile
+
+with ZipFile("sample_pairs.zip", "w") as archive:
+    archive.writestr("a.py", "def add(a, b):\n    return a + b\n")
+    archive.writestr("b.py", "def add(x, y):\n    return x + y\n")
+    archive.writestr("c.py", "def sub(a, b):\n    return a - b\n")
+PY
+
 matheel compare sample_pairs.zip \
   --feature-weight levenshtein=1.0 \
   --num 10
 ```
+
+Or score a pair directly from Python:
 
 ```python
 from matheel.similarity import calculate_similarity

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,7 +29,7 @@ pip install "matheel[all]"
 | `matheel[chunking]` | Chonkie chunkers for splitting code before embedding. |
 | `matheel[metrics]` | Optional code metric runtimes such as TSED and CodeBERTScore. |
 | `matheel[visualization]` | UMAP projection for dataset visualization. |
-| `matheel[gradio]` | Dependencies for running the Gradio web app. |
+| `matheel[gradio]` | Dependencies for running the Gradio web app from a repository checkout or the hosted Space. |
 | `matheel[all]` | All supported optional backends in one install. |
 
 Compatibility extras remain available for narrower installs: `sentence_transformers`, `model2vec`, `pylate`, and `chunking_code`.
@@ -38,12 +38,20 @@ Examples that use semantic weights assume `matheel[semantic]` or `matheel[all]` 
 
 ## Quick Checks
 
-Generate the tiny Java sample archive from source strings:
+Generate a tiny sample archive from source strings:
 
 Base CLI check:
 
 ```bash
-python examples/sample_data.py --output sample_pairs.zip --overwrite
+python - <<'PY'
+from zipfile import ZipFile
+
+with ZipFile("sample_pairs.zip", "w") as archive:
+    archive.writestr("a.py", "def add(a, b):\n    return a + b\n")
+    archive.writestr("b.py", "def add(x, y):\n    return x + y\n")
+    archive.writestr("c.py", "def sub(a, b):\n    return a - b\n")
+PY
+
 matheel compare sample_pairs.zip \
   --feature-weight levenshtein=1.0 \
   --num 10

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -1,7 +1,9 @@
 import json
 import math
 import os
+import shutil
 import tempfile
+import time
 import zipfile
 from pathlib import Path
 
@@ -91,6 +93,20 @@ DEFAULT_TSED_COSTS = "1,1,1"
 DEFAULT_CODEBERTSCORE_MODEL = "microsoft/codebert-base"
 DEFAULT_CODEBERTSCORE_MAX_LENGTH = 0
 DEFAULT_CODEBERTSCORE_MODEL_MAX_SEQUENCE = 512
+TEMP_WORKSPACE_TTL_SECONDS = int(os.environ.get("MATHEEL_GRADIO_TEMP_TTL_SECONDS", "86400"))
+TEMP_WORKSPACE_PREFIXES = (
+    "matheel-suite-",
+    "matheel-dataset-map-",
+    "matheel-pair-explanation-",
+    "matheel-leaderboard-inspect-",
+    "matheel-ready-leaderboard-upload-",
+    "matheel-ready-leaderboard-",
+    "matheel-dataset-upload-",
+    "matheel-dataset-validation-",
+    "matheel-threshold-tuning-",
+    "matheel-scored-pair-explanation-",
+    "matheel-leaderboard-",
+)
 FEATURE_UI_CHOICES = [
     "Embedding",
     "Levenshtein",
@@ -100,6 +116,41 @@ FEATURE_UI_CHOICES = [
     "Code Metric",
 ]
 DEFAULT_FEATURE_SELECTION = ["Embedding", "Levenshtein"]
+
+
+def cleanup_stale_temp_workspaces(
+    temp_root=None,
+    ttl_seconds=TEMP_WORKSPACE_TTL_SECONDS,
+    prefixes=TEMP_WORKSPACE_PREFIXES,
+):
+    root = Path(temp_root or tempfile.gettempdir())
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return 0
+
+    now = time.time()
+    cleaned = 0
+    for entry in entries:
+        if not entry.is_dir() or not any(entry.name.startswith(prefix) for prefix in prefixes):
+            continue
+        try:
+            age = now - entry.stat().st_mtime
+        except OSError:
+            continue
+        if age < max(0, int(ttl_seconds)):
+            continue
+        try:
+            shutil.rmtree(entry)
+        except OSError:
+            continue
+        cleaned += 1
+    return cleaned
+
+
+def make_temp_workspace(prefix, temp_root=None):
+    cleanup_stale_temp_workspaces(temp_root=temp_root)
+    return Path(tempfile.mkdtemp(prefix=prefix, dir=temp_root))
 
 
 def _metric_preset_from_leaderboard_preset(name):
@@ -1403,7 +1454,7 @@ def run_suite_gradio(
 
     run_configs = suite_rows_to_configs(execution_frame)
 
-    export_root = tempfile.mkdtemp(prefix="matheel-suite-")
+    export_root = os.fspath(make_temp_workspace("matheel-suite-"))
     summary_name = f"comparison_suite_summary.{output_format}"
     summary_export_path = os.path.join(export_root, summary_name)
     details_dir = os.path.join(export_root, "comparison_suite_details")
@@ -1651,7 +1702,7 @@ def generate_dataset_map_gradio(
 
     if progress is not None:
         progress(0.7, desc="Writing visualization artifacts")
-    export_root = Path(tempfile.mkdtemp(prefix="matheel-dataset-map-"))
+    export_root = make_temp_workspace("matheel-dataset-map-")
     artifacts = write_dataset_map_artifacts(
         projection,
         export_root,
@@ -1733,7 +1784,7 @@ def generate_pair_explanation_gradio(
     except ValueError as exc:
         raise gr.Error(str(exc)) from exc
 
-    export_root = Path(tempfile.mkdtemp(prefix="matheel-pair-explanation-"))
+    export_root = make_temp_workspace("matheel-pair-explanation-")
     artifacts = write_pair_explanation_artifacts(
         explanation,
         export_root,
@@ -1855,7 +1906,7 @@ def inspect_leaderboard_artifacts_gradio(leaderboard_file):
     report = _leaderboard_report_from_payload(payload)
     title = str(report["metadata"].get("name") or "Matheel Leaderboard")
     html_report = benchmark_report_html(report, title=title)
-    export_root = Path(tempfile.mkdtemp(prefix="matheel-leaderboard-inspect-"))
+    export_root = make_temp_workspace("matheel-leaderboard-inspect-")
     artifacts = write_leaderboard_artifacts(
         report,
         export_root,
@@ -1958,7 +2009,7 @@ def _normalized_dataset_roots_from_upload(uploaded_path):
         return _find_normalized_dataset_roots(path)
     if not zipfile.is_zipfile(path):
         raise gr.Error("Ready leaderboard inputs must be normalized dataset ZIP archives or directories.")
-    extract_root = Path(tempfile.mkdtemp(prefix="matheel-ready-leaderboard-upload-"))
+    extract_root = make_temp_workspace("matheel-ready-leaderboard-upload-")
     _safe_extract_uploaded_zip(path, extract_root)
     return _find_normalized_dataset_roots(extract_root)
 
@@ -2067,7 +2118,7 @@ def run_ready_leaderboard_gradio(
     }
     if progress is not None:
         progress(0.35, desc="Running leaderboard")
-    export_root = Path(tempfile.mkdtemp(prefix="matheel-ready-leaderboard-"))
+    export_root = make_temp_workspace("matheel-ready-leaderboard-")
     try:
         report, artifacts = run_leaderboard(
             manifest,
@@ -2130,7 +2181,7 @@ def _dataset_root_from_upload(uploaded_file, task_label):
     if not zipfile.is_zipfile(uploaded_path):
         raise gr.Error("Dataset upload must be a ZIP archive or a normalized dataset directory.")
 
-    extract_root = Path(tempfile.mkdtemp(prefix="matheel-dataset-upload-"))
+    extract_root = make_temp_workspace("matheel-dataset-upload-")
     _safe_extract_uploaded_zip(uploaded_path, extract_root)
     return _find_normalized_dataset_root(extract_root, task_label)
 
@@ -2393,7 +2444,7 @@ def validate_dataset_gradio(dataset_file, task_label, progress=gr.Progress(track
     dataset_root = _dataset_root_from_upload(dataset_file, task_label)
     if progress is not None:
         progress(0.3, desc="Inspecting dataset")
-    export_root = Path(tempfile.mkdtemp(prefix="matheel-dataset-validation-"))
+    export_root = make_temp_workspace("matheel-dataset-validation-")
     report, artifacts = write_dataset_validation_report(
         dataset_root,
         export_root,
@@ -2484,7 +2535,7 @@ def threshold_tuning_gradio(scored_state, optimize, progress=gr.Progress(track_t
         return empty_threshold_tuning_summary_html(), pd.DataFrame(), "", None
     if progress is not None:
         progress(0.35, desc="Sweeping thresholds")
-    export_root = Path(tempfile.mkdtemp(prefix="matheel-threshold-tuning-"))
+    export_root = make_temp_workspace("matheel-threshold-tuning-")
     try:
         report, artifacts = write_threshold_tuning_report_artifacts(
             scored,
@@ -2532,7 +2583,7 @@ def explain_scored_pair_gradio(
         return empty_pair_explanation_summary_html(), pd.DataFrame(), "", None
     if progress is not None:
         progress(0.35, desc="Building pair explanation")
-    export_root = Path(tempfile.mkdtemp(prefix="matheel-scored-pair-explanation-"))
+    export_root = make_temp_workspace("matheel-scored-pair-explanation-")
     try:
         explanation, artifacts = write_scored_pair_explanation(
             scored,
@@ -2636,7 +2687,7 @@ def evaluate_dataset_gradio(
     if progress is not None:
         progress(1.0, desc="Dataset evaluation complete")
 
-    export_root = tempfile.mkdtemp(prefix="matheel-leaderboard-")
+    export_root = os.fspath(make_temp_workspace("matheel-leaderboard-"))
     artifacts_zip = _write_leaderboard_artifacts(
         export_root,
         task_label,

--- a/matheel/algorithms.py
+++ b/matheel/algorithms.py
@@ -376,7 +376,10 @@ def score_source_pairs_with_algorithm(
             kind="mergesort",
             ignore_index=True,
         )
-    result = similarity_df.head(max(1, int(number_results)))
+    result_count = int(number_results)
+    if result_count < 1:
+        raise ValueError("number_results must be at least 1.")
+    result = similarity_df.head(result_count)
     attach_run_metadata(
         result,
         elapsed_seconds=elapsed_seconds_since(start_time),

--- a/matheel/benchmark_cards.py
+++ b/matheel/benchmark_cards.py
@@ -1,8 +1,15 @@
 import json
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 from .algorithms import normalize_algorithm_options, resolve_pair_algorithm
-from .datasets import PairDataset, RetrievalDataset, load_pair_dataset, load_retrieval_dataset
+from .datasets import (
+    PairDataset,
+    RetrievalDataset,
+    load_pair_dataset,
+    load_pair_datasets,
+    load_retrieval_dataset,
+    load_retrieval_datasets,
+)
 from .reproducibility import fingerprint_source
 
 
@@ -52,7 +59,7 @@ def algorithm_card(config, name=None):
         "card_type": "algorithm",
         "name": str(name or payload.get("name") or _algorithm_name_from_path(algorithm_path) or "matheel"),
         "algorithm_kind": "custom" if algorithm_path else "builtin",
-        "algorithm_path_name": Path(str(algorithm_path)).name if algorithm_path else "",
+        "algorithm_path_name": _path_name(algorithm_path) if algorithm_path else "",
         "algorithm_options": _sanitize_mapping(algorithm_options),
         "similarity_options": _sanitize_mapping(options),
         "fingerprint": {},
@@ -100,7 +107,11 @@ def _load_card_dataset(dataset, task_family=None):
         task_families = dataset.get("task_families") or ()
         task = next(iter(task_families), None)
     if task == "retrieval":
+        if isinstance(dataset, dict):
+            return load_retrieval_datasets(dataset)
         return load_retrieval_dataset(_dataset_identifier(dataset))
+    if isinstance(dataset, dict):
+        return load_pair_datasets(dataset)
     return load_pair_dataset(_dataset_identifier(dataset))
 
 
@@ -132,7 +143,7 @@ def _dataset_kind_from_task(task_family):
 def _algorithm_name_from_path(algorithm_path):
     if not algorithm_path:
         return None
-    return Path(str(algorithm_path)).stem
+    return Path(_path_name(algorithm_path)).stem
 
 
 def _custom_algorithm_card_fields(algorithm_path):
@@ -140,7 +151,7 @@ def _custom_algorithm_card_fields(algorithm_path):
         resolved = resolve_pair_algorithm(algorithm_path)
     except Exception:
         return {
-            "fingerprint": {"source_type": "unresolved", "file_name": Path(str(algorithm_path)).name},
+            "fingerprint": {"source_type": "unresolved", "file_name": _path_name(algorithm_path)},
         }
     return {
         "resolved_algorithm_name": resolved.name,
@@ -158,7 +169,7 @@ def _sanitize_mapping(values):
         if lowered in _CREDENTIAL_KEYS:
             sanitized[name] = "<redacted>"
         elif lowered in _PATH_KEYS and isinstance(value, (str, Path)):
-            sanitized[name] = Path(value).name
+            sanitized[name] = _path_name(value)
         elif isinstance(value, dict):
             sanitized[name] = _sanitize_mapping(value)
         elif isinstance(value, (list, tuple)):
@@ -169,3 +180,11 @@ def _sanitize_mapping(values):
         else:
             sanitized[name] = value
     return sanitized
+
+
+def _path_name(value):
+    text = str(value or "")
+    windows_path = PureWindowsPath(text)
+    if windows_path.drive or "\\" in text:
+        return windows_path.name or text
+    return Path(text).name or text

--- a/matheel/calibration.py
+++ b/matheel/calibration.py
@@ -27,8 +27,53 @@ def _finite_score(value):
 
 def _coerce_label(value, positive_label=True):
     if positive_label is True:
-        return bool(value)
+        return _coerce_default_binary_label(value)
     return value == positive_label
+
+
+def _coerce_default_binary_label(value):
+    if isinstance(value, bool):
+        return bool(value)
+    if isinstance(value, str):
+        key = value.strip().lower()
+        if key in {
+            "1",
+            "1.0",
+            "true",
+            "yes",
+            "y",
+            "positive",
+            "plagiarized",
+            "plagiarised",
+            "plagiarism",
+            "match",
+            "same",
+        }:
+            return True
+        if key in {
+            "0",
+            "0.0",
+            "false",
+            "no",
+            "n",
+            "negative",
+            "original",
+            "non_plagiarized",
+            "non_plagiarised",
+            "non_plagiarism",
+            "non-plagiarism",
+            "nonmatch",
+            "non-match",
+            "different",
+        }:
+            return False
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return bool(value)
+    if math.isfinite(numeric):
+        return numeric != 0.0
+    return bool(value)
 
 
 def _coerce_score_label_pairs(

--- a/matheel/code_metrics.py
+++ b/matheel/code_metrics.py
@@ -73,7 +73,6 @@ except ImportError:  # pragma: no cover - optional dependency
 
 
 _TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*|\d+|[^\w\s]")
-_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _RUBY_TRANX_SPLIT_RE = re.compile(r"([^A-Za-z0-9_])")
 _RUBY_TRANX_CAMEL_RE = re.compile(r"([a-z])([A-Z])")
 _SUPPORTED_CODE_LANGUAGES = (
@@ -488,76 +487,6 @@ def _weighted_match_score(reference_tokens, hypothesis_tokens, weights, ignored_
     return float(
         brevity_penalty * math.exp(sum(weight * math.log(precision) for weight, precision in zip(weights, precisions)))
     )
-
-
-def _keyword_weighted_match_score(reference_tokens, hypothesis_tokens, keywords, weights, epsilon=1e-12):
-    if not hypothesis_tokens:
-        return 0.0
-
-    precisions = []
-    max_order = len(weights)
-    for n in range(1, max_order + 1):
-        hyp_counts = Counter(ngram_tuples(hypothesis_tokens, n))
-        ref_counts = Counter(ngram_tuples(reference_tokens, n))
-        if not hyp_counts:
-            precisions.append(epsilon)
-            continue
-
-        def ngram_weight(ngram):
-            token_weights = [1.0 if token in keywords else 0.2 for token in ngram]
-            return sum(token_weights) / float(len(token_weights))
-
-        denom = sum(count * ngram_weight(ngram) for ngram, count in hyp_counts.items())
-        if denom <= 0:
-            precisions.append(epsilon)
-            continue
-
-        numer = 0.0
-        for ngram, count in hyp_counts.items():
-            numer += min(count, ref_counts.get(ngram, 0)) * ngram_weight(ngram)
-        if numer <= 0:
-            return 0.0
-        precisions.append(max(epsilon, numer / float(denom)))
-
-    brevity_penalty = _brevity_penalty(len(reference_tokens), len(hypothesis_tokens))
-    return float(
-        brevity_penalty * math.exp(sum(weight * math.log(precision) for weight, precision in zip(weights, precisions)))
-    )
-
-
-def _syntax_shape_tokens(tokens, keywords):
-    shapes = []
-    for token in tokens:
-        if token in keywords:
-            shapes.append(f"kw:{token}")
-        elif token.isdigit():
-            shapes.append("num")
-        elif _IDENTIFIER_RE.match(token):
-            shapes.append("id")
-        else:
-            shapes.append(f"sym:{token}")
-    return shapes
-
-
-def _identifier_overlap_score(reference_tokens, hypothesis_tokens, keywords):
-    ref_ids = [token for token in reference_tokens if _IDENTIFIER_RE.match(token) and token not in keywords]
-    hyp_ids = [token for token in hypothesis_tokens if _IDENTIFIER_RE.match(token) and token not in keywords]
-    if not ref_ids and not hyp_ids:
-        return 1.0
-    if not ref_ids or not hyp_ids:
-        return 0.0
-
-    ref_counts = Counter(ref_ids)
-    hyp_counts = Counter(hyp_ids)
-    overlap = sum(min(count, hyp_counts.get(token, 0)) for token, count in ref_counts.items())
-    if overlap <= 0:
-        return 0.0
-
-    precision = overlap / float(sum(hyp_counts.values()))
-    recall = overlap / float(sum(ref_counts.values()))
-    if precision + recall <= 0:
-        return 0.0
-    return float((2.0 * precision * recall) / (precision + recall))
 
 
 def parse_component_weights(raw_weights=None):

--- a/matheel/dataset_validation.py
+++ b/matheel/dataset_validation.py
@@ -337,6 +337,15 @@ def _read_csv_manifest(root, filename, required_columns, issues):
         return None
     try:
         frame = pd.read_csv(path)
+    except pd.errors.EmptyDataError:
+        expected = ", ".join(required_columns)
+        _add_issue(
+            issues,
+            "error",
+            "empty_csv",
+            f"{filename} is empty; expected columns: {expected}.",
+        )
+        return None
     except (pd.errors.ParserError, UnicodeDecodeError, OSError) as exc:
         _add_issue(issues, "error", "invalid_csv", f"{filename} could not be read as CSV: {exc}.")
         return None

--- a/matheel/datasets.py
+++ b/matheel/datasets.py
@@ -155,7 +155,12 @@ def resolve_dataset_source(
 
     resolved_destination = destination
     if resolved_destination is None and source_key != "local":
-        resolved_destination = _default_dataset_destination(source_key, identifier)
+        resolved_destination = _default_dataset_destination(
+            source_key,
+            identifier,
+            revision=revision,
+            split=split,
+        )
     if resolved_destination is not None:
         resolved_destination = _coerce_path(resolved_destination)
 
@@ -789,10 +794,21 @@ def _invoke_with_supported_kwargs(func, **kwargs):
     return func(**accepted)
 
 
-def _default_dataset_destination(source, identifier):
-    digest = sha1(str(identifier).encode("utf-8")).hexdigest()[:12]
+def _default_dataset_destination(source, identifier, revision="main", split=None):
+    fingerprint = {
+        "identifier": str(identifier),
+        "revision": str(revision or "main"),
+        "source": str(source),
+        "split": None if split is None else str(split),
+    }
+    digest = sha1(json.dumps(fingerprint, sort_keys=True).encode("utf-8")).hexdigest()[:12]
     safe_identifier = _safe_name_component(identifier)[:48]
-    return Path(tempfile.gettempdir()) / "matheel_datasets" / f"{source}_{safe_identifier}_{digest}"
+    safe_revision = _safe_name_component(revision or "main")[:24]
+    return (
+        Path(tempfile.gettempdir())
+        / "matheel_datasets"
+        / f"{source}_{safe_identifier}_{safe_revision}_{digest}"
+    )
 
 
 def _safe_name_component(value):
@@ -1520,11 +1536,18 @@ def _table_value(row, column):
 
 
 def _resolve_tabular_source_path(source_root, value):
-    path = Path(os.fspath(value))
-    if not path.is_absolute():
-        path = _coerce_path(source_root) / path
+    root = _coerce_path(source_root)
+    raw_path = Path(os.fspath(value)).expanduser()
+    candidate = raw_path if raw_path.is_absolute() else root / raw_path
+    path = candidate.resolve()
+    try:
+        path.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"Tabular adapter source file must stay within dataset root: {value}") from exc
     if not path.exists():
         raise ValueError(f"Tabular adapter source file does not exist: {value}")
+    if not path.is_file():
+        raise ValueError(f"Tabular adapter source path is not a file: {value}")
     return path
 
 

--- a/matheel/resampling.py
+++ b/matheel/resampling.py
@@ -1,4 +1,5 @@
 import math
+from numbers import Integral
 from dataclasses import dataclass
 
 import numpy as np
@@ -154,6 +155,8 @@ def repeated_kfold_splits(
 
 def bootstrap_resamples(items_or_count, n_rounds=100, sample_size=None, seed=None, prefix="bootstrap"):
     count = _normalize_count(items_or_count)
+    if count < 2:
+        raise ValueError("bootstrap_resamples requires at least two items for out-of-bag test indices.")
     rounds = int(n_rounds)
     if rounds < 1:
         raise ValueError("n_rounds must be at least 1.")
@@ -166,12 +169,22 @@ def bootstrap_resamples(items_or_count, n_rounds=100, sample_size=None, seed=Non
     all_indices = np.arange(count, dtype=int)
     splits = []
     for round_index in range(1, rounds + 1):
-        train_indices = generator.choice(all_indices, size=sample_count, replace=True)
-        unique_train = set(int(value) for value in train_indices.tolist())
-        test_indices = np.asarray(
-            [index for index in all_indices.tolist() if index not in unique_train],
-            dtype=int,
-        )
+        train_indices = None
+        test_indices = None
+        for _attempt in range(100):
+            train_indices = generator.choice(all_indices, size=sample_count, replace=True)
+            unique_train = set(int(value) for value in train_indices.tolist())
+            test_indices = np.asarray(
+                [index for index in all_indices.tolist() if index not in unique_train],
+                dtype=int,
+            )
+            if test_indices.size:
+                break
+        if test_indices is None or not test_indices.size:
+            raise ValueError(
+                "Could not create a bootstrap resample with out-of-bag test indices. "
+                "Use fewer samples or more input items."
+            )
         splits.append(
             DataSplit(
                 name=f"{prefix}_{round_index}",
@@ -278,7 +291,7 @@ def compare_metric_samples(
 
 
 def _normalize_count(items_or_count):
-    count = int(items_or_count) if isinstance(items_or_count, int) else len(items_or_count)
+    count = int(items_or_count) if isinstance(items_or_count, Integral) else len(items_or_count)
     if count <= 0:
         raise ValueError("items_or_count must describe at least one item.")
     return count
@@ -343,6 +356,12 @@ def _stratified_single_split(count, labels, train_size, validation_size, test_si
             validation_size=validation_size,
             test_size=test_size,
         )
+        test_count = len(label_indices) - train_count - validation_count
+        _validate_stratified_partition_counts(
+            len(label_indices),
+            (train_count, validation_count, test_count),
+            (train_size, validation_size, test_size),
+        )
         train_end = train_count
         validation_end = train_end + validation_count
         train_parts.append(label_indices[:train_end])
@@ -354,6 +373,25 @@ def _stratified_single_split(count, labels, train_size, validation_size, test_si
         _concat_sorted(validation_parts),
         _concat_sorted(test_parts),
     )
+
+
+def _validate_stratified_partition_counts(label_count, counts, ratios):
+    train_size, validation_size, test_size = ratios
+    train_ratio = float(train_size)
+    validation_ratio = float(validation_size)
+    test_ratio = 1.0 - train_ratio - validation_ratio if test_size is None else float(test_size)
+    requested = (
+        ("train", train_ratio, counts[0]),
+        ("validation", validation_ratio, counts[1]),
+        ("test", test_ratio, counts[2]),
+    )
+    missing = [name for name, ratio, count in requested if ratio > 0 and count == 0]
+    if missing:
+        partitions = ", ".join(missing)
+        raise ValueError(
+            "Stratified single split cannot preserve every label in each requested "
+            f"partition for label count {label_count}. Empty partition(s): {partitions}."
+        )
 
 
 def _group_single_split(count, groups, train_size, validation_size, test_size, shuffle=True, seed=None):

--- a/matheel/similarity.py
+++ b/matheel/similarity.py
@@ -140,6 +140,7 @@ def load_model(
     pooling_method="mean",
     max_token_length=None,
 ):
+    """Compatibility wrapper that loads a sentence-transformers backend model."""
     return load_vector_model(
         model_name or DEFAULT_MODEL_NAME,
         device=normalize_device(device),
@@ -1175,7 +1176,10 @@ def get_sim_list(
     ]
 
     similarity_df = pd.DataFrame(pairs_results, columns=RESULT_COLUMNS)
-    result = similarity_df.head(max(1, int(number_results)))
+    result_count = int(number_results)
+    if result_count < 1:
+        raise ValueError("number_results must be at least 1.")
+    result = similarity_df.head(result_count)
     return attach_run_metadata(
         result,
         elapsed_seconds=elapsed_seconds_since(start_time),

--- a/matheel/visualization.py
+++ b/matheel/visualization.py
@@ -43,14 +43,22 @@ def project_embeddings(embeddings, method="auto", seed=7):
 
     actual_method = selected
     if selected == "auto":
-        try:
-            coordinates = _project_umap(array, seed=seed)
-            actual_method = "umap"
-        except ImportError:
+        if array.shape[0] < 3:
             coordinates = _project_pca(array)
             actual_method = "pca"
+        else:
+            try:
+                coordinates = _project_umap(array, seed=seed)
+                actual_method = "umap"
+            except ImportError:
+                coordinates = _project_pca(array)
+                actual_method = "pca"
     elif selected == "umap":
-        coordinates = _project_umap(array, seed=seed)
+        if array.shape[0] < 3:
+            coordinates = _project_pca(array)
+            actual_method = "pca"
+        else:
+            coordinates = _project_umap(array, seed=seed)
     else:
         coordinates = _project_pca(array)
 
@@ -179,9 +187,10 @@ def write_dataset_map_artifacts(projection, output_dir, basename="dataset_map", 
     target = Path(output_dir)
     target.mkdir(parents=True, exist_ok=True)
     frame = projection.copy() if isinstance(projection, pd.DataFrame) else pd.DataFrame(projection)
-    csv_path = target / f"{basename}.csv"
-    json_path = target / f"{basename}.json"
-    html_path = target / f"{basename}.html"
+    safe_basename = _safe_artifact_basename(basename or "dataset_map")
+    csv_path = target / f"{safe_basename}.csv"
+    json_path = target / f"{safe_basename}.json"
+    html_path = target / f"{safe_basename}.html"
     frame.to_csv(csv_path, index=False)
     json_path.write_text(json.dumps(dataset_map_payload(frame), indent=2, sort_keys=True), encoding="utf-8")
     html_title = title or str(frame.attrs.get("dataset_name") or "Matheel Dataset Map")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ exclude = ["gradio_app*"]
 
 [tool.pytest.ini_options]
 addopts = ["-m", "not integration"]
+pythonpath = ["."]
 testpaths = ["tests"]
 markers = [
     "integration: real-model tests that use actual embedding backends and cached/downloaded model weights",

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -156,6 +156,20 @@ def test_score_source_pairs_with_algorithm_attaches_reproducibility_metadata(tmp
     assert len(results.attrs["algorithm"]["algorithm_source_fingerprint"]["sha256"]) == 64
 
 
+def test_score_source_pairs_with_algorithm_rejects_non_positive_number_results(tmp_path):
+    source_root = tmp_path / "codes"
+    source_root.mkdir()
+    (source_root / "a.py").write_text("print(1)\n", encoding="utf-8")
+    (source_root / "b.py").write_text("print(2)\n", encoding="utf-8")
+
+    def score_pair(code_a, code_b):
+        _ = (code_a, code_b)
+        return 1.0
+
+    with pytest.raises(ValueError, match="number_results"):
+        score_source_pairs_with_algorithm(source_root, algorithm=score_pair, number_results=0)
+
+
 def test_score_source_pairs_with_algorithm_reports_progress(tmp_path):
     source_root = tmp_path / "codes"
     source_root.mkdir()

--- a/tests/test_benchmark_cards.py
+++ b/tests/test_benchmark_cards.py
@@ -57,6 +57,17 @@ def test_algorithm_card_sanitizes_paths_and_fingerprints_custom_algorithm(tmp_pa
     assert str(tmp_path) not in json.dumps(card)
 
 
+def test_algorithm_card_sanitizes_windows_style_paths():
+    card = algorithm_card({"algorithm_path": r"C:\Users\alice\secret\algo.py"})
+    text = json.dumps(card)
+
+    assert card["name"] == "algo"
+    assert card["algorithm_path_name"] == "algo.py"
+    assert card["fingerprint"]["file_name"] == "algo.py"
+    assert "alice" not in text
+    assert "secret" not in text
+
+
 def test_algorithm_card_defaults_for_builtin_config():
     card = algorithm_card({"name": "levenshtein", "feature_weights": {"levenshtein": 1.0}})
 
@@ -88,6 +99,37 @@ def test_leaderboard_cards_and_markdown(tmp_path):
     assert cards["datasets"][0]["name"] == "pairs"
     assert cards["algorithms"][0]["name"] == "custom"
     assert "# Dataset: pairs" in card_markdown(cards["datasets"][0])
+
+
+def test_leaderboard_cards_support_adapter_backed_dataset_specs(tmp_path):
+    source_root = tmp_path / "raw"
+    source_root.mkdir()
+    pd.DataFrame(
+        [
+            {"left_text": "print(1)", "right_text": "print(1)", "label": 1},
+            {"left_text": "print(1)", "right_text": "print(2)", "label": 0},
+        ]
+    ).to_csv(source_root / "pairs.csv", index=False)
+
+    cards = leaderboard_cards(
+        {
+            "datasets": [
+                {
+                    "name": "raw_pairs",
+                    "task_family": "pair",
+                    "spec": {
+                        "identifier": str(source_root),
+                        "adapter": "auto_pair_tabular",
+                        "adapted_destination": str(tmp_path / "adapted"),
+                        "task_families": ("pair",),
+                    },
+                }
+            ],
+            "algorithms": [{"name": "levenshtein", "similarity_options": {}}],
+        }
+    )
+
+    assert cards["datasets"][0]["counts"]["pairs"] == 2
 
 
 def _write_pair_fixture(tmp_path):

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -122,6 +122,19 @@ def test_threshold_sweep_returns_dataframe_with_confusion_counts():
     assert frame.loc[0, "f1"] == pytest.approx(1.0)
 
 
+def test_evaluate_threshold_coerces_string_binary_labels():
+    report = evaluate_threshold(
+        [(0.1, "0"), (0.2, "false"), (0.8, "true"), (0.9, "1")],
+        threshold=0.5,
+    )
+
+    assert report["positive_count"] == 2
+    assert report["negative_count"] == 2
+    assert report["true_positive"] == 2
+    assert report["true_negative"] == 2
+    assert report["accuracy"] == pytest.approx(1.0)
+
+
 def test_roc_and_precision_recall_curves_report_perfect_ranking_metrics():
     scores = [0.95, 0.82, 0.3, 0.1]
     labels = [True, True, False, False]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import zipfile
+from pathlib import Path
 from types import ModuleType
 
 import pandas as pd
@@ -138,6 +139,22 @@ def test_dataset_validation_report_finds_pair_reference_errors(tmp_path):
     assert "empty_files" in codes
 
 
+def test_dataset_validation_report_handles_empty_csv_manifest(tmp_path):
+    dataset_root = tmp_path / "empty_manifest"
+    dataset_root.mkdir()
+    (dataset_root / "metadata.json").write_text(
+        json.dumps({"dataset_kind": "pair_classification", "name": "empty"}),
+        encoding="utf-8",
+    )
+    (dataset_root / "files.csv").write_text("", encoding="utf-8")
+    (dataset_root / "pairs.csv").write_text("left_id,right_id,label\n", encoding="utf-8")
+
+    report = validate_dataset_report(dataset_root, kind="pair")
+
+    assert report["status"] == "error"
+    assert any(issue["code"] == "empty_csv" for issue in report["issues"])
+
+
 def test_dataset_validation_report_finds_retrieval_reference_errors(tmp_path):
     dataset_root = tmp_path / "broken_retrieval"
     write_retrieval_dataset(
@@ -171,6 +188,28 @@ def test_default_dataset_sources_include_generic_resolvers():
     sources = set(available_dataset_sources())
 
     assert {"local", "github", "zenodo", "huggingface", "kaggle"}.issubset(sources)
+
+
+def test_default_remote_dataset_cache_includes_revision_and_split():
+    destinations = []
+
+    def resolver(identifier, destination=None, revision="main", token=None, split=None):
+        _ = (identifier, token, split)
+        target = Path(destination)
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "revision.txt").write_text(str(revision), encoding="utf-8")
+        destinations.append(target)
+        return target
+
+    register_dataset_source("unit_cache", resolver, overwrite=True)
+
+    first = resolve_dataset_source("unit_cache", "owner/repo", revision="main", split="train")
+    second = resolve_dataset_source("unit_cache", "owner/repo", revision="dev", split="train")
+    third = resolve_dataset_source("unit_cache", "owner/repo", revision="main", split="test")
+
+    assert first != second
+    assert first != third
+    assert len(set(destinations)) == 3
 
 
 def test_default_dataset_presets_include_only_approved_plagiarism_presets():
@@ -216,6 +255,29 @@ def test_safe_archive_extraction_rejects_path_traversal(tmp_path):
         _safe_extract_archive(archive_path, tmp_path / "out")
 
     assert not (tmp_path / "escape.txt").exists()
+
+
+def test_tabular_adapter_rejects_paths_outside_source_root(tmp_path):
+    source_root = tmp_path / "raw"
+    source_root.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("print('secret')\n", encoding="utf-8")
+    pd.DataFrame(
+        [
+            {
+                "left_path": "../outside.py",
+                "right_text": "print(1)",
+                "label": 1,
+            }
+        ]
+    ).to_csv(source_root / "pairs.csv", index=False)
+
+    with pytest.raises(ValueError, match="within dataset root"):
+        adapt_pair_dataset(
+            source_root,
+            adapter="auto_pair_tabular",
+            destination=tmp_path / "adapted",
+        )
 
 
 def test_kaggle_api_resolver_downloads_then_safe_extracts(tmp_path, monkeypatch):

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 import zipfile
 from pathlib import Path
 
@@ -18,6 +19,44 @@ SPEC = importlib.util.spec_from_file_location("matheel_gradio_app", APP_PATH)
 gradio_app = importlib.util.module_from_spec(SPEC)
 assert SPEC is not None and SPEC.loader is not None
 SPEC.loader.exec_module(gradio_app)
+
+
+def test_gradio_temp_workspace_cleanup_removes_only_stale_known_prefixes(tmp_path):
+    old_workspace = tmp_path / "matheel-suite-old"
+    fresh_workspace = tmp_path / "matheel-suite-fresh"
+    unrelated = tmp_path / "other-old"
+    old_workspace.mkdir()
+    fresh_workspace.mkdir()
+    unrelated.mkdir()
+    os.utime(old_workspace, (1, 1))
+    os.utime(unrelated, (1, 1))
+
+    cleaned = gradio_app.cleanup_stale_temp_workspaces(
+        temp_root=tmp_path,
+        ttl_seconds=60,
+        prefixes=("matheel-suite-",),
+    )
+
+    assert cleaned == 1
+    assert not old_workspace.exists()
+    assert fresh_workspace.exists()
+    assert unrelated.exists()
+
+
+def test_gradio_temp_workspace_creation_runs_cleanup(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_cleanup(temp_root=None):
+        calls.append(temp_root)
+        return 0
+
+    monkeypatch.setattr(gradio_app, "cleanup_stale_temp_workspaces", fake_cleanup)
+
+    workspace = gradio_app.make_temp_workspace("matheel-suite-", temp_root=tmp_path)
+
+    assert calls == [tmp_path]
+    assert workspace.exists()
+    assert workspace.parent == tmp_path
 
 
 def _build_suite_row(**overrides):

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -142,6 +142,38 @@ def test_leaderboard_runs_pair_and_retrieval_datasets(tmp_path):
     assert "Algorithm Details" in details_html
 
 
+def test_leaderboard_runs_adapter_backed_pair_dataset(tmp_path):
+    source_root = tmp_path / "raw_pairs"
+    source_root.mkdir()
+    pd.DataFrame(
+        [
+            {"left_text": "print(1)", "right_text": "print(1)", "label": 1},
+            {"left_text": "print(1)", "right_text": "print(2)", "label": 0},
+        ]
+    ).to_csv(source_root / "pairs.csv", index=False)
+
+    report, artifacts = run_leaderboard(
+        {
+            "name": "adapter_backed",
+            "datasets": [
+                {
+                    "name": "raw_pairs",
+                    "task": "pair",
+                    "path": str(source_root),
+                    "adapter": "auto_pair_tabular",
+                    "adapted_destination": str(tmp_path / "adapted_pairs"),
+                }
+            ],
+            "algorithms": [{"name": "levenshtein", "feature_weights": {"levenshtein": 1.0}}],
+        },
+        output_dir=tmp_path / "leaderboard",
+    )
+
+    assert artifacts["json"].exists()
+    assert report["cards"]["datasets"][0]["counts"]["pairs"] == 2
+    assert not report["per_dataset"].empty
+
+
 def test_leaderboard_manifest_accepts_algorithm_presets(tmp_path):
     pair_root = _write_pair_fixture(tmp_path)
     manifest = {

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -46,6 +47,13 @@ def test_kfold_splits_cover_all_items_once_in_test_sets():
     assert sorted(test_indices) == list(range(12))
 
 
+def test_kfold_splits_accepts_numpy_integer_count():
+    splits = kfold_splits(np.int64(10), n_splits=5, shuffle=False)
+
+    assert len(splits) == 5
+    assert sum(len(split.test_indices) for split in splits) == 10
+
+
 def test_kfold_splits_can_stratify_labels():
     splits = kfold_splits(6, n_splits=3, shuffle=False, labels=[1, 1, 1, 0, 0, 0])
 
@@ -79,6 +87,17 @@ def test_bootstrap_resamples_returns_requested_rounds():
     assert all(split.method == "bootstrap" for split in splits)
     assert all(len(split.train_indices) == 10 for split in splits)
     assert all(set(split.test_indices).isdisjoint(split.train_indices) for split in splits)
+    assert all(split.test_indices for split in splits)
+
+
+def test_bootstrap_resamples_rejects_inputs_without_oob_tests():
+    with pytest.raises(ValueError, match="out-of-bag"):
+        bootstrap_resamples(1, n_rounds=1)
+
+
+def test_stratified_single_split_rejects_class_missing_from_requested_partition():
+    with pytest.raises(ValueError, match="Stratified single split"):
+        single_split(4, train_size=0.5, test_size=0.5, labels=[0, 0, 0, 1], seed=1)
 
 
 def test_metric_summary_reports_uncertainty_fields():

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -111,6 +111,44 @@ def test_get_sim_list_rejects_regular_file_source(tmp_path):
         )
 
 
+def test_get_sim_list_rejects_non_positive_number_results(tmp_path):
+    archive_path = tmp_path / "codes.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("a.py", "print(1)")
+        archive.writestr("b.py", "print(2)")
+
+    with pytest.raises(ValueError, match="number_results"):
+        similarity.get_sim_list(
+            archive_path,
+            number_results=0,
+            feature_weights={"levenshtein": 1.0},
+        )
+
+
+def test_load_model_keeps_sentence_transformer_compatibility_wrapper(monkeypatch):
+    calls = []
+
+    def fake_load_vector_model(model_name, **kwargs):
+        calls.append((model_name, kwargs))
+        return "model"
+
+    monkeypatch.setattr(similarity, "load_vector_model", fake_load_vector_model)
+
+    assert similarity.load_model("demo-model", device="cpu") == "model"
+    assert calls == [
+        (
+            "demo-model",
+            {
+                "device": "cpu",
+                "vector_backend": "sentence_transformers",
+                "similarity_function": "cosine",
+                "pooling_method": "mean",
+                "max_token_length": None,
+            },
+        )
+    ]
+
+
 def test_get_sim_list_validates_source_before_model_metadata_lookup(tmp_path, monkeypatch):
     source_file = tmp_path / "single.py"
     source_file.write_text("print(1)", encoding="utf-8")

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -48,6 +48,13 @@ def test_project_embeddings_pca_is_deterministic():
     assert first.shape == (3, 2)
 
 
+def test_project_embeddings_reports_pca_for_tiny_auto_projection():
+    projection = project_embeddings([[1.0, 0.0], [0.0, 1.0]], method="auto", seed=7)
+
+    assert projection.attrs["requested_projection_method"] == "auto"
+    assert projection.attrs["projection_method"] == "pca"
+
+
 def test_project_embeddings_rejects_invalid_values():
     with pytest.raises(ValueError, match="finite"):
         project_embeddings([[1.0], [float("nan")]], method="pca")
@@ -226,6 +233,15 @@ def test_write_dataset_map_artifacts_accepts_projection(tmp_path):
 
     assert artifacts["csv"].name == "dataset_map.csv"
     assert json.loads(artifacts["json"].read_text(encoding="utf-8"))["points"][0]["document_id"] == "a"
+
+
+def test_write_dataset_map_artifacts_sanitizes_basename(tmp_path):
+    projection = build_embedding_projection([[1.0, 0.0]], ids=["a"], method="pca")
+    output_dir = tmp_path / "artifacts"
+    artifacts = write_dataset_map_artifacts(projection, output_dir, basename="../unsafe/map")
+
+    assert all(output_dir in path.parents for path in artifacts.values())
+    assert all(".." not in path.name for path in artifacts.values())
 
 
 def test_build_pair_explanation_marks_high_medium_low_and_no_match_regions():


### PR DESCRIPTION
## Summary
- fix non-UI review bugs across Gradio temp cleanup, dataset source caching, dataset adapters, resampling, calibration, source-pair scoring, visualization metadata, and benchmark cards
- align package contents, pytest import behavior, and quickstart docs with installable distributions
- remove unused CodeBLEU helpers and add regression coverage for the fixed edge cases

## Validation
- uv run pytest
- uv run python -m ruff check .
- uv run mkdocs build --strict
- uv run python -m build
- uv run python -m twine check dist/*
- uv run python scripts/sync_gradio_app_version.py --check
- uv run python -m compileall matheel gradio_app examples
- git diff --check

Closes #199
Closes #200
Closes #201
Closes #202
Closes #203
Closes #204
Closes #205
Closes #206
Closes #207
Closes #208
Closes #209
Closes #210
Closes #211
Closes #212
