### PR TITLE
Fix review regressions before v0.5.6

### DIFF
--- a/matheel/_path_utils.py
+++ b/matheel/_path_utils.py
@@ -32,3 +32,17 @@ def relative_path_to_posix(value):
     else:
         parts = Path(text).parts
     return "/".join(part for part in parts if part not in ("", "."))
+
+
+def resolve_relative_path_within_root(root, value):
+    text = str(value or "").strip()
+    if not text or is_unsafe_relative_path(text):
+        raise ValueError(f"Path must be a safe relative path. Got: {value}")
+
+    root_path = Path(root).expanduser().resolve()
+    target = (root_path / relative_path_to_posix(text)).resolve()
+    try:
+        target.relative_to(root_path)
+    except ValueError as exc:
+        raise ValueError(f"Path resolves outside its root: {value}") from exc
+    return target

--- a/matheel/dataset_validation.py
+++ b/matheel/dataset_validation.py
@@ -5,7 +5,10 @@ from pathlib import Path
 
 import pandas as pd
 
-from ._path_utils import is_unsafe_relative_path, relative_path_to_posix
+from ._path_utils import (
+    is_unsafe_relative_path,
+    resolve_relative_path_within_root,
+)
 
 
 PAIR_KIND = "pair_classification"
@@ -385,8 +388,11 @@ def _inspect_files_manifest(root, files, counts, issues):
         if is_unsafe_relative_path(raw_path):
             unsafe_paths.append(str(raw_path))
             continue
-        relative_path = Path(relative_path_to_posix(raw_path))
-        target = root / relative_path
+        try:
+            target = resolve_relative_path_within_root(root, raw_path)
+        except ValueError:
+            unsafe_paths.append(str(raw_path))
+            continue
         if not target.exists():
             missing_files.append(str(raw_path))
             continue

--- a/matheel/datasets.py
+++ b/matheel/datasets.py
@@ -17,7 +17,11 @@ from pathlib import Path
 
 import pandas as pd
 
-from ._path_utils import is_unsafe_relative_path, relative_path_to_posix
+from ._path_utils import (
+    is_unsafe_relative_path,
+    relative_path_to_posix,
+    resolve_relative_path_within_root,
+)
 
 
 DATASET_TASK_TYPES = ("plagiarism",)
@@ -370,7 +374,7 @@ def load_pair_dataset(dataset_root):
     pairs_path = root / "pairs.csv"
     if not pairs_path.exists():
         raise ValueError(f"Missing pairs manifest: {pairs_path}")
-    pairs = pd.read_csv(pairs_path)
+    pairs = pd.read_csv(pairs_path, dtype={"left_id": "string", "right_id": "string"})
     dataset = PairDataset(root=root, files=files, pairs=pairs, metadata=metadata)
     return validate_pair_dataset(dataset)
 
@@ -421,7 +425,7 @@ def validate_pair_dataset(dataset):
         raise ValueError(f"pairs.csv references unknown file ids: {', '.join(missing)}")
 
     for file_path in files["file_path"].tolist():
-        target = dataset.root / file_path
+        target = _resolve_dataset_file(dataset.root, file_path)
         if not target.exists():
             raise ValueError(f"files.csv references missing file: {file_path}")
         if not target.is_file():
@@ -449,9 +453,9 @@ def load_retrieval_dataset(dataset_root):
     dataset = RetrievalDataset(
         root=root,
         files=files,
-        queries=pd.read_csv(queries_path),
-        corpus=pd.read_csv(corpus_path),
-        qrels=pd.read_csv(qrels_path),
+        queries=pd.read_csv(queries_path, dtype={"query_id": "string", "file_id": "string"}),
+        corpus=pd.read_csv(corpus_path, dtype={"document_id": "string", "file_id": "string"}),
+        qrels=pd.read_csv(qrels_path, dtype={"query_id": "string", "document_id": "string"}),
         metadata=metadata,
     )
     return validate_retrieval_dataset(dataset)
