### PR TITLE
Fix v0.5.6 Hugging Face Space sync

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -61,7 +61,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          uvx hf repo create "${HF_REPO_ID}" --repo-type space --space-sdk gradio --exist-ok
           uvx hf upload \
             "${HF_REPO_ID}" \
             gradio_app \


### PR DESCRIPTION
Closes #233

## Summary
- stop recreating the configured Hugging Face Space before every upload
- upload directly to the existing Space, avoiding the new HTTP 402 creation policy

## Evidence
- v0.5.6 PyPI publish run 29499262439 succeeded
- Space sync run 29499313560 passed version/PyPI checks and failed only at `hf repo create --exist-ok`
- targeted Space/version tests: 8 passed
- Ruff, version synchronization, and diff checks passed

Merging this workflow-path change triggers a new main-branch sync attempt automatically.