### PR TITLE
Fix additional review bugs

### DIFF
--- a/matheel/_path_utils.py
+++ b/matheel/_path_utils.py
@@ -1,0 +1,34 @@
+from pathlib import Path, PureWindowsPath
+
+
+def path_name(value):
+    text = str(value or "")
+    windows_path = PureWindowsPath(text)
+    if windows_path.drive or "\\" in text:
+        return windows_path.name or text
+    return Path(text).name or text
+
+
+def is_unsafe_relative_path(value):
+    text = str(value or "").strip()
+    if not text:
+        return False
+    posix_path = Path(text)
+    windows_path = PureWindowsPath(text)
+    return (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or bool(windows_path.drive)
+        or ".." in posix_path.parts
+        or ".." in windows_path.parts
+    )
+
+
+def relative_path_to_posix(value):
+    text = str(value or "").strip()
+    windows_path = PureWindowsPath(text)
+    if windows_path.drive or "\\" in text:
+        parts = windows_path.parts
+    else:
+        parts = Path(text).parts
+    return "/".join(part for part in parts if part not in ("", "."))

--- a/matheel/benchmark_cache.py
+++ b/matheel/benchmark_cache.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pandas as pd
 
 from .algorithms import resolve_pair_algorithm
+from ._path_utils import path_name
 from .reproducibility import fingerprint_source
 
 
@@ -140,7 +141,7 @@ def _algorithm_fingerprint_from_options(options):
     try:
         resolved = resolve_pair_algorithm(algorithm)
     except Exception:
-        return {"source_type": "unresolved", "name": Path(str(algorithm)).name}
+        return {"source_type": "unresolved", "name": path_name(algorithm)}
     return {
         "algorithm_name": resolved.name,
         "algorithm_module": resolved.module_name,
@@ -166,9 +167,9 @@ def _json_safe(value, key_name=None):
     if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]
     if isinstance(value, Path):
-        return value.name
+        return path_name(value)
     if key_name in _PATH_KEYS and isinstance(value, str):
-        return Path(value).name
+        return path_name(value)
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
     try:

--- a/matheel/benchmark_cards.py
+++ b/matheel/benchmark_cards.py
@@ -1,5 +1,5 @@
 import json