@@ -578,7 +582,7 @@ def validate_retrieval_dataset(dataset):
         raise ValueError(f"qrels.csv references unknown document ids: {', '.join(missing_documents)}")
 
     for file_path in files["file_path"].tolist():
-        target = dataset.root / file_path
+        target = _resolve_dataset_file(dataset.root, file_path)
         if not target.exists():
             raise ValueError(f"files.csv references missing file: {file_path}")
         if not target.is_file():
@@ -610,7 +614,7 @@ def load_code_texts(dataset):
     for row in dataset.files.to_dict(orient="records"):
         file_id = _normalize_id(row["file_id"], "file_id")
         file_path = _normalize_relative_file_path(row["file_path"])
-        target = dataset.root / file_path
+        target = _resolve_dataset_file(dataset.root, file_path)
         if not target.is_file():
             raise ValueError(f"files.csv references path that is not a file: {file_path}")
         texts[file_id] = target.read_text(encoding="utf-8", errors="ignore")
@@ -669,7 +673,13 @@ def _coerce_frame(records, required_columns, frame_name):
 
 
 def _normalize_id(value, label):
-    text = str(value or "").strip()
+    try:
+        is_missing = bool(pd.isna(value))
+    except (TypeError, ValueError):
+        is_missing = False
+    if value is None or is_missing:
+        raise ValueError(f"{label} must be non-empty.")
+    text = str(value).strip()
     if not text:
         raise ValueError(f"{label} must be non-empty.")
     if "/" in text or "\\" in text:
@@ -687,6 +697,15 @@ def _normalize_relative_file_path(value):
     if not normalized:
         raise ValueError("file_path must be non-empty.")
     return normalized
+
+
+def _resolve_dataset_file(root, file_path):
+    try:
+        return resolve_relative_path_within_root(root, file_path)
+    except ValueError as exc:
+        raise ValueError(
+            f"file_path must resolve within the dataset root. Got: {file_path}"
+        ) from exc
 
 
 def _normalize_binary_label(value):
@@ -815,7 +834,7 @@ def _load_files_manifest(dataset_root):
     files_path = Path(dataset_root) / "files.csv"
     if not files_path.exists():
         raise ValueError(f"Missing files manifest: {files_path}")
-    return pd.read_csv(files_path)
+    return pd.read_csv(files_path, dtype={"file_id": "string"})
 
 
 def _normalize_task_family(value):

--- a/matheel/reproducibility.py
+++ b/matheel/reproducibility.py
@@ -72,24 +72,24 @@ def _fingerprint_file(path):
 def _fingerprint_directory(root):
     root_path = Path(root)
     digest = sha256()
-    file_count = 0
-    total_size = 0
+    entries = []
     for current_root, _, file_names in os.walk(root_path):
         current_root_path = Path(current_root)
-        for file_name in sorted(file_names):
+        for file_name in file_names:
             full_path = current_root_path / file_name
             relative = full_path.relative_to(root_path).as_posix()
             if _is_hidden_name(relative):
                 continue
             stat = full_path.stat()
             file_hash = _hash_file(full_path)
-            file_count += 1
-            total_size += int(stat.st_size)
-            digest.update(f"{relative}|{int(stat.st_size)}|{file_hash}".encode("utf-8"))
+            entries.append((relative, int(stat.st_size), file_hash))
+
+    for relative, file_size, file_hash in sorted(entries):
+        digest.update(f"{relative}|{file_size}|{file_hash}".encode("utf-8"))
     return {
         "source_type": "directory",
-        "file_count": int(file_count),
-        "total_bytes": int(total_size),
+        "file_count": len(entries),
+        "total_bytes": sum(file_size for _, file_size, _ in entries),
         "sha256": digest.hexdigest(),
     }
 

--- a/matheel/resampling.py
+++ b/matheel/resampling.py
@@ -379,7 +379,11 @@ def _validate_stratified_partition_counts(label_count, counts, ratios):
     train_size, validation_size, test_size = ratios
     train_ratio = float(train_size)
     validation_ratio = float(validation_size)
