### PR TITLE
Sync existing Hugging Face Space with Git

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -47,12 +47,6 @@ jobs:
         timeout-minutes: 12
         run: python scripts/check_pinned_matheel_release.py
 
-      - name: Set up uv
-        if: steps.pinned-release.outputs.should_sync_space == 'true'
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: true
-
       - name: Sync Gradio app to Hugging Face Space
         if: steps.pinned-release.outputs.should_sync_space == 'true'
         env:
@@ -61,11 +55,31 @@ jobs:
         run: |
           set -euo pipefail
 
-          uvx hf upload \
-            "${HF_REPO_ID}" \
-            gradio_app \
-            --repo-type space \
-            --exclude=".git*" \
-            --exclude=".github*" \
-            --delete="*" \
-            --commit-message="Sync from GitHub Actions"
+          space_dir="${RUNNER_TEMP}/hf-space"
+          staging_dir="${RUNNER_TEMP}/gradio-app"
+          hf_username="${HF_REPO_ID%%/*}"
+
+          git clone --depth 1 \
+            "https://huggingface.co/spaces/${HF_REPO_ID}" \
+            "${space_dir}"
+          mkdir -p "${staging_dir}"
+          git archive HEAD:gradio_app | tar -x -C "${staging_dir}"
+          rsync --archive --delete \
+            --exclude=".git/" \
+            --exclude=".gitattributes" \
+            "${staging_dir}/" \
+            "${space_dir}/"
+
+          git -C "${space_dir}" config user.name "github-actions[bot]"
+          git -C "${space_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${space_dir}" add --all
+
+          if git -C "${space_dir}" diff --cached --quiet; then
+            echo "Space is already synchronized."
+            exit 0
+          fi
+
+          git -C "${space_dir}" commit -m "Sync from GitHub Actions"
+          git -C "${space_dir}" push \
+            "https://${hf_username}:${HF_TOKEN}@huggingface.co/spaces/${HF_REPO_ID}" \
+            HEAD:main

--- a/tests/test_space_sync_release_check.py
+++ b/tests/test_space_sync_release_check.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+
 import pytest
 
 from scripts.check_pinned_matheel_release import check_pinned_release, pinned_matheel_version
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def write_sample_repo(root, version="1.2.3"):
@@ -101,3 +106,17 @@ def test_publish_event_fails_when_pin_never_appears(tmp_path):
 
     assert result == 1
     assert read_outputs(output_path)["should_sync_space"] == "false"
+
+
+def test_space_sync_updates_the_existing_repository_without_create_api():
+    workflow = (ROOT / ".github" / "workflows" / "sync-hf-space.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "hf repo create" not in workflow
+    assert "hf upload" not in workflow
+    assert "git clone --depth 1" in workflow
+    assert "git archive HEAD:gradio_app" in workflow
+    assert "rsync --archive --delete" in workflow
+    assert '--exclude=".gitattributes"' in workflow
+    assert "HEAD:main" in workflow


### PR DESCRIPTION
Closes #233

## Summary
- replace the `hf upload` path, which still invokes the paid Space-creation API, with Hugging Face documented direct Git synchronization
- clone the existing Space, preserve its Git history and `.gitattributes`, mirror only Git-tracked `gradio_app` files, and push only when content changed
- add a regression test preventing the create/upload API path from returning

## Validation
- fresh anonymous clone confirmed the configured public Space exists on `main` and is still pinned to 0.5.5
- dry-run mirror changed only README.md and requirements.txt to 0.5.6 while preserving `.gitattributes`
- 549 passed, 4 skipped, 3 deselected
- Ruff, workflow YAML parsing, and diff checks passed

Hugging Face documents Git as a supported Space deployment path: https://huggingface.co/docs/hub/en/spaces-github-actions