### PR TITLE
Strengthen CI before v0.5.6

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,8 @@
 name: Real Model Integration Tests
 
 on:
+  schedule:
+    - cron: "0 5 * * 1"
   workflow_dispatch:
     inputs:
       python-version:
@@ -23,7 +25,7 @@ concurrency:
 
 jobs:
   integration:
-    name: Python ${{ inputs.python-version }} real models
+    name: Python ${{ inputs.python-version || '3.12' }} real models
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -38,21 +40,21 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version: ${{ inputs.python-version || '3.12' }}
           cache: pip
 
       - name: Cache Hugging Face models
         uses: actions/cache@v5.0.5
         with:
           path: ~/.cache/huggingface
-          key: hf-models-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('tests/test_real_models.py') }}
+          key: hf-models-${{ runner.os }}-py${{ inputs.python-version || '3.12' }}-${{ hashFiles('tests/test_real_models.py') }}
           restore-keys: |
-            hf-models-${{ runner.os }}-py${{ inputs.python-version }}-
+            hf-models-${{ runner.os }}-py${{ inputs.python-version || '3.12' }}-
             hf-models-${{ runner.os }}-
 
       - name: Document integration requirements
         run: |
-          echo "This manual workflow installs matheel[all,dev]."
+          echo "This workflow installs matheel[all,dev]."
           echo "It may download public Hugging Face model weights and cache them under ${HF_HOME}."
           echo "The default pull-request workflow does not run these tests."
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,3 +45,65 @@ jobs:
 
       - name: Run tests
         run: python -m pytest
+
+  codebleu-compatibility:
+    name: CodeBLEU compatibility
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package and external CodeBLEU
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          # CodeBLEU 0.7.0 pins an older Tree-sitter than Matheel's language pack.
+          # Install its Python code only so the compatibility tests use Matheel's runtime.
+          python -m pip install --no-deps "codebleu==0.7.0"
+          python -m pip install \
+            "tree-sitter-c==0.24.2" \
+            "tree-sitter-java==0.23.5" \
+            "tree-sitter-php==0.24.1"
+
+      - name: Run native-to-pip compatibility tests
+        run: |
+          python -m pytest tests/test_code_metrics.py \
+            -k native_codebleu_matches_pip_selected_exact_examples
+
+  package-smoke:
+    name: Package smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
+      - name: Install and smoke-test the wheel
+        run: |
+          python -m venv "${RUNNER_TEMP}/matheel-smoke"
+          "${RUNNER_TEMP}/matheel-smoke/bin/python" -m pip install dist/*.whl
+          "${RUNNER_TEMP}/matheel-smoke/bin/matheel" --help
+          "${RUNNER_TEMP}/matheel-smoke/bin/python" -c \
+            "import matheel; print(matheel.__version__)"

--- a/docs/development.md
+++ b/docs/development.md
@@ -36,7 +36,9 @@ Install the full optional stack before running them locally:
 python -m pip install -e ".[all,dev]"
 ```
 
-The `Real Model Integration Tests` GitHub Actions workflow is manual-only. It installs `matheel[all,dev]`, caches Hugging Face model files under `~/.cache/huggingface`, and runs `python -m pytest -m integration` on the selected Python version. It is not part of default pull-request CI, so normal tests remain offline-friendly.
+The `Real Model Integration Tests` GitHub Actions workflow runs weekly on Python 3.12 and can also be started manually on any supported Python version. It installs `matheel[all,dev]`, caches Hugging Face model files under `~/.cache/huggingface`, and runs `python -m pytest -m integration`. It is not part of default pull-request CI, so normal tests remain offline-friendly.
+
+Pull-request CI also runs selected compatibility checks against the external `codebleu` package and builds the wheel and source distribution. The package job validates metadata, installs the wheel into a clean environment, imports Matheel, and exercises the CLI help command.
 
 ## Package Checks
 


### PR DESCRIPTION
## Summary
- run real-model integration tests weekly on Python 3.12 while preserving manual version selection
- validate native CodeBLEU against external codebleu 0.7.0 with compatible parser wheels
- build wheel and sdist, run Twine checks, and smoke-test a clean wheel installation
- document the expanded CI behavior
- add Python 3.13 to required main-branch checks

## Local validation
- default suite: 548 passed, 4 skipped, 3 deselected
- CodeBLEU compatibility: 4 passed, 143 deselected
- wheel and sdist built successfully
- Twine checks passed
- clean wheel install, import, and CLI help passed
- Ruff, strict MkDocs, and git diff --check passed

Closes #229