-from pathlib import Path, PureWindowsPath
+from pathlib import Path
 
 from .algorithms import normalize_algorithm_options, resolve_pair_algorithm
 from .datasets import (
@@ -10,6 +10,7 @@ from .datasets import (
     load_retrieval_dataset,
     load_retrieval_datasets,
 )
+from ._path_utils import path_name
 from .reproducibility import fingerprint_source
 
 
@@ -183,8 +184,4 @@ def _sanitize_mapping(values):
 
 
 def _path_name(value):
-    text = str(value or "")
-    windows_path = PureWindowsPath(text)
-    if windows_path.drive or "\\" in text:
-        return windows_path.name or text
-    return Path(text).name or text
+    return path_name(value)

--- a/matheel/benchmark_registry.py
+++ b/matheel/benchmark_registry.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from ._path_utils import path_name
 from .leaderboard import leaderboard_payload
 
 
@@ -195,7 +196,7 @@ def _sanitize_artifact_paths(artifact_paths):
     else:
         raw = ((Path(str(path)).stem, path) for path in artifact_paths)
     return {
-        str(name): Path(str(path)).name
+        str(name): path_name(path)
         for name, path in raw
         if path not in (None, "")
     }
@@ -207,7 +208,7 @@ def _clean_json_object(value):
 
 def _json_default(value):
     if isinstance(value, Path):
-        return value.name
+        return path_name(value)
     if hasattr(value, "item"):
         return value.item()
     if pd.isna(value):

--- a/matheel/dataset_validation.py
+++ b/matheel/dataset_validation.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from ._path_utils import is_unsafe_relative_path, relative_path_to_posix
+
 
 PAIR_KIND = "pair_classification"
 RETRIEVAL_KIND = "retrieval"
@@ -374,25 +376,28 @@ def _inspect_files_manifest(root, files, counts, issues):
 
     missing_files = []
     unsafe_paths = []
+    non_file_paths = []
     empty_files = []
     for row in files.to_dict(orient="records"):
         raw_path = row.get("file_path")
         if pd.isna(raw_path):
             continue
-        relative_path = Path(str(raw_path))
-        if relative_path.is_absolute() or ".." in relative_path.parts:
+        if is_unsafe_relative_path(raw_path):
             unsafe_paths.append(str(raw_path))
             continue
+        relative_path = Path(relative_path_to_posix(raw_path))
         target = root / relative_path
         if not target.exists():
             missing_files.append(str(raw_path))
             continue
-        if target.is_file():
-            try:
-                if not target.read_text(encoding="utf-8", errors="ignore").strip():
-                    empty_files.append(str(raw_path))
-            except OSError:
-                missing_files.append(str(raw_path))
+        if not target.is_file():
+            non_file_paths.append(str(raw_path))
+            continue
+        try:
+            if not target.read_text(encoding="utf-8", errors="ignore").strip():
+                empty_files.append(str(raw_path))
+        except OSError:
+            missing_files.append(str(raw_path))
 
     if unsafe_paths:
         _add_issue(
@@ -409,6 +414,14 @@ def _inspect_files_manifest(root, files, counts, issues):
             "missing_files",
             f"files.csv references missing files: {', '.join(missing_files[:8])}.",
             len(missing_files),
+        )
+    if non_file_paths:
+        _add_issue(
+            issues,
+            "error",
+            "non_file_paths",
+            f"files.csv references paths that are not files: {', '.join(non_file_paths[:8])}.",
+            len(non_file_paths),
         )
     if empty_files:
         _add_issue(
@@ -459,9 +472,46 @@ def _coerce_binary_label(value):
     if isinstance(value, bool):
         return int(value)
     text = str(value).strip().lower()
-    if text in {"1", "1.0", "true", "yes", "y", "positive", "plagiarized", "plagiarised", "p"}:
+    if text in {
+        "1",
+        "1.0",
+        "true",
+        "yes",
+        "y",
+        "p",
+        "positive",
+        "cheating",
+        "clone",
+        "plagiarized",
+        "plagiarised",
+        "plagiarism",
+        "match",
+        "same",
+    }:
         return 1
-    if text in {"0", "0.0", "false", "no", "n", "negative", "non_plagiarized", "non_plagiarised", "np"}:
+    if text in {
+        "0",
+        "0.0",
+        "false",
+        "no",
+        "n",
+        "negative",
+        "original",
+        "nonplagiarized",
+        "nonplagiarised",
+        "non_plagiarized",
+        "non_plagiarised",
+        "not plagiarized",
+        "not plagiarised",
+        "not_plagiarized",
+        "not_plagiarised",
+        "non_plagiarism",
+        "non-plagiarism",
+        "nonmatch",
+        "non-match",
+        "different",
+        "np",
+    }:
         return 0
     return None
 

--- a/matheel/datasets.py
+++ b/matheel/datasets.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from ._path_utils import is_unsafe_relative_path, relative_path_to_posix
+
 
 DATASET_TASK_TYPES = ("plagiarism",)
 DATASET_KINDS = ("pair_classification", "retrieval")
@@ -422,6 +424,8 @@ def validate_pair_dataset(dataset):
         target = dataset.root / file_path
         if not target.exists():
             raise ValueError(f"files.csv references missing file: {file_path}")
+        if not target.is_file():
+            raise ValueError(f"files.csv references path that is not a file: {file_path}")
 
     return PairDataset(root=dataset.root, files=files, pairs=pairs, metadata=metadata)
 
@@ -577,6 +581,8 @@ def validate_retrieval_dataset(dataset):
         target = dataset.root / file_path
         if not target.exists():
             raise ValueError(f"files.csv references missing file: {file_path}")
+        if not target.is_file():
+            raise ValueError(f"files.csv references path that is not a file: {file_path}")
 
     return RetrievalDataset(
         root=dataset.root,
@@ -604,7 +610,10 @@ def load_code_texts(dataset):
     for row in dataset.files.to_dict(orient="records"):
         file_id = _normalize_id(row["file_id"], "file_id")
         file_path = _normalize_relative_file_path(row["file_path"])
-        texts[file_id] = (dataset.root / file_path).read_text(encoding="utf-8", errors="ignore")
+        target = dataset.root / file_path
+        if not target.is_file():
+            raise ValueError(f"files.csv references path that is not a file: {file_path}")
+        texts[file_id] = target.read_text(encoding="utf-8", errors="ignore")
     return texts
 
 
@@ -672,10 +681,12 @@ def _normalize_relative_file_path(value):
     text = str(value or "").strip()
     if not text:
         raise ValueError("file_path must be non-empty.")
-    path = Path(text)
-    if path.is_absolute() or ".." in path.parts:
+    if is_unsafe_relative_path(text):
         raise ValueError(f"file_path must be relative to the dataset root. Got: {value}")
-    return path.as_posix()
+    normalized = relative_path_to_posix(text)
+    if not normalized:
+        raise ValueError("file_path must be non-empty.")
+    return normalized
 
 
 def _normalize_binary_label(value):
@@ -683,9 +694,51 @@ def _normalize_binary_label(value):
         return int(value)
     if isinstance(value, str):
         key = value.strip().lower()
-        if key in {"1", "true", "yes", "y", "positive", "plagiarized", "plagiarism", "match"}:
+        if key in {
+            "1",
+            "1.0",
+            "true",
+            "yes",
+            "y",
+            "p",
+            "positive",
+            "cheating",
+            "clone",
+            "plagiarized",
+            "plagiarised",
+            "plagiarism",
+            "match",
+            "same",
+        }:
             return 1
-        if key in {"0", "false", "no", "n", "negative", "original", "non_plagiarism", "non-match"}:
+        if key in {
+            "0",
+            "0.0",
+            "false",
+            "no",
+            "n",
+            "np",
+            "negative",
+            "original",
+            "not cheating",
+            "not_cheating",
+            "non-cheating",
+            "non cheating",
+            "non-clone",
+            "nonplagiarized",
+            "nonplagiarised",
+            "non_plagiarized",
+            "non_plagiarised",
+            "not plagiarized",
+            "not plagiarised",
+            "not_plagiarized",
+            "not_plagiarised",
+            "non_plagiarism",
+            "non-plagiarism",
+            "nonmatch",
+            "non-match",
+            "different",
+        }:
             return 0
     try:
         numeric = float(value)
@@ -1262,10 +1315,7 @@ def _column_from_options(frame, options, option_name, aliases, label, required=F
 def _prioritized_tabular_files(root, requested_table=None, split=None):
     base = _coerce_path(root)
     if requested_table:
-        table_path = Path(os.fspath(requested_table))
-        if not table_path.is_absolute():
-            table_path = base / table_path
-        return [_coerce_path(table_path)]
+        return [_resolve_tabular_root_file(base, requested_table, "Tabular adapter table")]
 
     candidates = _find_tabular_files(base)
     if split is None:
@@ -1536,18 +1586,28 @@ def _table_value(row, column):
 
 
 def _resolve_tabular_source_path(source_root, value):
+    return _resolve_tabular_root_file(source_root, value, "Tabular adapter source file")
+
+
+def _resolve_tabular_root_file(source_root, value, label):
     root = _coerce_path(source_root)
-    raw_path = Path(os.fspath(value)).expanduser()
-    candidate = raw_path if raw_path.is_absolute() else root / raw_path
+    raw_value = os.fspath(value)
+    raw_path = Path(raw_value).expanduser()
+    if raw_path.is_absolute():
+        candidate = raw_path
+    else:
+        if is_unsafe_relative_path(raw_value):
+            raise ValueError(f"{label} must stay within dataset root: {value}")
+        candidate = root / relative_path_to_posix(raw_value)
     path = candidate.resolve()
     try:
         path.relative_to(root)
     except ValueError as exc:
-        raise ValueError(f"Tabular adapter source file must stay within dataset root: {value}") from exc
+        raise ValueError(f"{label} must stay within dataset root: {value}") from exc
     if not path.exists():
-        raise ValueError(f"Tabular adapter source file does not exist: {value}")
+        raise ValueError(f"{label} does not exist: {value}")
     if not path.is_file():
-        raise ValueError(f"Tabular adapter source path is not a file: {value}")
+        raise ValueError(f"{label} path is not a file: {value}")
     return path
 
 
@@ -1565,8 +1625,10 @@ def _coerce_binary_like(value):
             "clone",
             "positive",
             "plagiarized",
+            "plagiarised",
             "plagiarism",
             "match",
+            "same",
         }:
             return 1
         if key in {
@@ -1582,9 +1644,19 @@ def _coerce_binary_like(value):
             "negative",
             "original",
             "nonplagiarized",
+            "nonplagiarised",
+            "non_plagiarized",
+            "non_plagiarised",
             "not plagiarized",
+            "not plagiarised",
+            "not_plagiarized",
+            "not_plagiarised",
             "non_plagiarism",
+            "non-plagiarism",
+            "nonmatch",
             "non-match",
+            "different",
+            "np",
         }:
             return 0
     try:
@@ -1601,9 +1673,35 @@ def _coerce_relevance_like(value):
         return float(value)
     if isinstance(value, str):
         key = value.strip().lower()
-        if key in {"true", "yes", "y", "relevant", "positive", "plagiarized", "plagiarism", "match"}:
+        if key in {
+            "true",
+            "yes",
+            "y",
+            "relevant",
+            "positive",
+            "plagiarized",
+            "plagiarised",
+            "plagiarism",
+            "match",
+            "same",
+        }:
             return 1.0
-        if key in {"false", "no", "n", "irrelevant", "negative", "non-match"}:
+        if key in {
+            "false",
+            "no",
+            "n",
+            "irrelevant",
+            "negative",
+            "original",
+            "non_plagiarized",
+            "non_plagiarised",
+            "non_plagiarism",
+            "non-plagiarism",
+            "nonmatch",
+            "non-match",
+            "different",
+            "np",
+        }:
             return 0.0
     return _normalize_nonnegative_relevance(value)
 

--- a/matheel/leaderboard.py
+++ b/matheel/leaderboard.py
@@ -10,6 +10,7 @@ from .calibration import calibration_report
 from .datasets import load_pair_datasets, load_retrieval_datasets
 from .evaluation import evaluate_pair_dataset, evaluate_retrieval_dataset
 from .leaderboard_presets import get_leaderboard_algorithm_preset
+from ._path_utils import path_name
 from .reproducibility import collect_reproducibility_snapshot, write_reproducibility_snapshot
 
 
@@ -35,8 +36,8 @@ _TASK_ALIASES = {
     "retrieval": "retrieval",
     "ranking": "retrieval",
 }
-_PATH_KEYS = {"identifier", "path", "algorithm_path"}
-_ALWAYS_LOCAL_PATH_KEYS = {"path", "algorithm_path"}
+_PATH_KEYS = {"identifier", "path", "algorithm_path", "destination", "adapted_destination"}
+_ALWAYS_LOCAL_PATH_KEYS = {"path", "algorithm_path", "destination", "adapted_destination"}
 _MAYBE_LOCAL_PATH_KEYS = {"identifier"}
 
 
@@ -405,17 +406,20 @@ def _resolve_relative_paths(payload, base_dir=None):
     if base_dir is None:
         return payload
     resolved = dict(payload)
-    for key in _PATH_KEYS:
+    source = str(resolved.get("source") or "local").strip().lower()
+    for key in ("path", "algorithm_path", "destination", "adapted_destination"):
         if key in resolved:
             resolved[key] = _resolve_relative_path(resolved[key], base_dir)
+    if "identifier" in resolved and source == "local":
+        resolved["identifier"] = _resolve_relative_path(resolved["identifier"], base_dir, force=True)
     return resolved
 
 
-def _resolve_relative_path(value, base_dir):
+def _resolve_relative_path(value, base_dir, force=False):
     if not isinstance(value, str):
         return value
     text = value.strip()
-    if not text or Path(text).expanduser().is_absolute() or not _looks_like_path(text):
+    if not text or Path(text).expanduser().is_absolute() or (not force and not _looks_like_path(text)):
         return value
     return str((Path(base_dir) / text).resolve())
 
@@ -479,11 +483,7 @@ def _should_sanitize_manifest_path(key_name, value):
 
 
 def _path_name(value):
-    text = str(value or "")
-    windows_path = PureWindowsPath(text)
-    if windows_path.drive or "\\" in text:
-        return windows_path.name or text
-    return Path(text).name or text
+    return path_name(value)
 
 
 def _safe_basename(value):

--- a/matheel/reports.py
+++ b/matheel/reports.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from .leaderboard import leaderboard_payload
+from ._path_utils import path_name
 
 
 def benchmark_report_html(report, title=None, artifact_links=None):
@@ -233,5 +234,5 @@ def _sanitize_artifact_links(links):
     for name, value in dict(links).items():
         if value in (None, ""):
             continue
-        sanitized[str(name)] = Path(str(value)).name
+        sanitized[str(name)] = path_name(value)
     return sanitized

--- a/matheel/reproducibility.py
+++ b/matheel/reproducibility.py
@@ -7,6 +7,8 @@ from hashlib import sha256
 from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 
+from ._path_utils import path_name
+
 
 _PACKAGE_NAMES = (
     "matheel",
@@ -107,14 +109,14 @@ def _json_safe(value):
         for key, item in sorted(value.items(), key=lambda item: str(item[0])):
             name = str(key)
             if name in _PATH_OPTION_NAMES and isinstance(item, (str, Path)):
-                payload[name] = Path(item).name if item else item
+                payload[name] = path_name(item) if item else item
             else:
                 payload[name] = _json_safe(item)
         return payload
     if isinstance(value, (list, tuple)):
         return [_json_safe(item) for item in value]
     if isinstance(value, Path):
-        return value.name
+        return path_name(value)
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
     try:

--- a/tests/test_benchmark_cache.py
+++ b/tests/test_benchmark_cache.py
@@ -13,6 +13,7 @@ from matheel.benchmark_cache import (
     load_benchmark_cache_result,
     write_benchmark_cache_result,
 )
+from matheel.reproducibility import collect_reproducibility_snapshot
 
 
 def test_benchmark_cache_helpers_are_exported_from_package_root():
@@ -134,3 +135,21 @@ def test_benchmark_cache_metadata_does_not_store_absolute_paths(tmp_path):
     metadata = json.loads(paths["metadata"].read_text(encoding="utf-8"))
 
     assert str(tmp_path) not in json.dumps(metadata)
+
+
+def test_benchmark_cache_and_reproducibility_sanitize_windows_paths():
+    run_config = {
+        "run_name": "windows",
+        "options": {"algorithm_path": r"C:\Users\alice\secret\algo.py"},
+    }
+    payload = benchmark_cache_key(
+        {"source_type": "file", "sha256": "abc"},
+        run_config,
+        dependency_versions={"matheel": "test"},
+    )
+    snapshot = collect_reproducibility_snapshot(run_configs=[run_config])
+
+    assert payload["components"]["run_config"]["options"]["algorithm_path"] == "algo.py"
+    assert snapshot["run_configs"][0]["options"]["algorithm_path"] == "algo.py"
+    assert "alice" not in json.dumps(payload)
+    assert "alice" not in json.dumps(snapshot)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -280,6 +280,29 @@ def test_tabular_adapter_rejects_paths_outside_source_root(tmp_path):
         )
 
 
+def test_tabular_adapter_rejects_table_paths_outside_source_root(tmp_path):
+    source_root = tmp_path / "raw"
+    source_root.mkdir()
+    outside = tmp_path / "outside.csv"
+    pd.DataFrame(
+        [{"left_text": "print(1)", "right_text": "print(1)", "label": 1}]
+    ).to_csv(outside, index=False)
+
+    with pytest.raises(ValueError, match="within dataset root"):
+        adapt_pair_dataset(
+            source_root,
+            adapter="auto_pair_tabular",
+            adapter_options={"pair_table": "../outside.csv"},
+        )
+
+    with pytest.raises(ValueError, match="within dataset root"):
+        adapt_retrieval_dataset(
+            source_root,
+            adapter="auto_retrieval_tabular",
+            adapter_options={"retrieval_table": "../outside.csv"},
+        )
+
+
 def test_kaggle_api_resolver_downloads_then_safe_extracts(tmp_path, monkeypatch):
     captured = {}
 
@@ -982,6 +1005,34 @@ def test_pair_dataset_roundtrip_writes_manifest_files(tmp_path):
     assert (dataset_root / "files" / "a.py").exists()
 
 
+def test_pair_dataset_loader_matches_validation_binary_label_vocabulary(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame(
+            [
+                {"file_id": "a", "text": "print(1)"},
+                {"file_id": "b", "text": "print(1)"},
+                {"file_id": "c", "text": "print(2)"},
+            ]
+        ),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 1}]),
+    )
+    pd.DataFrame(
+        [
+            {"left_id": "a", "right_id": "b", "label": "plagiarised"},
+            {"left_id": "a", "right_id": "c", "label": "non_plagiarized"},
+            {"left_id": "b", "right_id": "c", "label": "np"},
+        ]
+    ).to_csv(dataset_root / "pairs.csv", index=False)
+
+    loaded = load_pair_dataset(dataset_root)
+    report = validate_dataset_report(dataset_root, kind="pair")
+
+    assert loaded.pairs["label"].tolist() == [1, 0, 0]
+    assert "invalid_pair_labels" not in {issue["code"] for issue in report["issues"]}
+
+
 def test_pair_dataset_rejects_unknown_file_reference(tmp_path):
     dataset_root = tmp_path / "pairs"
     write_pair_dataset(
@@ -1003,6 +1054,52 @@ def test_pair_dataset_rejects_path_separator_file_ids(tmp_path):
             files=pd.DataFrame([{"file_id": "../a", "text": "print(1)"}]),
             pairs=pd.DataFrame([{"left_id": "../a", "right_id": "../a", "label": 1}]),
         )
