### PR TITLE
Release v0.5.6

### DIFF
--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.5.5` and includes:
+This Space is aligned with `matheel==0.5.6` and includes:
 
 - Pair, collection, comparison-suite, normalized-dataset, dataset-validation, threshold-tuning, visualization, scored-pair explanation, ready-leaderboard, and leaderboard-inspection workflows
 - Metric presets for balanced, lexical, embedding-only, code-aware, and individual offline baselines

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.5.5
+matheel[all]==0.5.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.5.5"
+version = "0.5.6"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
Closes #231

## Summary
- bump the package version to 0.5.6
- synchronize the Hugging Face Gradio app pin and README
- prepare the patch release containing the reviewed correctness fixes and stronger CI coverage

## Validation
- 548 passed, 4 skipped, 3 deselected
- Ruff passed
- strict MkDocs build passed
- Gradio version synchronization passed
- sdist and wheel build passed
- Twine metadata checks passed
- clean Python 3.10 wheel install, import, version, and CLI help passed

The real-model integration workflow is being run separately on this branch before merge.