### PR TITLE
Fix additional review bug regressions

### DIFF
--- a/matheel/calibration.py
+++ b/matheel/calibration.py
@@ -32,6 +32,12 @@ def _coerce_label(value, positive_label=True):
 
 
 def _coerce_default_binary_label(value):
+    try:
+        is_missing = bool(pd.isna(value))
+    except (TypeError, ValueError):
+        is_missing = False
+    if is_missing:
+        raise ValueError(f"Binary labels must be 0 or 1. Got: {value}")
     if isinstance(value, bool):
         return bool(value)
     if isinstance(value, str):
@@ -42,7 +48,10 @@ def _coerce_default_binary_label(value):
             "true",
             "yes",
             "y",
+            "p",
             "positive",
+            "cheating",
+            "clone",
             "plagiarized",
             "plagiarised",
             "plagiarism",
@@ -56,10 +65,22 @@ def _coerce_default_binary_label(value):
             "false",
             "no",
             "n",
+            "np",
             "negative",
             "original",
+            "not cheating",
+            "not_cheating",
+            "non-cheating",
+            "non cheating",
+            "non-clone",
+            "nonplagiarized",
+            "nonplagiarised",
             "non_plagiarized",
             "non_plagiarised",
+            "not plagiarized",
+            "not plagiarised",
+            "not_plagiarized",
+            "not_plagiarised",
             "non_plagiarism",
             "non-plagiarism",
             "nonmatch",
@@ -69,11 +90,11 @@ def _coerce_default_binary_label(value):
             return False
     try:
         numeric = float(value)