+
+
+def test_pair_dataset_rejects_windows_style_unsafe_file_paths(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    dataset_root.mkdir()
+    (dataset_root / "metadata.json").write_text(
+        json.dumps({"dataset_kind": "pair_classification", "name": "unsafe"}),
+        encoding="utf-8",
+    )
+    (dataset_root / "files.csv").write_text(
+        "file_id,file_path\n"
+        "a,..\\escape.py\n"
+        "b,C:\\temp\\secret.py\n",
+        encoding="utf-8",
+    )
+    (dataset_root / "pairs.csv").write_text("left_id,right_id,label\na,b,1\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="relative to the dataset root"):
+        load_pair_dataset(dataset_root)
+
+    report = validate_dataset_report(dataset_root, kind="pair")
+
+    assert report["status"] == "error"
+    assert "unsafe_file_paths" in {issue["code"] for issue in report["issues"]}
+
+
+def test_pair_dataset_rejects_directory_file_references(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame([{"file_id": "a", "text": "print(1)"}]),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "a", "label": 1}]),
+    )
+    directory_path = dataset_root / "files" / "directory"
+    directory_path.mkdir()
+    files = pd.read_csv(dataset_root / "files.csv")
+    files.loc[0, "file_path"] = "files/directory"
+    files.to_csv(dataset_root / "files.csv", index=False)
+
+    with pytest.raises(ValueError, match="not a file"):
+        load_pair_dataset(dataset_root)
+
+    report = validate_dataset_report(dataset_root, kind="pair")
+
+    assert report["status"] == "error"
+    assert "non_file_paths" in {issue["code"] for issue in report["issues"]}
 
 
 def test_retrieval_dataset_roundtrip_writes_manifests(tmp_path):
