### PR TITLE
Add Gradio UI smoke coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,6 +77,31 @@ jobs:
           python -m pytest tests/test_code_metrics.py \
             -k native_codebleu_matches_pip_selected_exact_examples
 
+  gradio-smoke:
+    name: Gradio smoke
+    runs-on: ubuntu-latest
+    env:
+      GRADIO_ANALYTICS_ENABLED: "False"
+      HF_HUB_OFFLINE: "1"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package and Gradio test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,gradio]"
+
+      - name: Run Gradio structure and launch checks
+        run: python -m pytest tests/test_gradio_app.py tests/test_gradio_html_utils.py
+
   package-smoke:
     name: Package smoke
     runs-on: ubuntu-latest

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,6 +40,17 @@ The `Real Model Integration Tests` GitHub Actions workflow runs weekly on Python
 
 Pull-request CI also runs selected compatibility checks against the external `codebleu` package and builds the wheel and source distribution. The package job validates metadata, installs the wheel into a clean environment, imports Matheel, and exercises the CLI help command.
 
+## Gradio Checks
+
+The default development install does not include Gradio, so Gradio-specific tests skip when its optional dependencies are unavailable. Install the Gradio and development extras to run the same focused checks as pull-request CI:
+
+```bash
+python -m pip install -e ".[dev,gradio]"
+python -m pytest tests/test_gradio_app.py tests/test_gradio_html_utils.py
+```
+
+These tests cover workflow helpers, the stable tab and primary-action structure, and a live server smoke check of the root page and `/config` endpoint. They intentionally avoid model downloads.
+
 ## Package Checks
 
 When preparing release or packaging changes, build the package and check the distribution metadata:

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -1,8 +1,10 @@
 import importlib.util
 import json
 import os
+import socket
 import zipfile
 from pathlib import Path
+from urllib.request import urlopen
 
 import pandas as pd
 import pytest
@@ -19,6 +21,88 @@ SPEC = importlib.util.spec_from_file_location("matheel_gradio_app", APP_PATH)
 gradio_app = importlib.util.module_from_spec(SPEC)
 assert SPEC is not None and SPEC.loader is not None
 SPEC.loader.exec_module(gradio_app)
+
+
+EXPECTED_GRADIO_TABS = (
+    "Pairwise",
+    "Collection",
+    "Suite",
+    "Datasets",
+    "Visualization",
+    "Dataset Map",
+    "Pair Explanation",
+    "Leaderboard",
+    "Ready Leaderboard",
+    "Inspect Artifacts",
+)
+EXPECTED_PRIMARY_ACTIONS = {
+    "Run Pair": "calculate_similarity_gradio",
+    "Run Collection": "get_sim_list_gradio",
+    "Run Suite": "run_suite_gradio",
+    "Validate Dataset": "validate_dataset_gradio",
+    "Run Dataset Evaluation": "evaluate_dataset_gradio_with_state",
+    "Generate Map": "generate_dataset_map_gradio",
+    "Generate Explanation": "generate_pair_explanation_gradio",
+    "Run Ready Leaderboard": "run_ready_leaderboard_gradio",
+    "Inspect Leaderboard": "inspect_leaderboard_artifacts_gradio",
+}
+
+
+def test_gradio_ui_keeps_core_workflow_tabs_and_primary_actions_wired():
+    config = gradio_app.demo.get_config_file()
+    components = {component["id"]: component for component in config["components"]}
+    tab_labels = tuple(
+        component["props"]["label"]
+        for component in components.values()
+        if component["type"] == "tabitem"
+    )
+
+    assert tab_labels == EXPECTED_GRADIO_TABS
+
+    buttons = {
+        component["props"].get("value"): component_id
+        for component_id, component in components.items()
+        if component["type"] == "button"
+    }
+    for button_text, api_name in EXPECTED_PRIMARY_ACTIONS.items():
+        button_id = buttons[button_text]
+        click_dependencies = [
+            dependency
+            for dependency in config["dependencies"]
+            if (button_id, "click") in dependency["targets"]
+        ]
+
+        assert len(click_dependencies) == 1
+        assert click_dependencies[0]["backend_fn"] is True
+        assert click_dependencies[0]["api_name"] == api_name
+
+
+def test_gradio_app_launches_and_serves_root_and_config():
+    with socket.socket() as port_socket:
+        port_socket.bind(("127.0.0.1", 0))
+        server_port = port_socket.getsockname()[1]
+
+    _, local_url, _ = gradio_app.demo.launch(
+        server_name="127.0.0.1",
+        server_port=server_port,
+        prevent_thread_lock=True,
+        quiet=True,
+        show_error=True,
+    )
+    try:
+        with urlopen(local_url, timeout=10) as response:
+            root_html = response.read().decode("utf-8")
+            assert response.status == 200
+        with urlopen(f"{local_url}config", timeout=10) as response:
+            live_config = json.load(response)
+            assert response.status == 200
+    finally:
+        gradio_app.demo.close()
+
+    assert "<gradio-app" in root_html
+    assert "Matheel Framework" in root_html
+    assert live_config["title"] == "Matheel Framework"
+    assert len(live_config["components"]) == len(gradio_app.demo.get_config_file()["components"])
 
 
 def test_gradio_temp_workspace_cleanup_removes_only_stale_known_prefixes(tmp_path):


### PR DESCRIPTION
Closes #241.

Related: #178.

## What changed

- add a dedicated Python 3.12 Gradio smoke job using `.[dev,gradio]`
- assert the stable workflow tabs and primary click-handler wiring from the Blocks config
- launch the app on a temporary local port and verify the root page and `/config`
- document how contributors can run the same focused checks locally

## Why

The normal CI matrix installs only `.[dev]`, so Gradio-specific tests can skip there. Existing tests covered helpers and workflow functions but did not catch missing tabs, disconnected primary buttons, or startup/routing regressions.

This establishes a focused safety net before the redesign in #178 without locking down presentation details.

## Validation

- `python -m ruff check .`
- `python -m pytest` (556 passed, 4 skipped, 3 deselected)
- `python -m mkdocs build --strict`
- `python scripts/sync_gradio_app_version.py --check`
- real-browser lexical Pairwise smoke: all top-level tabs rendered and the sample pair returned a 0.4355 score without a model download