-    except (TypeError, ValueError):
-        return bool(value)
-    if math.isfinite(numeric):
-        return numeric != 0.0
-    return bool(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Binary labels must be 0 or 1. Got: {value}") from exc
+    if not math.isfinite(numeric) or numeric not in (0.0, 1.0):
+        raise ValueError(f"Binary labels must be 0 or 1. Got: {value}")
+    return bool(numeric)
 
 
 def _coerce_score_label_pairs(

--- a/matheel/cli.py
+++ b/matheel/cli.py
@@ -257,9 +257,13 @@ def _dataset_kind_from_path(dataset_path, requested_kind):
         return requested_kind
 
     root = Path(dataset_path)
-    if all((root / name).exists() for name in ("files.csv", "queries.csv", "corpus.csv", "qrels.csv")):
+    has_pair_files = (root / "files.csv").exists() and (root / "pairs.csv").exists()
+    has_retrieval_files = all((root / name).exists() for name in ("files.csv", "queries.csv", "corpus.csv", "qrels.csv"))
+    if has_pair_files and has_retrieval_files:
+        raise click.UsageError("Dataset contains both pair and retrieval manifests. Use --kind pair or --kind retrieval.")
+    if has_retrieval_files:
         return "retrieval"
-    if (root / "files.csv").exists() and (root / "pairs.csv").exists():
+    if has_pair_files:
         return "pair"
     raise click.UsageError("Could not detect dataset kind. Use --kind pair or --kind retrieval.")
 

--- a/matheel/code_metrics.py
+++ b/matheel/code_metrics.py
@@ -16,20 +16,12 @@ except ImportError:  # pragma: no cover - optional dependency
     codebleu_package_dir = None
     codebleu_get_tree_sitter_language = None
 
-try:
-    from bert_score import BERTScorer
-except ImportError:  # pragma: no cover - optional dependency
-    BERTScorer = None
-
-try:
-    from transformers import AutoConfig
-except ImportError:  # pragma: no cover - optional dependency
-    AutoConfig = None
-
-try:
-    import torch
-except ImportError:  # pragma: no cover - optional dependency
-    torch = None
+BERTScorer = None
+AutoConfig = None
+torch = None
+_BERTSCORER_IMPORT_ATTEMPTED = False
+_AUTOCONFIG_IMPORT_ATTEMPTED = False
+_TORCH_IMPORT_ATTEMPTED = False
 
 try:
     from apted import APTED
@@ -148,6 +140,7 @@ _TREE_SITTER_PARSE_LOCK = RLock()
 _CODEBERTSCORE_SCORER_CACHE_LOCK = RLock()
 _CODEBERTSCORE_SCORER_USAGE_LOCK = RLock()
 _CODEBERTSCORE_LAYER_CACHE_LOCK = RLock()
+_CODEBERTSCORE_DEPENDENCY_LOCK = RLock()
 _KEYWORDS = {
     "c": {
         "auto", "break", "case", "char", "const", "continue", "default", "do", "double", "else",
@@ -1036,29 +1029,81 @@ def _tsed_pair_score(reference_tree, prediction_tree, delete_cost=1.0, insert_co
     return float(max(0.0, min(1.0, (max_len - edit_distance) / float(max_len))))
 
 
+def _load_bert_scorer():
+    global BERTScorer, _BERTSCORER_IMPORT_ATTEMPTED
+    if BERTScorer is not None:
+        return BERTScorer
+    with _CODEBERTSCORE_DEPENDENCY_LOCK:
+        if BERTScorer is not None:
+            return BERTScorer
+        if not _BERTSCORER_IMPORT_ATTEMPTED:
+            try:
+                from bert_score import BERTScorer as loaded_bert_scorer
+            except ImportError:  # pragma: no cover - optional dependency
+                loaded_bert_scorer = None
+            BERTScorer = loaded_bert_scorer
+            _BERTSCORER_IMPORT_ATTEMPTED = True
+    return BERTScorer
+
+
+def _load_auto_config():
+    global AutoConfig, _AUTOCONFIG_IMPORT_ATTEMPTED
+    if AutoConfig is not None:
+        return AutoConfig
+    with _CODEBERTSCORE_DEPENDENCY_LOCK:
+        if AutoConfig is not None:
+            return AutoConfig
+        if not _AUTOCONFIG_IMPORT_ATTEMPTED:
+            try:
+                from transformers import AutoConfig as loaded_auto_config
+            except ImportError:  # pragma: no cover - optional dependency
+                loaded_auto_config = None
+            AutoConfig = loaded_auto_config
+            _AUTOCONFIG_IMPORT_ATTEMPTED = True
+    return AutoConfig
+
+
+def _load_torch():
+    global torch, _TORCH_IMPORT_ATTEMPTED
+    if torch is not None:
+        return torch
+    with _CODEBERTSCORE_DEPENDENCY_LOCK:
+        if torch is not None:
+            return torch
+        if not _TORCH_IMPORT_ATTEMPTED:
+            try:
+                import torch as loaded_torch
+            except ImportError:  # pragma: no cover - optional dependency
+                loaded_torch = None
+            torch = loaded_torch
+            _TORCH_IMPORT_ATTEMPTED = True
+    return torch
+
+
 def _resolve_codebertscore_device(requested):
     token = (requested or "auto").strip().lower()
+    torch_module = _load_torch()
     if token in {"cpu", "cuda", "mps"}:
         if token == "cuda":
-            if torch is not None and torch.cuda.is_available():
+            if torch_module is not None and torch_module.cuda.is_available():
                 return "cuda"
             return "cpu"
         if token == "mps":
             if (
-                torch is not None
-                and hasattr(torch.backends, "mps")
-                and torch.backends.mps.is_available()
+                torch_module is not None
+                and hasattr(torch_module.backends, "mps")
+                and torch_module.backends.mps.is_available()
             ):
                 return "mps"
             return "cpu"
         return token
 
-    if torch is not None and torch.cuda.is_available():
+    if torch_module is not None and torch_module.cuda.is_available():
         return "cuda"
     if (
-        torch is not None
-        and hasattr(torch.backends, "mps")
-        and torch.backends.mps.is_available()
+        torch_module is not None
+        and hasattr(torch_module.backends, "mps")
+        and torch_module.backends.mps.is_available()
     ):
         return "mps"
     return "cpu"
@@ -1068,11 +1113,12 @@ def _infer_codebertscore_num_layers(model_type):
     with _CODEBERTSCORE_LAYER_CACHE_LOCK:
         if model_type in _CODEBERTSCORE_LAYER_CACHE:
             return _CODEBERTSCORE_LAYER_CACHE[model_type]
-        if AutoConfig is None:
+        auto_config = _load_auto_config()
+        if auto_config is None:
             _CODEBERTSCORE_LAYER_CACHE[model_type] = None
             return None
         try:
-            config = AutoConfig.from_pretrained(model_type)
+            config = auto_config.from_pretrained(model_type)
         except Exception:
             _CODEBERTSCORE_LAYER_CACHE[model_type] = None
             return None
@@ -1149,7 +1195,8 @@ def _resolve_codebertscore_scorer(
     use_fast_tokenizer=False,
     nthreads=4,
 ):
-    if BERTScorer is None:
+    bert_scorer = _load_bert_scorer()
+    if bert_scorer is None:
         raise ImportError("CodeBERTScore requires bert-score. Install with: pip install bert-score")
 
     resolved_device = _resolve_codebertscore_device(device)
@@ -1179,7 +1226,7 @@ def _resolve_codebertscore_scorer(
         if cache_key in _CODEBERTSCORE_SCORER_CACHE:
             return _CODEBERTSCORE_SCORER_CACHE[cache_key]
 
-        scorer = BERTScorer(
+        scorer = bert_scorer(
             model_type=str(model_type),
             num_layers=parsed_layers,
             lang=normalized_lang,

--- a/matheel/evaluation.py
+++ b/matheel/evaluation.py
@@ -11,7 +11,7 @@ from .algorithms import (
 from .calibration import evaluate_threshold
 from .datasets import PairDataset, RetrievalDataset, load_code_texts, load_pair_dataset, load_retrieval_dataset
 from .preprocessing import preprocess_code
-from .resampling import summarize_metric_samples
+from .resampling import DataSplit, summarize_metric_samples
 from .similarity import calculate_similarity
 
 
@@ -222,6 +222,11 @@ def retrieval_ranking_metrics(
 
     frame = frame.copy()
     frame[score_column] = frame[score_column].map(_normalize_finite_score)
+    _reject_duplicate_results(
+        frame,
+        query_column=query_column,
+        document_column=document_column,
+    )
     qrels_lookup = _qrels_lookup(
         qrels_frame,
         query_column=query_column,
@@ -430,6 +435,23 @@ def _rank_query_results(frame, document_column, score_column):
     )
 
 
+def _reject_duplicate_results(frame, query_column, document_column):
+    pairs = frame[[query_column, document_column]].astype(str)
+    duplicate_mask = pairs.duplicated(subset=[query_column, document_column], keep=False)
+    if not bool(duplicate_mask.any()):
+        return
+    duplicate_pairs = sorted(
+        {
+            f"{row[query_column]}->{row[document_column]}"
+            for row in pairs.loc[duplicate_mask, [query_column, document_column]].to_dict(orient="records")
+        }
+    )
+    preview = ", ".join(duplicate_pairs[:5])
+    if len(duplicate_pairs) > 5:
+        preview = f"{preview}, ..."
+    raise ValueError(f"scored_results contains duplicate query/document result rows: {preview}")
+
+
 def _average_precision(ranked_documents, relevant_by_document):
     if not relevant_by_document:
         return 0.0
@@ -497,7 +519,10 @@ def _normalize_nonnegative_relevance(value):
 
 
 def _normalize_splits(splits):
-    selected = tuple(splits)
+    if isinstance(splits, DataSplit):
+        selected = (splits,)
+    else:
+        selected = tuple(splits)
     if not selected:
         raise ValueError("At least one split is required.")
     return selected

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -124,15 +124,20 @@ def test_threshold_sweep_returns_dataframe_with_confusion_counts():
 
 def test_evaluate_threshold_coerces_string_binary_labels():
     report = evaluate_threshold(
-        [(0.1, "0"), (0.2, "false"), (0.8, "true"), (0.9, "1")],
+        [(0.1, "0"), (0.2, "false"), (0.3, "np"), (0.8, "true"), (0.9, "1"), (0.7, "p")],
         threshold=0.5,
     )
 
-    assert report["positive_count"] == 2
-    assert report["negative_count"] == 2
-    assert report["true_positive"] == 2
-    assert report["true_negative"] == 2
+    assert report["positive_count"] == 3
+    assert report["negative_count"] == 3
+    assert report["true_positive"] == 3
+    assert report["true_negative"] == 3
     assert report["accuracy"] == pytest.approx(1.0)
+
+
+def test_evaluate_threshold_rejects_unknown_default_binary_labels():
+    with pytest.raises(ValueError, match="Binary labels must be 0 or 1"):
+        evaluate_threshold([(0.9, "maybe"), (0.1, "0")], threshold=0.5)
 
 
 def test_roc_and_precision_recall_curves_report_perfect_ranking_metrics():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -818,6 +818,50 @@ def test_datasets_validate_command_reports_pair_summary(tmp_path):
     }
 
 
+def test_datasets_validate_auto_rejects_ambiguous_dataset_kind(tmp_path):
+    dataset_root = tmp_path / "ambiguous"
+    dataset_root.mkdir()
+    (dataset_root / "a.py").write_text("print(1)", encoding="utf-8")
+    (dataset_root / "b.py").write_text("print(2)", encoding="utf-8")
+    pd.DataFrame(
+        [
+            {"file_id": "a", "file_path": "a.py"},
+            {"file_id": "b", "file_path": "b.py"},
+        ]
+    ).to_csv(dataset_root / "files.csv", index=False)
+    pd.DataFrame([{"left_id": "a", "right_id": "b", "label": 0}]).to_csv(
+        dataset_root / "pairs.csv",
+        index=False,
+    )
+    pd.DataFrame([{"query_id": "q1", "file_id": "a"}]).to_csv(dataset_root / "queries.csv", index=False)
+    pd.DataFrame([{"document_id": "d1", "file_id": "b"}]).to_csv(dataset_root / "corpus.csv", index=False)
+    pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]).to_csv(
+        dataset_root / "qrels.csv",
+        index=False,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["datasets", "validate", str(dataset_root)])
+
+    assert result.exit_code != 0
+    assert "Dataset contains both pair and retrieval manifests" in result.output
+    assert "Use --kind pair or --kind retrieval" in result.output
+
+    pair_result = runner.invoke(
+        main,
+        ["datasets", "validate", str(dataset_root), "--kind", "pair", "--format", "json"],
+    )
+    retrieval_result = runner.invoke(
+        main,
+        ["datasets", "validate", str(dataset_root), "--kind", "retrieval", "--format", "json"],
+    )
+
+    assert pair_result.exit_code == 0
+    assert json.loads(pair_result.output)["dataset_kind"] == "pair_classification"
+    assert retrieval_result.exit_code == 0
+    assert json.loads(retrieval_result.output)["dataset_kind"] == "retrieval"
+
+
 def test_datasets_validate_command_writes_report_artifacts(tmp_path):
     dataset_root = tmp_path / "pairs"
     write_pair_dataset(

--- a/tests/test_code_metrics.py
+++ b/tests/test_code_metrics.py
@@ -1,3 +1,4 @@
+import builtins
 import time
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
@@ -171,6 +172,22 @@ def test_available_code_metrics_includes_new_metrics():
     assert "ruby" in metrics
     assert "tsed" in metrics
     assert "codebertscore" in metrics
+
+
+def test_available_code_metrics_does_not_load_codebertscore_dependencies(monkeypatch):
+    imported = []
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name.split(".", 1)[0] in {"bert_score", "transformers", "torch"}:
+            imported.append(name)
+            raise AssertionError(f"unexpected optional dependency import: {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    assert "codebertscore" in available_code_metrics()
+    assert imported == []
 
 
 def test_available_code_metric_languages_expose_expanded_scope():

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -12,7 +12,7 @@ from matheel.evaluation import (
     score_pair_dataset,
     score_retrieval_dataset,
 )
-from matheel.resampling import kfold_splits
+from matheel.resampling import kfold_splits, single_split
 
 
 def _write_tiny_pair_dataset(path):
@@ -346,6 +346,18 @@ def test_retrieval_ranking_metrics_handles_queries_without_relevant_documents():
     assert metrics["ndcg_at_k"] == 0.0
 
 
+def test_retrieval_ranking_metrics_rejects_duplicate_result_rows():
+    scored_results = pd.DataFrame(
+        [
+            {"query_id": "q1", "document_id": "d1", "similarity_score": 0.9, "relevance": 1},
+            {"query_id": "q1", "document_id": "d1", "similarity_score": 0.8, "relevance": 1},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="duplicate query/document result rows"):
+        retrieval_ranking_metrics(scored_results, k=2)
+
+
 def test_retrieval_ranking_metrics_requires_score_column():
     with pytest.raises(ValueError, match="similarity_score"):
         retrieval_ranking_metrics([{"query_id": "q1", "document_id": "d1", "relevance": 1}])
@@ -369,6 +381,22 @@ def test_evaluate_pair_resamples_returns_fold_metrics_and_summary():
     assert summary.loc[summary["metric"] == "accuracy", "mean"].item() == pytest.approx(1.0)
 
 
+def test_evaluate_pair_resamples_accepts_single_split_object():
+    scored_pairs = pd.DataFrame(
+        [
+            {"similarity_score": 0.9, "label": 1},
+            {"similarity_score": 0.1, "label": 0},
+        ]
+    )
+    split = single_split(len(scored_pairs), train_size=0.5, test_size=0.5, shuffle=False)
+
+    metrics, summary = evaluate_pair_resamples(scored_pairs, split, threshold=0.5)
+
+    assert metrics["split"].tolist() == ["split_1"]
+    assert metrics["test_count"].tolist() == [1]
+    assert summary.loc[summary["metric"] == "accuracy", "count"].item() == 1
+
+
 def test_evaluate_retrieval_resamples_uses_query_level_splits():
     scored_results = pd.DataFrame(
         [
@@ -385,3 +413,21 @@ def test_evaluate_retrieval_resamples_uses_query_level_splits():
     assert metrics["query_count"].tolist() == [1, 1]
     assert metrics["mean_average_precision"].tolist() == [1.0, 1.0]
     assert summary.loc[summary["metric"] == "ndcg_at_k", "mean"].item() == pytest.approx(1.0)
+
+
+def test_evaluate_retrieval_resamples_accepts_single_split_object():
+    scored_results = pd.DataFrame(
+        [
+            {"query_id": "q1", "document_id": "d1", "similarity_score": 1.0, "relevance": 1},
+            {"query_id": "q1", "document_id": "d2", "similarity_score": 0.1, "relevance": 0},
+            {"query_id": "q2", "document_id": "d1", "similarity_score": 0.2, "relevance": 0},
+            {"query_id": "q2", "document_id": "d2", "similarity_score": 0.9, "relevance": 1},
+        ]
+    )
+    split = single_split(2, train_size=0.5, test_size=0.5, shuffle=False)
+
+    metrics, summary = evaluate_retrieval_resamples(scored_results, split, k=1)
+
+    assert metrics["split"].tolist() == ["split_1"]
+    assert metrics["query_count"].tolist() == [1]
+    assert summary.loc[summary["metric"] == "ndcg_at_k", "count"].item() == 1


### PR DESCRIPTION
## Summary
- reject duplicate retrieval result rows before computing ranking metrics
- tighten default calibration label parsing and accept dataset-style binary aliases
- accept direct `DataSplit` inputs in resample evaluators
- report ambiguous dataset kind detection in the CLI instead of silently choosing retrieval
- lazy-load CodeBERTScore optional dependencies to avoid heavy import side effects

## Validation
- uv run python -m pytest tests/test_evaluation.py tests/test_calibration.py tests/test_cli.py tests/test_code_metrics.py
- uv run pytest
- uv run python -m ruff check .
- uv run mkdocs build --strict
- uv run python -m build
- uv run python -m twine check dist/*
- uv run python scripts/sync_gradio_app_version.py --check
- uv run python -m compileall matheel gradio_app examples
- git diff --check

Closes #221
Closes #222
Closes #223
Closes #224
Closes #225
