### PR TITLE
Refresh release notebooks and Gradio guidance

### DIFF
--- a/docs/gradio.md
+++ b/docs/gradio.md
@@ -1,0 +1,64 @@
+# Gradio App
+
+Matheel's Gradio app provides interactive pairwise, collection, suite, dataset, visualization, and leaderboard workflows. Use the [hosted Hugging Face Space](https://huggingface.co/spaces/buelfhood/matheel-framework), the [Colab launcher](https://colab.research.google.com/github/FahadEbrahim/matheel/blob/main/examples/notebooks/04_gradio_app.ipynb), or a local checkout.
+
+## Run Locally
+
+From the repository root, create an environment and install the Gradio dependencies:
+
+```bash
+python -m venv .venv
+.venv/bin/python -m pip install -e ".[gradio]"
+.venv/bin/python gradio_app/app.py
+```
+
+Open the local URL shown in the terminal. The Gradio extra supports the app and lexical workflows. Install `.[all]` when you also need every semantic backend, chunker, code metric, and visualization dependency.
+
+The app targets Gradio 5. Its dependencies intentionally require `gradio>=5,<6` because the Hugging Face model-search component currently requires Gradio below version 6.
+
+## Guided Pairwise Check
+
+Start with a lexical-only comparison so the first run does not need model weights:
+
+1. Open the **Pairwise** tab.
+2. Paste this into **Code A**:
+
+    ```python
+    def add(a, b):
+        return a + b
+    ```
+
+3. Paste this into **Code B**:
+
+    ```python
+    def add(x, y):
+        return x + y
+    ```
+
+4. Under **Metrics**, set **Metric Preset** to **Lexical Only**.
+5. Select **Run Pair** and inspect the overall score and metric breakdown.
+
+Semantic presets can download model weights and may take longer on their first run.
+
+## Choose a Workflow
+
+| Tab | Use it for |
+| --- | --- |
+| **Pairwise** | Compare two pasted code snippets and inspect the metric breakdown. |
+| **Collection** | Rank similar files from an uploaded ZIP archive. |
+| **Suite** | Run multiple saved comparison configurations over the same collection. |
+| **Datasets** | Validate normalized dataset ZIPs, evaluate scores, tune thresholds, and export reports. |
+| **Visualization** | Generate dataset maps or explain scored pairs. |
+| **Leaderboard** | Build a ready leaderboard from normalized data or inspect exported JSON/ZIP artifacts. |
+
+Collection and dataset uploads are ZIP-first. Keep source paths relative inside the archive, and use normalized dataset ZIPs for evaluation, visualization, and ready-leaderboard tasks. Download generated artifacts if you need to retain them after the session ends.
+
+## Troubleshooting
+
+- **The first semantic run is slow:** model files and ML runtimes may need to initialize or download. Try the lexical preset first to verify the app itself.
+- **A backend is unavailable:** install `.[all]`, restart the app, and check the terminal for the missing optional dependency.
+- **An upload is rejected:** use a ZIP archive and check that the selected workflow expects either a source collection or a normalized dataset.
+- **A Colab launch cell keeps running:** this is expected while the server is active. Open the public Gradio link printed by the cell.
+- **The hosted Space appears stale:** compare the Matheel version shown in its README with the latest [PyPI release](https://pypi.org/project/matheel/), then report the mismatch in GitHub Issues.
+
+For automated checks and contributor setup, see [Development](development.md). Release-facing notebook references are validated against `pyproject.toml` in CI.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,6 +104,8 @@ print(results.head())
 - Run the reproducible benchmark demo when you need a small auditable evaluation workflow.
 - Run the Gradio app or notebooks when you want an interactive workflow, including normalized dataset evaluation, visualization artifacts, ready leaderboards, and leaderboard inspection.
 
+For installation, a guided pairwise check, workflow descriptions, and troubleshooting, see the [Gradio app guide](gradio.md).
+
 ## Demos and Examples
 
 - Hugging Face Space demo: [buelfhood/matheel-framework](https://huggingface.co/spaces/buelfhood/matheel-framework)
@@ -116,6 +118,7 @@ print(results.head())
 
 ## Documentation Map
 
+- [Gradio app](gradio.md)
 - [Preprocessing](preprocessing.md)
 - [Tokenization and preprocessing limits](tokenization.md)
 - [Chunking](chunking.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,4 +35,13 @@ python examples/evaluation/dataset_validation_demo.py
 python examples/evaluation/threshold_tuning_demo.py
 ```
 
+Launch the Gradio app from a repository checkout:
+
+```bash
+python -m pip install -e ".[gradio]"
+python gradio_app/app.py
+```
+
+Use `.[all]` instead of `.[gradio]` when you want every semantic, chunking, metric, and visualization backend. The [Gradio notebook](notebooks/04_gradio_app.ipynb) includes a guided lexical pairwise check, while the [Gradio app guide](../docs/gradio.md) covers every tab and common troubleshooting.
+
 Generated archives and benchmark outputs are ignored by git.

--- a/examples/notebooks/01_core_workflows.ipynb
+++ b/examples/notebooks/01_core_workflows.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.5\"\n",
+    "MATHEEL_REF = \"v0.5.6\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/02_datasets_and_reproducibility.ipynb
+++ b/examples/notebooks/02_datasets_and_reproducibility.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.5\"\n",
+    "MATHEEL_REF = \"v0.5.6\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/03_custom_algorithms.ipynb
+++ b/examples/notebooks/03_custom_algorithms.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.5\"\n",
+    "MATHEEL_REF = \"v0.5.6\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/04_gradio_app.ipynb
+++ b/examples/notebooks/04_gradio_app.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%%bash\n",
     "set -euo pipefail\n",
-    "MATHEEL_REF=\"v0.5.5\"\n",
+    "MATHEEL_REF=\"v0.5.6\"\n",
     "pip uninstall -y torchvision || true\n",
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",
@@ -25,6 +25,22 @@
     "git checkout \"$MATHEEL_REF\"\n",
     "pip install -e \".[all]\"\n",
     "echo \"Matheel installed from $MATHEEL_REF. If Colab asks, restart the runtime once before launching the app.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Guided pairwise check\n",
+    "\n",
+    "After the app opens, use the **Pairwise** tab for a quick check that does not download a model:\n",
+    "\n",
+    "1. Paste `def add(a, b):\\n    return a + b` into **Code A**.\n",
+    "2. Paste `def add(x, y):\\n    return x + y` into **Code B**.\n",
+    "3. In **Metrics**, set **Metric Preset** to **Lexical Only**.\n",
+    "4. Select **Run Pair** and inspect the overall score and metric breakdown.\n",
+    "\n",
+    "The lexical preset keeps this first run fast. Semantic presets can download model weights and take longer on their first run."
    ]
   },
   {

--- a/examples/notebooks/05_visualization_and_leaderboard.ipynb
+++ b/examples/notebooks/05_visualization_and_leaderboard.ipynb
@@ -20,7 +20,7 @@
         "import sys\n",
         "from pathlib import Path\n",
         "\n",
-        "MATHEEL_REF = \"v0.5.5\"\n",
+        "MATHEEL_REF = \"v0.5.6\"\n",
         "\n",
         "\n",
         "def run(*args, cwd=None):\n",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Getting Started:
       - Home: index.md
       - Usage: usage.md
+      - Gradio app: gradio.md
   - Scoring:
       - Preprocessing: preprocessing.md
       - Tokenization and limits: tokenization.md

--- a/scripts/sync_gradio_app_version.py
+++ b/scripts/sync_gradio_app_version.py
@@ -21,6 +21,14 @@ PYPI_BADGE_RE = re.compile(
 )
 REQUIREMENTS_VERSION_RE = re.compile(r"(?m)^matheel\[all\]==[^\s]+$")
 PROJECT_VERSION_RE = re.compile(r'(?m)^version\s*=\s*"([^"]+)"\s*$')
+NOTEBOOK_REF_RE = re.compile(r'(MATHEEL_REF\s*=\s*\\"v)([^\\"]+)(\\")')
+RELEASE_NOTEBOOKS = (
+    "01_core_workflows.ipynb",
+    "02_datasets_and_reproducibility.ipynb",
+    "03_custom_algorithms.ipynb",
+    "04_gradio_app.ipynb",
+    "05_visualization_and_leaderboard.ipynb",
+)
 
 
 def project_version(root):
@@ -56,7 +64,7 @@ def replace_single(path, pattern, replacement):
 
 def planned_updates(root):
     version = project_version(root)
-    targets = (
+    targets = [
         (
             root / "README.md",
             PYPI_BADGE_RE,
@@ -73,6 +81,14 @@ def planned_updates(root):
             REQUIREMENTS_VERSION_RE,
             f"matheel[all]=={version}",
         ),
+    ]
+    targets.extend(
+        (
+            root / "examples" / "notebooks" / notebook_name,
+            NOTEBOOK_REF_RE,
+            rf"\g<1>{version}\g<3>",
+        )
+        for notebook_name in RELEASE_NOTEBOOKS
     )
 
     updates = []

--- a/tests/test_gradio_version_sync.py
+++ b/tests/test_gradio_version_sync.py
@@ -1,8 +1,11 @@
-from scripts.sync_gradio_app_version import sync_gradio_app_version
+import json
+
+from scripts.sync_gradio_app_version import RELEASE_NOTEBOOKS, sync_gradio_app_version
 
 
 def write_sample_repo(root, version="1.2.3", synced_version="0.1.0"):
     (root / "gradio_app").mkdir()
+    (root / "examples" / "notebooks").mkdir(parents=True)
     (root / "pyproject.toml").write_text(
         f'[project]\nname = "matheel"\nversion = "{version}"\n',
         encoding="utf-8",
@@ -20,6 +23,16 @@ def write_sample_repo(root, version="1.2.3", synced_version="0.1.0"):
         f"matheel[all]=={synced_version}\n",
         encoding="utf-8",
     )
+    for index, notebook_name in enumerate(RELEASE_NOTEBOOKS):
+        assignment = (
+            f'MATHEEL_REF="v{synced_version}"\n'
+            if index == 3
+            else f'MATHEEL_REF = "v{synced_version}"\n'
+        )
+        (root / "examples" / "notebooks" / notebook_name).write_text(
+            json.dumps({"cells": [{"source": [assignment]}]}) + "\n",
+            encoding="utf-8",
+        )
 
 
 def test_sync_gradio_app_version_updates_stale_files(tmp_path):
@@ -36,6 +49,13 @@ def test_sync_gradio_app_version_updates_stale_files(tmp_path):
     assert (tmp_path / "gradio_app" / "requirements.txt").read_text(
         encoding="utf-8"
     ) == "matheel[all]==1.2.3\n"
+    for notebook_name in RELEASE_NOTEBOOKS:
+        notebook = json.loads(
+            (tmp_path / "examples" / "notebooks" / notebook_name).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert notebook["cells"][0]["source"][0].endswith('"v1.2.3"\n')
     assert sync_gradio_app_version(tmp_path, check=True) == 0
 
 
@@ -53,3 +73,8 @@ def test_sync_gradio_app_version_check_reports_stale_files(tmp_path):
     assert (tmp_path / "gradio_app" / "requirements.txt").read_text(
         encoding="utf-8"
     ) == "matheel[all]==0.1.0\n"
+    for notebook_name in RELEASE_NOTEBOOKS:
+        notebook_text = (tmp_path / "examples" / "notebooks" / notebook_name).read_text(
+            encoding="utf-8"
+        )
+        assert "v0.1.0" in notebook_text

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.sync_gradio_app_version import RELEASE_NOTEBOOKS
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("notebook_name", RELEASE_NOTEBOOKS)
+def test_release_notebook_is_valid_nbformat_json(notebook_name):
+    notebook_path = REPOSITORY_ROOT / "examples" / "notebooks" / notebook_name
+    notebook = json.loads(notebook_path.read_text(encoding="utf-8"))
+
+    assert notebook["nbformat"] == 4
+    assert isinstance(notebook["cells"], list)
+    assert notebook["cells"]
+    assert all(cell.get("cell_type") in {"code", "markdown", "raw"} for cell in notebook["cells"])


### PR DESCRIPTION
Closes #239.

## What changed

- update all five release-facing notebooks to `v0.5.6`
- include notebook refs in the release-version synchronization check
- validate notebook JSON structure in the regular test suite
- add a dedicated Gradio guide and MkDocs navigation entry
- add local launch guidance and a guided lexical pairwise notebook check

## Why

The notebooks still installed `v0.5.5`, and CI only synchronized the README badge and Space dependency files. Gradio usage was also spread across short references without one practical guide.

This keeps examples aligned with the package release and gives users a fast, model-free first workflow before the Gradio redesign starts.

## Validation

- `python scripts/sync_gradio_app_version.py --check`
- `python -m ruff check .`
- `python -m pytest` (554 passed, 4 skipped, 3 deselected)
- `python -m mkdocs build --strict`
