### PR TITLE
Detect equal-length Space pin updates

### DIFF
--- a/.github/workflows/sync-hf-space.yml
+++ b/.github/workflows/sync-hf-space.yml
@@ -64,7 +64,7 @@ jobs:
             "${space_dir}"
           mkdir -p "${staging_dir}"
           git archive HEAD:gradio_app | tar -x -C "${staging_dir}"
-          rsync --archive --delete \
+          rsync --archive --checksum --delete \
             --exclude=".git/" \
             --exclude=".gitattributes" \
             "${staging_dir}/" \

--- a/tests/test_space_sync_release_check.py
+++ b/tests/test_space_sync_release_check.py
@@ -117,6 +117,6 @@ def test_space_sync_updates_the_existing_repository_without_create_api():
     assert "hf upload" not in workflow
     assert "git clone --depth 1" in workflow
     assert "git archive HEAD:gradio_app" in workflow
-    assert "rsync --archive --delete" in workflow
+    assert "rsync --archive --checksum --delete" in workflow
     assert '--exclude=".gitattributes"' in workflow
     assert "HEAD:main" in workflow


### PR DESCRIPTION
Closes #233

## Summary
- make Space mirroring compare file checksums instead of relying only on rsync size/mtime quick checks
- require checksum mode in the workflow regression test

## Evidence
- run 29499871621 cloned the old May 31 Space commit but incorrectly reported it already synchronized
- the stale and current version pins have equal byte lengths
- a local reproduction with deliberately identical source/destination timestamps detects only README.md and requirements.txt when `--checksum` is enabled
- targeted workflow tests: 7 passed
- Ruff and diff checks passed

After merge, the workflow-path trigger will perform the live deployment again.