### PR TITLE
Keep the PyPI badge current after releases

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -32,6 +32,9 @@ python scripts/sync_gradio_app_version.py --check
 - Confirm the README PyPI badges are dynamic and use the standard Shields cache:
   - PyPI version: `https://img.shields.io/pypi/v/matheel.svg`
   - Python versions: `https://img.shields.io/pypi/pyversions/matheel.svg`
+- Confirm the PyPI version badge includes `cacheSeconds=3600&release=v<version>`.
+  The release key gives GitHub Camo a fresh image URL for each published version;
+  `scripts/sync_gradio_app_version.py` maintains it automatically.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matheel
 
 [![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
-[![PyPI](https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=3600)](https://pypi.org/project/matheel/)
+[![PyPI](https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=3600&release=v0.5.6)](https://pypi.org/project/matheel/)
 [![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg?cacheSeconds=3600)](https://pypi.org/project/matheel/)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://fahadebrahim.github.io/matheel/)
 [![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)

--- a/scripts/sync_gradio_app_version.py
+++ b/scripts/sync_gradio_app_version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Sync Gradio app Matheel version references from pyproject.toml."""
+"""Sync release-facing Matheel version references from pyproject.toml."""
 
 from __future__ import annotations
 
@@ -14,7 +14,11 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
     tomllib = None
 
 
-README_VERSION_RE = re.compile(r"`matheel==[^`]+`")
+GRADIO_README_VERSION_RE = re.compile(r"`matheel==[^`]+`")
+PYPI_BADGE_RE = re.compile(
+    r"https://img\.shields\.io/pypi/v/matheel\.svg\?cacheSeconds=3600"
+    r"(?:&release=v?[^)\s]+)?"
+)
 REQUIREMENTS_VERSION_RE = re.compile(r"(?m)^matheel\[all\]==[^\s]+$")
 PROJECT_VERSION_RE = re.compile(r'(?m)^version\s*=\s*"([^"]+)"\s*$')
 
@@ -54,8 +58,14 @@ def planned_updates(root):
     version = project_version(root)
     targets = (
         (
+            root / "README.md",
+            PYPI_BADGE_RE,
+            "https://img.shields.io/pypi/v/matheel.svg"
+            f"?cacheSeconds=3600&release=v{version}",
+        ),
+        (
             root / "gradio_app" / "README.md",
-            README_VERSION_RE,
+            GRADIO_README_VERSION_RE,
             f"`matheel=={version}`",
         ),
         (
@@ -80,11 +90,11 @@ def sync_gradio_app_version(root, check=False):
             for path, _ in updates:
                 print(f"{path.relative_to(root)} is not synced with pyproject.toml.", file=sys.stderr)
             return 1
-        print("Gradio app version references are synced.")
+        print("Release version references are synced.")
         return 0
 
     if not updates:
-        print("Gradio app version references are already synced.")
+        print("Release version references are already synced.")
         return 0
 
     for path, updated in updates:
@@ -95,12 +105,12 @@ def sync_gradio_app_version(root, check=False):
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(
-        description="Sync Gradio app Matheel version references from pyproject.toml."
+        description="Sync release-facing Matheel version references from pyproject.toml."
     )
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Fail if Gradio app version references are stale.",
+        help="Fail if release-facing version references are stale.",
     )
     parser.add_argument(
         "--root",

--- a/tests/test_gradio_version_sync.py
+++ b/tests/test_gradio_version_sync.py
@@ -1,18 +1,23 @@
 from scripts.sync_gradio_app_version import sync_gradio_app_version
 
 
-def write_sample_repo(root, version="1.2.3", gradio_version="0.1.0"):
+def write_sample_repo(root, version="1.2.3", synced_version="0.1.0"):
     (root / "gradio_app").mkdir()
     (root / "pyproject.toml").write_text(
         f'[project]\nname = "matheel"\nversion = "{version}"\n',
         encoding="utf-8",
     )
+    (root / "README.md").write_text(
+        "[![PyPI](https://img.shields.io/pypi/v/matheel.svg"
+        f"?cacheSeconds=3600&release=v{synced_version})](https://pypi.org/project/matheel/)\n",
+        encoding="utf-8",
+    )
     (root / "gradio_app" / "README.md").write_text(
-        f"This Space is aligned with `matheel=={gradio_version}` and includes:\n",
+        f"This Space is aligned with `matheel=={synced_version}` and includes:\n",
         encoding="utf-8",
     )
     (root / "gradio_app" / "requirements.txt").write_text(
-        f"matheel[all]=={gradio_version}\n",
+        f"matheel[all]=={synced_version}\n",
         encoding="utf-8",
     )
 
@@ -22,6 +27,9 @@ def test_sync_gradio_app_version_updates_stale_files(tmp_path):
 
     assert sync_gradio_app_version(tmp_path) == 0
 
+    assert "cacheSeconds=3600&release=v1.2.3" in (tmp_path / "README.md").read_text(
+        encoding="utf-8"
+    )
     assert "`matheel==1.2.3`" in (tmp_path / "gradio_app" / "README.md").read_text(
         encoding="utf-8"
     )
@@ -36,6 +44,9 @@ def test_sync_gradio_app_version_check_reports_stale_files(tmp_path):
 
     assert sync_gradio_app_version(tmp_path, check=True) == 1
 
+    assert "cacheSeconds=3600&release=v0.1.0" in (tmp_path / "README.md").read_text(
+        encoding="utf-8"
+    )
     assert "`matheel==0.1.0`" in (tmp_path / "gradio_app" / "README.md").read_text(
         encoding="utf-8"
     )


### PR DESCRIPTION
Closes #237

## Summary
- add a release-specific cache key to the dynamic PyPI badge so GitHub Camo creates a fresh proxy URL
- update the existing release-version synchronization script to maintain the badge key from pyproject.toml
- add regression coverage for stale badge keys
- document the behavior in the release checklist

## Root cause
PyPI and Shields returned v0.5.6, but GitHub Camo retained the previous SVG under the unchanged badge URL with a three-hour edge cache. Purging the Camo entry was accepted but the edge continued serving v0.5.5.

## Validation
- the release-keyed Shields URL returns v0.5.6
- the newly generated GitHub Camo URL returns v0.5.6
- 549 passed, 4 skipped, 3 deselected
- Ruff passed
- strict MkDocs build passed
- release version synchronization and diff checks passed