@@ -1059,4 +1156,23 @@ def test_retrieval_dataset_rejects_unknown_qrels_reference(tmp_path):
     qrels_path.write_text("query_id,document_id,relevance\nq1,missing,1\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="unknown document ids: missing"):
+        load_retrieval_dataset(dataset_root)
+
+
+def test_retrieval_dataset_rejects_directory_file_references(tmp_path):
+    dataset_root = tmp_path / "retrieval"
+    write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame([{"file_id": "q", "text": "print(1)"}]),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "q"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "q"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    )
+    directory_path = dataset_root / "files" / "directory"
+    directory_path.mkdir()
+    files = pd.read_csv(dataset_root / "files.csv")
+    files.loc[0, "file_path"] = "files/directory"
+    files.to_csv(dataset_root / "files.csv", index=False)
+
+    with pytest.raises(ValueError, match="not a file"):
         load_retrieval_dataset(dataset_root)

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -222,6 +222,35 @@ def test_leaderboard_manifest_resolves_relative_paths(tmp_path):
     assert manifest["algorithms"][0]["algorithm_path"] == str(exact_path.resolve())
 
 
+def test_leaderboard_manifest_preserves_remote_dataset_identifiers(tmp_path):
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    manifest_path = config_dir / "leaderboard.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "datasets": [
+                    {
+                        "name": "remote",
+                        "task": "pair",
+                        "source": "github",
+                        "identifier": "owner/repository",
+                        "destination": "cache/remote",
+                    },
+                ],
+                "algorithms": [{"name": "lexical", "feature_weights": {"levenshtein": 1.0}}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = load_leaderboard_manifest(manifest_path)
+
+    spec = manifest["datasets"][0]["spec"]
+    assert spec["identifier"] == "owner/repository"
+    assert spec["destination"] == str((config_dir / "cache" / "remote").resolve())
+
+
 def test_leaderboard_payload_and_html_escape_values(tmp_path):
     pair_root = _write_pair_fixture(tmp_path)
     exact_path, _ = _write_algorithm_fixtures(tmp_path)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -29,6 +29,17 @@ def test_benchmark_report_html_escapes_content_and_sanitizes_links(tmp_path):
     assert "Algorithm Cards" in output
 
 
+def test_benchmark_report_html_sanitizes_windows_artifact_links():
+    output = benchmark_report_html(
+        _synthetic_report(),
+        artifact_links={"source": r"C:\Users\alice\secret\artifact.html"},
+    )
+
+    assert "artifact.html" in output
+    assert "alice" not in output
+    assert "C:" not in output
+
+
 def test_write_benchmark_report_writes_static_html(tmp_path):
     output_path = tmp_path / "reports" / "leaderboard.html"
 


### PR DESCRIPTION
## Summary
- preserve remote leaderboard dataset identifiers while still resolving local paths
- harden normalized dataset and tabular adapter path handling across POSIX and Windows-style path strings
- align binary label handling and sanitize Windows-style paths in cache, reproducibility, registry, and report metadata

## Validation
- uv run pytest
- uv run python -m ruff check .
- uv run mkdocs build --strict
- uv run python -m build
- uv run python -m twine check dist/*
- uv run python scripts/sync_gradio_app_version.py --check
- uv run python -m compileall matheel gradio_app examples
- git diff --check

Closes #214
Closes #215
Closes #216
Closes #217
Closes #218
Closes #219