-    test_ratio = 1.0 - train_ratio - validation_ratio if test_size is None else float(test_size)
+    test_ratio = (
+        1.0 - train_ratio - validation_ratio
+        if test_size is None
+        else float(test_size)
+    )
     requested = (
         ("train", train_ratio, counts[0]),
         ("validation", validation_ratio, counts[1]),
@@ -400,35 +404,66 @@ def _group_single_split(count, groups, train_size, validation_size, test_size, s
     if shuffle:
         generator.shuffle(unique_groups)
 
-    train_target, validation_target, _ = _partition_counts(
+    train_target, validation_target, test_target = _partition_counts(
         count,
         train_size=train_size,
         validation_size=validation_size,
         test_size=test_size,
     )
 
-    train_indices = []
-    validation_indices = []
-    test_indices = []
-    train_count = 0
-    validation_count = 0
+    train_ratio = float(train_size)
+    validation_ratio = float(validation_size)
+    test_ratio = 1.0 - train_ratio - validation_ratio if test_size is None else float(test_size)
+    requested_partitions = [
+        (name, target)
+        for name, ratio, target in (
+            ("train", train_ratio, train_target),
+            ("validation", validation_ratio, validation_target),
+            ("test", test_ratio, test_target),
+        )
+        if ratio > 0
+    ]
+    if len(unique_groups) < len(requested_partitions):
+        raise ValueError(
+            "Grouped single split requires at least one unique group for every "
+            "requested non-empty partition."
+        )
 
-    for group in unique_groups:
-        group_indices = np.where(groups == group)[0]
-        if train_count < train_target:
-            train_indices.extend(group_indices.tolist())
-            train_count += len(group_indices)
-            continue
-        if validation_count < validation_target:
-            validation_indices.extend(group_indices.tolist())
-            validation_count += len(group_indices)
-            continue
-        test_indices.extend(group_indices.tolist())
+    partition_indices = {"train": [], "validation": [], "test": []}
+    group_position = 0
+    for partition_index, (partition_name, target_count) in enumerate(requested_partitions):
+        remaining_partitions = len(requested_partitions) - partition_index - 1
+        if remaining_partitions == 0:
+            selected_groups = unique_groups[group_position:]
+            group_position = len(unique_groups)
+        else:
+            max_position = len(unique_groups) - remaining_partitions
+            selected_groups = []
+            selected_count = 0
+            while group_position < max_position:
+                group = unique_groups[group_position]
+                selected_groups.append(group)
+                selected_count += int(np.sum(groups == group))
+                group_position += 1
+                if selected_count >= target_count:
+                    break
+
+        for group in selected_groups:
+            partition_indices[partition_name].extend(np.where(groups == group)[0].tolist())
+
+    empty_partitions = [
+        name for name, _ in requested_partitions if not partition_indices[name]
+    ]
+    if empty_partitions:
+        raise ValueError(
+            "Grouped single split could not populate requested partition(s): "
+            f"{', '.join(empty_partitions)}."
+        )
 
     return (
-        np.asarray(sorted(train_indices), dtype=int),
-        np.asarray(sorted(validation_indices), dtype=int),
-        np.asarray(sorted(test_indices), dtype=int),
+        np.asarray(sorted(partition_indices["train"]), dtype=int),
+        np.asarray(sorted(partition_indices["validation"]), dtype=int),
+        np.asarray(sorted(partition_indices["test"]), dtype=int),
     )
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1033,6 +1033,32 @@ def test_pair_dataset_loader_matches_validation_binary_label_vocabulary(tmp_path
     assert "invalid_pair_labels" not in {issue["code"] for issue in report["issues"]}
 
 
+def test_pair_dataset_roundtrip_preserves_zero_string_ids(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame([{"file_id": "0", "text": "print(0)"}]),
+        pairs=pd.DataFrame([{"left_id": "0", "right_id": "0", "label": 1}]),
+    )
+
+    loaded = load_pair_dataset(dataset_root)
+
+    assert loaded.files["file_id"].tolist() == ["0"]
+    assert loaded.pairs[["left_id", "right_id"]].to_dict(orient="records") == [
+        {"left_id": "0", "right_id": "0"}
+    ]
+
+
+@pytest.mark.parametrize("missing_id", [None, float("nan"), pd.NA, ""])
+def test_pair_dataset_rejects_missing_file_ids(tmp_path, missing_id):
+    with pytest.raises(ValueError, match="file_id must be non-empty"):
+        write_pair_dataset(
+            tmp_path / "pairs",
+            files=pd.DataFrame([{"file_id": missing_id, "text": "print(1)"}]),
+            pairs=pd.DataFrame([{"left_id": "a", "right_id": "a", "label": 1}]),
+        )
+
+
 def test_pair_dataset_rejects_unknown_file_reference(tmp_path):
     dataset_root = tmp_path / "pairs"
     write_pair_dataset(
@@ -1102,6 +1128,29 @@ def test_pair_dataset_rejects_directory_file_references(tmp_path):
     assert "non_file_paths" in {issue["code"] for issue in report["issues"]}
 
 
+def test_pair_dataset_rejects_symlinks_outside_dataset_root(tmp_path):
+    dataset_root = tmp_path / "pairs"
+    write_pair_dataset(
+        dataset_root,
+        files=pd.DataFrame([{"file_id": "a", "text": "inside", "suffix": ".py"}]),
+        pairs=pd.DataFrame([{"left_id": "a", "right_id": "a", "label": 1}]),
+    )
+    outside = tmp_path / "outside.py"
+    outside.write_text("secret", encoding="utf-8")
+    linked_file = dataset_root / "files" / "a.py"
+    linked_file.unlink()
+    try:
+        linked_file.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"Symlinks are unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="within the dataset root"):
+        load_pair_dataset(dataset_root)
+
+    report = validate_dataset_report(dataset_root, kind="pair")
+    assert "unsafe_file_paths" in {issue["code"] for issue in report["issues"]}
+
+
 def test_retrieval_dataset_roundtrip_writes_manifests(tmp_path):
     dataset_root = tmp_path / "retrieval"
 
@@ -1136,6 +1185,26 @@ def test_retrieval_dataset_roundtrip_writes_manifests(tmp_path):
     assert (dataset_root / "queries.csv").exists()
     assert (dataset_root / "corpus.csv").exists()
     assert (dataset_root / "qrels.csv").exists()
+
+
+def test_retrieval_dataset_roundtrip_preserves_zero_string_ids(tmp_path):
+    dataset_root = tmp_path / "retrieval"
+    write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame([{"file_id": "0", "text": "print(0)"}]),
+        queries=pd.DataFrame([{"query_id": "0", "file_id": "0"}]),
+        corpus=pd.DataFrame([{"document_id": "0", "file_id": "0"}]),
+        qrels=pd.DataFrame([{"query_id": "0", "document_id": "0", "relevance": 1}]),
+    )
+
+    loaded = load_retrieval_dataset(dataset_root)
+
+    assert loaded.files["file_id"].tolist() == ["0"]
+    assert loaded.queries.to_dict(orient="records") == [{"query_id": "0", "file_id": "0"}]
+    assert loaded.corpus.to_dict(orient="records") == [{"document_id": "0", "file_id": "0"}]
+    assert loaded.qrels[["query_id", "document_id"]].to_dict(orient="records") == [
+        {"query_id": "0", "document_id": "0"}
+    ]
 
 
 def test_retrieval_dataset_rejects_unknown_qrels_reference(tmp_path):
@@ -1176,3 +1245,28 @@ def test_retrieval_dataset_rejects_directory_file_references(tmp_path):
 
     with pytest.raises(ValueError, match="not a file"):
         load_retrieval_dataset(dataset_root)
+
+
+def test_retrieval_dataset_rejects_symlinks_outside_dataset_root(tmp_path):
+    dataset_root = tmp_path / "retrieval"
+    write_retrieval_dataset(
+        dataset_root,
+        files=pd.DataFrame([{"file_id": "q", "text": "inside", "suffix": ".py"}]),
+        queries=pd.DataFrame([{"query_id": "q1", "file_id": "q"}]),
+        corpus=pd.DataFrame([{"document_id": "d1", "file_id": "q"}]),
+        qrels=pd.DataFrame([{"query_id": "q1", "document_id": "d1", "relevance": 1}]),
+    )
+    outside = tmp_path / "outside.py"
+    outside.write_text("secret", encoding="utf-8")
+    linked_file = dataset_root / "files" / "q.py"
+    linked_file.unlink()
+    try:
+        linked_file.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"Symlinks are unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="within the dataset root"):
+        load_retrieval_dataset(dataset_root)
+
+    report = validate_dataset_report(dataset_root, kind="retrieval")
+    assert "unsafe_file_paths" in {issue["code"] for issue in report["issues"]}

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,21 @@
+import os
+
+import matheel.reproducibility as reproducibility
+
+
+def test_directory_fingerprint_is_independent_of_walk_order(tmp_path, monkeypatch):
+    root = tmp_path / "source"
+    (root / "a").mkdir(parents=True)
+    (root / "b").mkdir()
+    (root / "a" / "one.py").write_text("print(1)\n", encoding="utf-8")
+    (root / "b" / "two.py").write_text("print(2)\n", encoding="utf-8")
+    walk_rows = list(os.walk(root))
+
+    expected = reproducibility.fingerprint_source(root)
+    monkeypatch.setattr(
+        reproducibility.os,
+        "walk",
+        lambda _root: iter(reversed(walk_rows)),
+    )
+
+    assert reproducibility.fingerprint_source(root) == expected

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -100,6 +100,38 @@ def test_stratified_single_split_rejects_class_missing_from_requested_partition(
         single_split(4, train_size=0.5, test_size=0.5, labels=[0, 0, 0, 1], seed=1)
 
 
+def test_group_single_split_rejects_impossible_requested_partitions():
+    with pytest.raises(ValueError, match="requested non-empty partition"):
+        single_split(
+            4,
+            train_size=0.5,
+            test_size=0.5,
+            groups=["only"] * 4,
+            shuffle=False,
+        )
+
+
+def test_group_single_split_reserves_groups_for_every_requested_partition():
+    groups = ["a"] * 3 + ["b"] * 3 + ["c"] * 2 + ["d"] * 2
+
+    split = single_split(
+        len(groups),
+        train_size=0.5,
+        validation_size=0.3,
+        test_size=0.2,
+        groups=groups,
+        shuffle=False,
+    )
+
+    partitions = (split.train_indices, split.validation_indices, split.test_indices)
+    partition_groups = [{groups[index] for index in indices} for indices in partitions]
+    assert all(partitions)
+    assert sum(len(indices) for indices in partitions) == len(groups)
+    assert partition_groups[0].isdisjoint(partition_groups[1])
+    assert partition_groups[0].isdisjoint(partition_groups[2])
+    assert partition_groups[1].isdisjoint(partition_groups[2])
+
+
 def test_metric_summary_reports_uncertainty_fields():
     summary = metric_summary([0.2, 0.4, 0.8], confidence=0.5)
 


### PR DESCRIPTION
## Summary
- preserve zero-valued dataset identifiers and reject missing IDs
- reject normalized dataset paths whose symlink targets escape the dataset root
- keep every requested grouped split partition non-empty or fail clearly
- make directory fingerprints independent of traversal order
- add focused pair, retrieval, resampling, and reproducibility regressions

## Validation
- 548 passed, 4 skipped, 3 deselected
- Ruff passed
- compileall passed
- strict MkDocs build passed
- Gradio version references are synchronized
- git diff --check passed

Closes #227