### PR TITLE
Add a ready-made public leaderboard

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -152,7 +152,7 @@ Built-in generic source resolvers:
 | `github` | Download a repository archive by `owner/repo`. | Public repositories need no token. |
 | `zenodo` | Download files for a Zenodo record id. | Archives are extracted with path traversal checks. |
 | `huggingface` | Resolve a Hugging Face dataset repository. | Requires optional Hugging Face Hub support. |
-| `kaggle` | Download a Kaggle dataset. | Requires optional Kaggle API or CLI credentials. |
+| `kaggle` | Download a Kaggle dataset. | Uses the API/CLI when installed and otherwise supports Kaggle's anonymous public download endpoint. Private datasets still require Kaggle credentials. |
 
 Source resolvers only locate or download data; users are responsible for dataset access, credentials, licenses, and source terms.
 

--- a/docs/gradio.md
+++ b/docs/gradio.md
@@ -49,11 +49,13 @@ Semantic presets can download model weights and may take longer on their first r
 | **Suites** | Run multiple saved comparison configurations over the same collection. |
 | **Datasets** | Validate normalized dataset ZIPs, evaluate scores, tune thresholds, and export reports. |
 | **Explain** | Generate dataset maps or explain matched regions in a code pair. |
-| **Reports** | Build a leaderboard from normalized data or inspect exported JSON/ZIP artifacts. |
+| **Reports** | Open the ready-made all-preset leaderboard, build a custom leaderboard, or inspect exported JSON/ZIP artifacts. |
 
 The top banner shows the recommended path from a quick comparison through evaluation and reporting. Each workflow states what it produces, while advanced preparation options remain collapsed until needed. On wider screens, the configuration panel stays available while results grow.
 
 Collection and dataset uploads are ZIP-first. Keep source paths relative inside the archive, and use normalized dataset ZIPs for evaluation, explanation, and leaderboard tasks. Download generated artifacts if you need to retain them after the session ends.
+
+The first **Reports** subtab is a ready-made sampled leaderboard covering every registered public dataset preset and every built-in algorithm preset. It loads from a committed JSON artifact, so viewing it does not download datasets or run models. Its summary shows the sampling limits, seed, backend, and generation date; use **Build Leaderboard** for full-corpus or custom settings.
 
 ## Troubleshooting
 

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -2,10 +2,25 @@
 
 Matheel leaderboards rank algorithms across normalized pair-classification and retrieval datasets. The workflow is local and offline: users provide normalized datasets or source specs, Matheel scores them, then exports per-dataset and aggregate ranking tables.
 
-The Gradio app includes two leaderboard workflows:
+The Gradio app includes three leaderboard workflows:
 
+- **Ready-made Leaderboard** immediately displays a committed public snapshot covering every registered dataset preset and every built-in algorithm preset.
 - **Build Leaderboard** runs selected algorithm presets over uploaded normalized dataset ZIPs, shows all registered dataset presets, applies task-specific metric defaults, and exports standard leaderboard artifacts.
 - **Inspect Artifacts** loads a leaderboard JSON or ZIP artifact and renders the aggregate table, per-dataset table, static report, and downloadable report bundle.
+
+## Ready-made Public Snapshot
+
+Open **Reports → Ready-made Leaderboard** to see rankings without uploading data or starting a benchmark run. The snapshot covers all six registered public dataset presets as seven task views: five pair-classification datasets plus SOCO14 and IRPlag retrieval views. All eight built-in algorithm presets are included.
+
+This is a deterministic product demo, not a claim of full-corpus research performance. Each pair dataset uses a label-stratified sample capped at 128 pairs; each retrieval view is capped at 24 queries and 64 documents while retaining the selected queries' judged documents. It uses seed `7`, task-appropriate code languages, and the offline `static_hash` vector backend with 256 dimensions. The app displays these limits alongside the rankings.
+
+Maintainers can regenerate the committed JSON artifact from the public source presets:
+
+```bash
+python scripts/build_ready_leaderboard.py
+```
+
+The builder downloads and normalizes the registered sources, creates deterministic samples, scores every algorithm preset, and writes `gradio_app/assets/ready_leaderboard.json`. Use **Build Leaderboard** or the CLI with a custom manifest when full-corpus evaluation, another embedding backend, or different sampling is required.
 
 ## Manifest
 
@@ -98,7 +113,7 @@ The example is deterministic and offline. It uses synthetic normalized datasets 
 
 ## Gradio Build Leaderboard
 
-The Gradio **Reports → Build Leaderboard** workflow expects normalized dataset ZIP uploads. It does not bundle real datasets or credentials. The registered dataset table lists the current dataset presets, their task families, their source resolver, and the default evaluation plan:
+The Gradio **Reports → Build Leaderboard** workflow expects normalized dataset ZIP uploads. Unlike the ready-made sampled snapshot, custom runs do not fetch or bundle real datasets or credentials. The registered dataset table lists the current dataset presets, their task families, their source resolver, and the default evaluation plan:
 
 - Pair-classification datasets use pair metrics such as `f1`, `accuracy`, `auroc`, and `average_precision`.
 - Retrieval datasets use ranking metrics such as `mean_average_precision`, `mean_reciprocal_rank`, `ndcg_at_k`, `precision_at_k`, and `recall_at_k`.

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -13,7 +13,7 @@ Interactive code-similarity analysis with configurable embedding, lexical, chunk
 
 This Space is aligned with `matheel==0.5.6` and includes:
 
-- Pair, collection, comparison-suite, normalized-dataset, dataset-validation, threshold-tuning, visualization, scored-pair explanation, ready-leaderboard, and leaderboard-inspection workflows
+- Pair, collection, comparison-suite, normalized-dataset, dataset-validation, threshold-tuning, visualization, scored-pair explanation, ready-made public leaderboard, custom leaderboard, and leaderboard-inspection workflows
 - Metric presets for balanced, lexical, embedding-only, code-aware, and individual offline baselines
 - Downloadable artifacts for dataset evaluation, validation reports, threshold sweeps, dataset maps, pair explanations, ready leaderboards, leaderboard reports, and leaderboard detail reports
 - Raw and parser-derived lexical tokenization for Winnowing and GST

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -193,6 +193,7 @@ READY_LEADERBOARD_RETRIEVAL_METRICS = (
     "precision_at_k",
     "recall_at_k",
 )
+READY_MADE_LEADERBOARD_PATH = Path(__file__).resolve().parent / "assets" / "ready_leaderboard.json"
 THRESHOLD_OPTIMIZE_CHOICES = ("f1", "accuracy", "precision", "recall")
 PAIR_DATASET_SCORE_COLUMNS = [
     "left_id",
@@ -2144,6 +2145,99 @@ def _leaderboard_report_from_payload(payload):
     }
 
 
+def load_ready_made_leaderboard_payload(artifact_path=READY_MADE_LEADERBOARD_PATH):
+    path = Path(artifact_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Ready-made leaderboard artifact does not exist: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Ready-made leaderboard artifact must be valid JSON.") from exc
+    if not _looks_like_leaderboard_payload(payload):
+        raise ValueError("Ready-made leaderboard artifact is not a Matheel leaderboard payload.")
+    return payload
+
+
+def ready_made_leaderboard_summary_html(report):
+    profile = dict(report["metadata"].get("benchmark_profile") or {})
+    dataset_presets = list(profile.get("dataset_presets") or [])
+    algorithms = list(profile.get("algorithm_presets") or [])
+    generated_at = str(profile.get("generated_at") or "unknown")
+    if "T" in generated_at:
+        generated_at = generated_at.split("T", 1)[0]
+    sample_plan = (
+        f"≤{profile.get('pair_sample_limit', '?')} pairs; "
+        f"≤{profile.get('retrieval_query_limit', '?')} queries × "
+        f"{profile.get('retrieval_corpus_limit', '?')} documents"
+    )
+    return summary_panel_html(
+        "Ready-made Leaderboard",
+        [
+            ("Dataset Presets", str(len(dataset_presets))),
+            ("Task Views", str(profile.get("dataset_task_count") or len(report["cards"]["datasets"]))),
+            ("Algorithms", str(len(algorithms) or len(report["cards"]["algorithms"]))),
+            ("Backend", str(profile.get("vector_backend") or "unknown")),
+            ("Sampling", sample_plan),
+            ("Seed", str(profile.get("seed", ""))),
+            ("Generated", generated_at),
+        ],
+    )
+
+
+def ready_made_leaderboard_coverage_frame(report):
+    rows = []
+    for card in report.get("cards", {}).get("datasets", []):
+        metadata = dict(card.get("metadata") or {})
+        source = dict(card.get("source") or {})
+        counts = dict(card.get("counts") or {})
+        if card.get("task_family") == "retrieval":
+            sample = f"{counts.get('queries', 0)} queries × {counts.get('documents', 0)} documents"
+        else:
+            sample = f"{counts.get('pairs', 0)} pairs"
+        rows.append(
+            {
+                "Dataset": card.get("name", ""),
+                "Preset": source.get("preset") or metadata.get("source_preset", ""),
+                "Task": card.get("task_family", ""),
+                "Sample": sample,
+                "Source": source.get("source", ""),
+                "License": card.get("license", "unknown"),
+            }
+        )
+    return pd.DataFrame(
+        rows,
+        columns=["Dataset", "Preset", "Task", "Sample", "Source", "License"],
+    )
+
+
+def ready_made_leaderboard_values(artifact_path=READY_MADE_LEADERBOARD_PATH):
+    try:
+        payload = load_ready_made_leaderboard_payload(artifact_path)
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        return (
+            summary_panel_html(
+                "Ready-made Leaderboard",
+                [("Status", "Snapshot unavailable"), ("Reason", str(exc))],
+                variant="empty",
+            ),
+            pd.DataFrame(),
+            pd.DataFrame(),
+            pd.DataFrame(),
+            "",
+            None,
+        )
+    report = _leaderboard_report_from_payload(payload)
+    title = str(report["metadata"].get("name") or "Matheel Ready-made Leaderboard")
+    return (
+        ready_made_leaderboard_summary_html(report),
+        leaderboard_display_frame(report["aggregate"]),
+        leaderboard_display_frame(report["per_dataset"]),
+        ready_made_leaderboard_coverage_frame(report),
+        benchmark_report_html(report, title=title),
+        os.fspath(Path(artifact_path)),
+    )
+
+
 def leaderboard_display_frame(frame):
     display = frame.copy() if isinstance(frame, pd.DataFrame) else pd.DataFrame(frame)
     for column in ("score", "mean_score", "median_score"):
@@ -3393,6 +3487,9 @@ def get_sim_list_gradio(
         effective_chunking_method,
         runtime_device,
     ), results
+
+
+ready_made_initial = ready_made_leaderboard_values()
 
 
 with gr.Blocks(
@@ -5104,6 +5201,52 @@ with gr.Blocks(
                 padding=False,
             )
             with gr.Tabs(elem_classes=["matheel-subtabs"]):
+                with gr.Tab("Ready-made Leaderboard"):
+                    gr.Markdown(
+                        "Scores are precomputed across every registered public dataset preset and "
+                        "every built-in algorithm preset. The snapshot uses deterministic samples "
+                        "and the offline `static_hash` vector backend; use Build Leaderboard for a "
+                        "full-corpus or custom run."
+                    )
+                    ready_made_summary = gr.HTML(value=ready_made_initial[0], padding=False)
+                    ready_made_aggregate = gr.Dataframe(
+                        value=ready_made_initial[1],
+                        label="Ranked Algorithms",
+                        wrap=False,
+                        interactive=False,
+                        max_height=360,
+                        row_count=1,
+                        show_search="filter",
+                        elem_classes=["matheel-table"],
+                    )
+                    ready_made_per_dataset = gr.Dataframe(
+                        value=ready_made_initial[2],
+                        label="Per-Dataset Ranking",
+                        wrap=False,
+                        interactive=False,
+                        max_height=420,
+                        row_count=1,
+                        show_search="filter",
+                        elem_classes=["matheel-table"],
+                    )
+                    ready_made_coverage = gr.Dataframe(
+                        value=ready_made_initial[3],
+                        label="Dataset Coverage",
+                        wrap=False,
+                        interactive=False,
+                        max_height=280,
+                        row_count=1,
+                        show_search="filter",
+                        elem_classes=["matheel-table"],
+                    )
+                    with gr.Accordion("Static Report", open=False):
+                        ready_made_report = gr.HTML(value=ready_made_initial[4], padding=False)
+                    ready_made_artifact = gr.File(
+                        value=ready_made_initial[5],
+                        label="Ready-made Leaderboard JSON",
+                        interactive=False,
+                    )
+
                 with gr.Tab("Build Leaderboard"):
                     with gr.Row(elem_classes=["matheel-workflow-grid"]):
                         with gr.Column(scale=8, elem_classes=["matheel-results-panel"]):
@@ -5112,7 +5255,7 @@ with gr.Blocks(
                                 file_types=[".zip"],
                                 file_count="multiple",
                             )
-                            ready_run = gr.Button("Run Ready Leaderboard", variant="primary")
+                            ready_run = gr.Button("Run Custom Leaderboard", variant="primary")
                             ready_summary = gr.HTML(
                                 value=empty_ready_leaderboard_summary_html(),
                                 padding=False,

--- a/gradio_app/assets/ready_leaderboard.json
+++ b/gradio_app/assets/ready_leaderboard.json
@@ -1,0 +1,4212 @@
+{
+  "aggregate": [
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 5,
+      "mean_score": 0.7078125,
+      "median_score": 0.6875,
+      "metric": "accuracy",
+      "rank": 1,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 5,
+      "mean_score": 0.68125,
+      "median_score": 0.6875,
+      "metric": "accuracy",
+      "rank": 2,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 5,
+      "mean_score": 0.68125,
+      "median_score": 0.671875,
+      "metric": "accuracy",
+      "rank": 2,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 5,
+      "mean_score": 0.634375,
+      "median_score": 0.578125,
+      "metric": "accuracy",
+      "rank": 4,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 5,
+      "mean_score": 0.4984375,
+      "median_score": 0.5390625,
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 5,
+      "mean_score": 0.478125,
+      "median_score": 0.5,
+      "metric": "accuracy",
+      "rank": 6,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 5,
+      "mean_score": 0.4765625,
+      "median_score": 0.515625,
+      "metric": "accuracy",
+      "rank": 7,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 5,
+      "mean_score": 0.4546875,
+      "median_score": 0.5,
+      "metric": "accuracy",
+      "rank": 8,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 5,
+      "mean_score": 0.7466363572268625,
+      "median_score": 0.704833984375,
+      "metric": "auroc",
+      "rank": 1,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 5,
+      "mean_score": 0.7445820807531681,
+      "median_score": 0.7314453125,
+      "metric": "auroc",
+      "rank": 2,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 5,
+      "mean_score": 0.7423154206869239,
+      "median_score": 0.719482421875,
+      "metric": "auroc",
+      "rank": 3,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 5,
+      "mean_score": 0.736485605078725,
+      "median_score": 0.698974609375,
+      "metric": "auroc",
+      "rank": 4,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 5,
+      "mean_score": 0.7351649055539553,
+      "median_score": 0.7193603515625,
+      "metric": "auroc",
+      "rank": 5,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 5,
+      "mean_score": 0.7213825334821428,
+      "median_score": 0.710693359375,
+      "metric": "auroc",
+      "rank": 6,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 5,
+      "mean_score": 0.6788661074308755,
+      "median_score": 0.672607421875,
+      "metric": "auroc",
+      "rank": 7,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 5,
+      "mean_score": 0.6752092858942972,
+      "median_score": 0.6894009216589859,
+      "metric": "auroc",
+      "rank": 8,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 5,
+      "mean_score": 0.7758434116358421,
+      "median_score": 0.7501913247981334,
+      "metric": "average_precision",
+      "rank": 1,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 5,
+      "mean_score": 0.7751913428650271,
+      "median_score": 0.7326505640007483,
+      "metric": "average_precision",
+      "rank": 2,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 5,
+      "mean_score": 0.7730374155731103,
+      "median_score": 0.7490839658623487,
+      "metric": "average_precision",
+      "rank": 3,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 5,
+      "mean_score": 0.7719591787687496,
+      "median_score": 0.7568576748502717,
+      "metric": "average_precision",
+      "rank": 4,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 5,
+      "mean_score": 0.7633969213241152,
+      "median_score": 0.7094727169942896,
+      "metric": "average_precision",
+      "rank": 5,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 5,
+      "mean_score": 0.745278970827107,
+      "median_score": 0.716838188050789,
+      "metric": "average_precision",
+      "rank": 6,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 5,
+      "mean_score": 0.6954111123460163,
+      "median_score": 0.69745657628427,
+      "metric": "average_precision",
+      "rank": 7,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 5,
+      "mean_score": 0.68484791674822,
+      "median_score": 0.7044802802912479,
+      "metric": "average_precision",
+      "rank": 8,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 5,
+      "mean_score": 0.6570957853376644,
+      "median_score": 0.6262626262626262,
+      "metric": "f1",
+      "rank": 1,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 5,
+      "mean_score": 0.6552275825102655,
+      "median_score": 0.6407766990291262,
+      "metric": "f1",
+      "rank": 2,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 5,
+      "mean_score": 0.6279524199834177,
+      "median_score": 0.6666666666666667,
+      "metric": "f1",
+      "rank": 3,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 5,
+      "mean_score": 0.6260922092166901,
+      "median_score": 0.6595744680851063,
+      "metric": "f1",
+      "rank": 4,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 5,
+      "mean_score": 0.6222446418987392,
+      "median_score": 0.6666666666666666,
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 5,
+      "mean_score": 0.6178044641691685,
+      "median_score": 0.6666666666666666,
+      "metric": "f1",
+      "rank": 6,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 5,
+      "mean_score": 0.5707412937853459,
+      "median_score": 0.6021505376344085,
+      "metric": "f1",
+      "rank": 7,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 5,
+      "mean_score": 0.3455134718292613,
+      "median_score": 0.2702702702702703,
+      "metric": "f1",
+      "rank": 8,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 2,
+      "mean_score": 0.4861971639663393,
+      "median_score": 0.4861971639663393,
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 2,
+      "mean_score": 0.484009133828182,
+      "median_score": 0.484009133828182,
+      "metric": "mean_average_precision",
+      "rank": 2,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 2,
+      "mean_score": 0.46789295473157466,
+      "median_score": 0.46789295473157466,
+      "metric": "mean_average_precision",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 2,
+      "mean_score": 0.4678812607490513,
+      "median_score": 0.4678812607490513,
+      "metric": "mean_average_precision",
+      "rank": 4,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 2,
+      "mean_score": 0.4675716972816353,
+      "median_score": 0.4675716972816353,
+      "metric": "mean_average_precision",
+      "rank": 5,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 2,
+      "mean_score": 0.4663090541059761,
+      "median_score": 0.4663090541059761,
+      "metric": "mean_average_precision",
+      "rank": 6,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 2,
+      "mean_score": 0.46629849153388997,
+      "median_score": 0.46629849153388997,
+      "metric": "mean_average_precision",
+      "rank": 7,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 2,
+      "mean_score": 0.423693152955002,
+      "median_score": 0.423693152955002,
+      "metric": "mean_average_precision",
+      "rank": 8,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 2,
+      "mean_score": 0.4875399184340937,
+      "median_score": 0.4875399184340937,
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 2,
+      "mean_score": 0.48529709219334627,
+      "median_score": 0.48529709219334627,
+      "metric": "mean_reciprocal_rank",
+      "rank": 2,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 2,
+      "mean_score": 0.47108659642871853,
+      "median_score": 0.47108659642871853,
+      "metric": "mean_reciprocal_rank",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 2,
+      "mean_score": 0.46940774352553405,
+      "median_score": 0.46940774352553405,
+      "metric": "mean_reciprocal_rank",
+      "rank": 4,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 2,
+      "mean_score": 0.46916432428056115,
+      "median_score": 0.46916432428056115,
+      "metric": "mean_reciprocal_rank",
+      "rank": 5,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 2,
+      "mean_score": 0.467726812952353,
+      "median_score": 0.467726812952353,
+      "metric": "mean_reciprocal_rank",
+      "rank": 6,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 2,
+      "mean_score": 0.4676196888948147,
+      "median_score": 0.4676196888948147,
+      "metric": "mean_reciprocal_rank",
+      "rank": 7,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 2,
+      "mean_score": 0.4250831335221499,
+      "median_score": 0.4250831335221499,
+      "metric": "mean_reciprocal_rank",
+      "rank": 8,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 2,
+      "mean_score": 0.4881390949598624,
+      "median_score": 0.4881390949598624,
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 2,
+      "mean_score": 0.48697930624809116,
+      "median_score": 0.48697930624809116,
+      "metric": "ndcg_at_k",
+      "rank": 2,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 2,
+      "mean_score": 0.4786324953562618,
+      "median_score": 0.4786324953562618,
+      "metric": "ndcg_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 2,
+      "mean_score": 0.4729494056776412,
+      "median_score": 0.4729494056776412,
+      "metric": "ndcg_at_k",
+      "rank": 4,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 2,
+      "mean_score": 0.47268949508884917,
+      "median_score": 0.47268949508884917,
+      "metric": "ndcg_at_k",
+      "rank": 5,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 2,
+      "mean_score": 0.47246223082992017,
+      "median_score": 0.47246223082992017,
+      "metric": "ndcg_at_k",
+      "rank": 6,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 2,
+      "mean_score": 0.46730576162652904,
+      "median_score": 0.46730576162652904,
+      "metric": "ndcg_at_k",
+      "rank": 7,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 2,
+      "mean_score": 0.4453344632590881,
+      "median_score": 0.4453344632590881,
+      "metric": "ndcg_at_k",
+      "rank": 8,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 2,
+      "mean_score": 0.060416666666666674,
+      "median_score": 0.060416666666666674,
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 2,
+      "mean_score": 0.060416666666666674,
+      "median_score": 0.060416666666666674,
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 2,
+      "mean_score": 0.05833333333333334,
+      "median_score": 0.05833333333333334,
+      "metric": "precision_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 2,
+      "mean_score": 0.05833333333333334,
+      "median_score": 0.05833333333333334,
+      "metric": "precision_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 2,
+      "mean_score": 0.05833333333333334,
+      "median_score": 0.05833333333333334,
+      "metric": "precision_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 2,
+      "mean_score": 0.058333333333333334,
+      "median_score": 0.058333333333333334,
+      "metric": "precision_at_k",
+      "rank": 6,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 2,
+      "mean_score": 0.058333333333333334,
+      "median_score": 0.058333333333333334,
+      "metric": "precision_at_k",
+      "rank": 6,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 2,
+      "mean_score": 0.05625000000000001,
+      "median_score": 0.05625000000000001,
+      "metric": "precision_at_k",
+      "rank": 8,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 2,
+      "mean_score": 0.5416666666666667,
+      "median_score": 0.5416666666666667,
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 2,
+      "mean_score": 0.5416666666666667,
+      "median_score": 0.5416666666666667,
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 2,
+      "mean_score": 0.5208333333333334,
+      "median_score": 0.5208333333333334,
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 2,
+      "mean_score": 0.5208333333333334,
+      "median_score": 0.5208333333333334,
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 2,
+      "mean_score": 0.5208333333333334,
+      "median_score": 0.5208333333333334,
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 2,
+      "mean_score": 0.5208333333333334,
+      "median_score": 0.5208333333333334,
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 2,
+      "mean_score": 0.5208333333333334,
+      "median_score": 0.5208333333333334,
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 2,
+      "mean_score": 0.5,
+      "median_score": 0.5,
+      "metric": "recall_at_k",
+      "rank": 8,
+      "sample_count": 1704,
+      "task_family": "retrieval"
+    }
+  ],
+  "cards": {
+    "algorithms": [
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "Balanced",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "levenshtein": 0.3,
+            "semantic": 0.7
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      },
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "Lexical Only",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "gst": 0.25,
+            "levenshtein": 0.5,
+            "winnowing": 0.25
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      },
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "Embedding Only",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "semantic": 1.0
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      },
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "Code-Aware",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.25,
+          "device": "cpu",
+          "feature_weights": {
+            "code_metric": 0.25,
+            "levenshtein": 0.25,
+            "semantic": 0.5
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      },
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "Jaro-Winkler",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "jaro_winkler": 1.0
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      },
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "Winnowing",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "winnowing": 1.0
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      },
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "GST",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "gst": 1.0
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      },
+      {
+        "algorithm_kind": "builtin",
+        "algorithm_options": {},
+        "algorithm_path_name": "",
+        "card_type": "algorithm",
+        "fingerprint": {},
+        "name": "CodeBLEU",
+        "package": "",
+        "package_version": "",
+        "schema_version": 1,
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 1.0,
+          "device": "cpu",
+          "feature_weights": {
+            "code_metric": 1.0
+          },
+          "k": null,
+          "static_vector_dim": 256,
+          "threshold": null,
+          "vector_backend": "static_hash"
+        }
+      }
+    ],
+    "datasets": [
+      {
+        "card_type": "dataset",
+        "counts": {
+          "files": 216,
+          "pairs": 128,
+          "positive_pairs": 64
+        },
+        "dataset_kind": "pair_classification",
+        "fingerprint": {
+          "file_count": 219,
+          "sha256": "9e8922008a5b6c4cdedbfc783964ab24e0046166c3a21683c217087c905f1b62",
+          "source_type": "directory",
+          "total_bytes": 806205
+        },
+        "license": "CC-BY-4.0",
+        "metadata": {
+          "benchmark_sample": {
+            "corpus_limit": 64,
+            "pair_limit": 128,
+            "query_limit": 24,
+            "sampled_pairs": 128,
+            "seed": 7,
+            "source_pairs": 911
+          },
+          "dataset_kind": "pair_classification",
+          "license": "CC-BY-4.0",
+          "name": "conplag",
+          "source_preset": "conplag",
+          "source_url": "https://zenodo.org/records/7332790",
+          "task_type": "plagiarism"
+        },
+        "name": "conplag",
+        "schema_version": 1,
+        "source": {
+          "identifier": "7332790",
+          "preset": "conplag",
+          "source": "zenodo",
+          "url": "https://zenodo.org/records/7332790"
+        },
+        "source_url": "https://zenodo.org/records/7332790",
+        "task_family": "pair",
+        "task_type": "plagiarism"
+      },
+      {
+        "card_type": "dataset",
+        "counts": {
+          "files": 45,
+          "pairs": 128,
+          "positive_pairs": 35
+        },
+        "dataset_kind": "pair_classification",
+        "fingerprint": {
+          "file_count": 48,
+          "sha256": "dfd20c00072ab89be6d2342103e2310df610ebe177beab39776a441733d9c190",
+          "source_type": "directory",
+          "total_bytes": 865364
+        },
+        "license": "CC-BY-4.0",
+        "metadata": {
+          "benchmark_sample": {
+            "corpus_limit": 64,
+            "pair_limit": 128,
+            "query_limit": 24,
+            "sampled_pairs": 128,
+            "seed": 7,
+            "source_pairs": 350
+          },
+          "dataset_kind": "pair_classification",
+          "license": "CC-BY-4.0",
+          "name": "criminal_minds",
+          "source_preset": "criminal_minds",
+          "source_url": "https://zenodo.org/records/19115559",
+          "task_type": "plagiarism"
+        },
+        "name": "criminal_minds",
+        "schema_version": 1,
+        "source": {
+          "identifier": "19115559",
+          "preset": "criminal_minds",
+          "source": "zenodo",
+          "url": "https://zenodo.org/records/19115559"
+        },
+        "source_url": "https://zenodo.org/records/19115559",
+        "task_family": "pair",
+        "task_type": "plagiarism"
+      },
+      {
+        "card_type": "dataset",
+        "counts": {
+          "files": 60,
+          "pairs": 128,
+          "positive_pairs": 64
+        },
+        "dataset_kind": "pair_classification",
+        "fingerprint": {
+          "file_count": 63,
+          "sha256": "b66270e2bf3ce4a26214afa713dc622d626a57ed173627d454087e6424fd242f",
+          "source_type": "directory",
+          "total_bytes": 38901
+        },
+        "license": "GPL-3.0",
+        "metadata": {
+          "benchmark_sample": {
+            "corpus_limit": 64,
+            "pair_limit": 128,
+            "query_limit": 24,
+            "sampled_pairs": 128,
+            "seed": 7,
+            "source_pairs": 470
+          },
+          "dataset_kind": "pair_classification",
+          "license": "GPL-3.0",
+          "name": "ipca",
+          "source_preset": "ipca",
+          "source_url": "https://github.com/humsha/IPCA",
+          "task_type": "plagiarism"
+        },
+        "name": "ipca",
+        "schema_version": 1,
+        "source": {
+          "identifier": "humsha/IPCA",
+          "preset": "ipca",
+          "source": "github",
+          "url": "https://github.com/humsha/IPCA"
+        },
+        "source_url": "https://github.com/humsha/IPCA",
+        "task_family": "pair",
+        "task_type": "plagiarism"
+      },
+      {
+        "card_type": "dataset",
+        "counts": {
+          "files": 135,
+          "pairs": 128,
+          "positive_pairs": 64
+        },
+        "dataset_kind": "pair_classification",
+        "fingerprint": {
+          "file_count": 138,
+          "sha256": "d2fb324801cc5eeaf31253b0813ef4bd906b2d7882338e2b6f41ae794515ee67",
+          "source_type": "directory",
+          "total_bytes": 112218
+        },
+        "license": "Apache-2.0",
+        "metadata": {
+          "benchmark_sample": {
+            "corpus_limit": 64,
+            "pair_limit": 128,
+            "query_limit": 24,
+            "sampled_pairs": 128,
+            "seed": 7,
+            "source_pairs": 460
+          },
+          "dataset_kind": "pair_classification",
+          "license": "Apache-2.0",
+          "name": "irplag_pair",
+          "source_preset": "irplag",
+          "source_url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset",
+          "task_type": "plagiarism"
+        },
+        "name": "irplag_pair",
+        "schema_version": 1,
+        "source": {
+          "identifier": "oscarkarnalim/sourcecodeplagiarismdataset",
+          "preset": "irplag",
+          "source": "github",
+          "url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset"
+        },
+        "source_url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset",
+        "task_family": "pair",
+        "task_type": "plagiarism"
+      },
+      {
+        "card_type": "dataset",
+        "counts": {
+          "documents": 7,
+          "files": 31,
+          "qrels": 24,
+          "queries": 24
+        },
+        "dataset_kind": "retrieval",
+        "fingerprint": {
+          "file_count": 36,
+          "sha256": "d28ec578ca90d25ef2c69ba9d34b6485c96c635f66a60a68ca2a77429919d2a0",
+          "source_type": "directory",
+          "total_bytes": 28670
+        },
+        "license": "Apache-2.0",
+        "metadata": {
+          "benchmark_sample": {
+            "corpus_limit": 64,
+            "pair_limit": 128,
+            "query_limit": 24,
+            "sampled_documents": 7,
+            "sampled_queries": 24,
+            "seed": 7,
+            "source_documents": 7,
+            "source_queries": 460
+          },
+          "dataset_kind": "retrieval",
+          "license": "Apache-2.0",
+          "name": "irplag_retrieval",
+          "source_preset": "irplag",
+          "source_url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset",
+          "task_type": "plagiarism"
+        },
+        "name": "irplag_retrieval",
+        "schema_version": 1,
+        "source": {
+          "identifier": "oscarkarnalim/sourcecodeplagiarismdataset",
+          "preset": "irplag",
+          "source": "github",
+          "url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset"
+        },
+        "source_url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset",
+        "task_family": "retrieval",
+        "task_type": "plagiarism"
+      },
+      {
+        "card_type": "dataset",
+        "counts": {
+          "documents": 64,
+          "files": 88,
+          "qrels": 29,
+          "queries": 24
+        },
+        "dataset_kind": "retrieval",
+        "fingerprint": {
+          "file_count": 93,
+          "sha256": "9eeb48e104af02df1dfafec0908e4724602b56bb59c66ba39ad4988e8d5a30c2",
+          "source_type": "directory",
+          "total_bytes": 194954
+        },
+        "license": "unknown",
+        "metadata": {
+          "benchmark_sample": {
+            "corpus_limit": 64,
+            "pair_limit": 128,
+            "query_limit": 24,
+            "sampled_documents": 64,
+            "sampled_queries": 24,
+            "seed": 7,
+            "source_documents": 469,
+            "source_queries": 464
+          },
+          "dataset_kind": "retrieval",
+          "license": "unknown",
+          "name": "soco14",
+          "source_preset": "soco14",
+          "source_url": "https://zenodo.org/records/7433031",
+          "task_type": "plagiarism"
+        },
+        "name": "soco14",
+        "schema_version": 1,
+        "source": {
+          "identifier": "7433031",
+          "preset": "soco14",
+          "source": "zenodo",
+          "url": "https://zenodo.org/records/7433031"
+        },
+        "source_url": "https://zenodo.org/records/7433031",
+        "task_family": "retrieval",
+        "task_type": "plagiarism"
+      },
+      {
+        "card_type": "dataset",
+        "counts": {
+          "files": 142,
+          "pairs": 128,
+          "positive_pairs": 64
+        },
+        "dataset_kind": "pair_classification",
+        "fingerprint": {
+          "file_count": 145,
+          "sha256": "2807e39d8966c680d3c7a60532f3363999096fb051afda0e8e8a4fd05059d486",
+          "source_type": "directory",
+          "total_bytes": 147006
+        },
+        "license": "unknown",
+        "metadata": {
+          "benchmark_sample": {
+            "corpus_limit": 64,
+            "pair_limit": 128,
+            "query_limit": 24,
+            "sampled_pairs": 128,
+            "seed": 7,
+            "source_pairs": 293
+          },
+          "dataset_kind": "pair_classification",
+          "license": "unknown",
+          "name": "student_code_similarity",
+          "source_preset": "student_code_similarity",
+          "source_url": "https://www.kaggle.com/datasets/ehsankhani/student-code-similarity-and-plagiarism-labels",
+          "task_type": "plagiarism"
+        },
+        "name": "student_code_similarity",
+        "schema_version": 1,
+        "source": {
+          "identifier": "ehsankhani/student-code-similarity-and-plagiarism-labels",
+          "preset": "student_code_similarity",
+          "source": "kaggle",
+          "url": "https://www.kaggle.com/datasets/ehsankhani/student-code-similarity-and-plagiarism-labels"
+        },
+        "source_url": "https://www.kaggle.com/datasets/ehsankhani/student-code-similarity-and-plagiarism-labels",
+        "task_family": "pair",
+        "task_type": "plagiarism"
+      }
+    ]
+  },
+  "manifest": {
+    "algorithms": [
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "Balanced",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "levenshtein": 0.3,
+            "semantic": 0.7
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      },
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "Lexical Only",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "gst": 0.25,
+            "levenshtein": 0.5,
+            "winnowing": 0.25
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      },
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "Embedding Only",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "semantic": 1.0
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      },
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "Code-Aware",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.25,
+          "device": "cpu",
+          "feature_weights": {
+            "code_metric": 0.25,
+            "levenshtein": 0.25,
+            "semantic": 0.5
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      },
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "Jaro-Winkler",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "jaro_winkler": 1.0
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      },
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "Winnowing",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "winnowing": 1.0
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      },
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "GST",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 0.0,
+          "device": "cpu",
+          "feature_weights": {
+            "gst": 1.0
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      },
+      {
+        "algorithm_options": {},
+        "algorithm_path": null,
+        "k": null,
+        "name": "CodeBLEU",
+        "similarity_options": {
+          "code_metric": "codebleu",
+          "code_metric_weight": 1.0,
+          "device": "cpu",
+          "feature_weights": {
+            "code_metric": 1.0
+          },
+          "static_vector_dim": 256,
+          "vector_backend": "static_hash"
+        },
+        "threshold": null
+      }
+    ],
+    "datasets": [
+      {
+        "k": null,
+        "name": "conplag",
+        "similarity_options": {
+          "code_language": "java"
+        },
+        "spec": {
+          "identifier": "7332790",
+          "name": "conplag",
+          "preset": "conplag",
+          "source": "zenodo",
+          "task_families": [
+            "pair"
+          ],
+          "url": "https://zenodo.org/records/7332790"
+        },
+        "task_family": "pair",
+        "threshold": 0.5
+      },
+      {
+        "k": null,
+        "name": "criminal_minds",
+        "similarity_options": {
+          "code_language": "java"
+        },
+        "spec": {
+          "identifier": "19115559",
+          "name": "criminal_minds",
+          "preset": "criminal_minds",
+          "source": "zenodo",
+          "task_families": [
+            "pair"
+          ],
+          "url": "https://zenodo.org/records/19115559"
+        },
+        "task_family": "pair",
+        "threshold": 0.5
+      },
+      {
+        "k": null,
+        "name": "ipca",
+        "similarity_options": {
+          "code_language": "cpp"
+        },
+        "spec": {
+          "identifier": "humsha/IPCA",
+          "name": "ipca",
+          "preset": "ipca",
+          "source": "github",
+          "task_families": [
+            "pair"
+          ],
+          "url": "https://github.com/humsha/IPCA"
+        },
+        "task_family": "pair",
+        "threshold": 0.5
+      },
+      {
+        "k": null,
+        "name": "irplag_pair",
+        "similarity_options": {
+          "code_language": "java"
+        },
+        "spec": {
+          "identifier": "oscarkarnalim/sourcecodeplagiarismdataset",
+          "name": "irplag_pair",
+          "preset": "irplag",
+          "source": "github",
+          "task_families": [
+            "pair"
+          ],
+          "url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset"
+        },
+        "task_family": "pair",
+        "threshold": 0.5
+      },
+      {
+        "k": 10,
+        "name": "irplag_retrieval",
+        "similarity_options": {
+          "code_language": "java"
+        },
+        "spec": {
+          "identifier": "oscarkarnalim/sourcecodeplagiarismdataset",
+          "name": "irplag_retrieval",
+          "preset": "irplag",
+          "source": "github",
+          "task_families": [
+            "retrieval"
+          ],
+          "url": "https://github.com/oscarkarnalim/sourcecodeplagiarismdataset"
+        },
+        "task_family": "retrieval",
+        "threshold": null
+      },
+      {
+        "k": 10,
+        "name": "soco14",
+        "similarity_options": {
+          "code_language": "cpp"
+        },
+        "spec": {
+          "identifier": "7433031",
+          "name": "soco14",
+          "preset": "soco14",
+          "source": "zenodo",
+          "task_families": [
+            "retrieval"
+          ],
+          "url": "https://zenodo.org/records/7433031"
+        },
+        "task_family": "retrieval",
+        "threshold": null
+      },
+      {
+        "k": null,
+        "name": "student_code_similarity",
+        "similarity_options": {
+          "code_language": "python"
+        },
+        "spec": {
+          "identifier": "ehsankhani/student-code-similarity-and-plagiarism-labels",
+          "name": "student_code_similarity",
+          "preset": "student_code_similarity",
+          "source": "kaggle",
+          "task_families": [
+            "pair"
+          ],
+          "url": "https://www.kaggle.com/datasets/ehsankhani/student-code-similarity-and-plagiarism-labels"
+        },
+        "task_family": "pair",
+        "threshold": 0.5
+      }
+    ],
+    "name": "Matheel Ready-made Public Leaderboard",
+    "pair_metrics": [
+      "f1",
+      "accuracy",
+      "auroc",
+      "average_precision"
+    ],
+    "retrieval_metrics": [
+      "mean_average_precision",
+      "mean_reciprocal_rank",
+      "ndcg_at_k",
+      "precision_at_k",
+      "recall_at_k"
+    ],
+    "schema_version": 1,
+    "seed": 7
+  },
+  "metadata": {
+    "benchmark_profile": {
+      "algorithm_presets": [
+        "Balanced",
+        "Lexical Only",
+        "Embedding Only",
+        "Code-Aware",
+        "Jaro-Winkler",
+        "Winnowing",
+        "GST",
+        "CodeBLEU"
+      ],
+      "dataset_presets": [
+        "conplag",
+        "criminal_minds",
+        "ipca",
+        "irplag",
+        "soco14",
+        "student_code_similarity"
+      ],
+      "dataset_task_count": 7,
+      "generated_at": "2026-07-16T17:03:12+00:00",
+      "pair_sample_limit": 128,
+      "profile": "sampled_public_snapshot",
+      "retrieval_corpus_limit": 64,
+      "retrieval_query_limit": 24,
+      "seed": 7,
+      "static_vector_dim": 256,
+      "vector_backend": "static_hash"
+    },
+    "name": "Matheel Ready-made Public Leaderboard",
+    "pair_metrics": [
+      "f1",
+      "accuracy",
+      "auroc",
+      "average_precision"
+    ],
+    "retrieval_metrics": [
+      "mean_average_precision",
+      "mean_reciprocal_rank",
+      "ndcg_at_k",
+      "precision_at_k",
+      "recall_at_k"
+    ],
+    "schema_version": 1,
+    "seed": 7
+  },
+  "per_dataset": [
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7109375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.6875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.671875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6640625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5234375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.75341796875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7518310546875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.74609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.710693359375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6943359375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.68359375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.6751708984375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.6329345703125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7568576748502717,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7501913247981334,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.7490839658623487,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.716838188050789,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.7094727169942896,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.7044802802912479,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.69745657628427,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.6881926897189472,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.6736842105263158,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.6666666666666666,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.6666666666666666,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6595744680851063,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6407766990291262,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.574468085106383,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5531914893617021,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.5274725274725275,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.9140625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.890625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.8515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.8046875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.9674347158218122,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.9585253456221196,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.9514592933947766,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.9348694316436247,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.9281105990783404,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.9142857142857137,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.8230414746543776,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "auroc",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.6894009216589859,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.9621114778900307,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.9521990356227357,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.9520640732265446,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.9279852488185821,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.9265109893880616,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.8978228694826491,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.7799214664690306,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "average_precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.6156912326537285,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.8135593220338984,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7499999999999999,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.6274509803921569,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.4444444444444445,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.4294478527607362,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.4294478527607362,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.4294478527607362,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.4294478527607362,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7109375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7109375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.6875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.5625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.5625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.4921875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7314453125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.730224609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.719482421875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.719482421875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.7193603515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.7109375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.704833984375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.672607421875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7998428400706629,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7926967435339002,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.7916713877086519,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.7895330579217847,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.7895168308762787,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.7746851430113617,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.7718224475801972,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.7174157090998402,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.6666666666666666,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.6666666666666666,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.656084656084656,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6363636363636365,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6262626262626262,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.6021505376344085,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5918367346938775,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.2222222222222222,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.6015625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.59375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.578125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.578125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "accuracy",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.6995849609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.681884765625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.665283203125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.64501953125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.634765625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.623291015625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.60400390625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.5458984375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7469214184197887,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7287596311467154,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.6981018276706048,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6897697807190576,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6784288381525189,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.6660539783541585,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.6557264967855821,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "average_precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.6021717642135509,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7150837988826816,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7032967032967034,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.7011494252873562,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6666666666666666,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6585365853658537,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.6164383561643836,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.4615384615384615,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "f1",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.2702702702702703,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.6875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.5625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.5390625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.53125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.5234375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "accuracy",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.74853515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7353515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.698974609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6669921875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6640625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.6148681640625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.591796875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "auroc",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.559326171875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7326505640007483,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.7300738590023756,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.7084010591212848,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6876114168502041,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6813221568051532,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.6631205248238571,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.6254462326482182,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "average_precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.6162078315227816,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.7183098591549296,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.6775956284153005,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.6702702702702702,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.6666666666666667,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6595744680851063,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5714285714285714,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "f1",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.2631578947368421,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 7,
+      "sample_count": 168,
+      "score": 0.6770833333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_average_precision",
+      "rank": 8,
+      "sample_count": 168,
+      "score": 0.5736111111111111,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 7,
+      "sample_count": 168,
+      "score": 0.6770833333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "mean_reciprocal_rank",
+      "rank": 8,
+      "sample_count": 168,
+      "score": 0.5736111111111111,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 7,
+      "sample_count": 168,
+      "score": 0.6846115232530581,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "ndcg_at_k",
+      "rank": 8,
+      "sample_count": 168,
+      "score": 0.6048652337004853,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.07083333333333335,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_retrieval",
+      "dataset_source": "github",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 168,
+      "score": 0.7083333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 1,
+      "sample_count": 1536,
+      "score": 0.27377519479889284,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 2,
+      "sample_count": 1536,
+      "score": 0.2640609945993451,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.2596849343230307,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 4,
+      "sample_count": 1536,
+      "score": 0.2555347748786189,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 5,
+      "sample_count": 1536,
+      "score": 0.22745257612981598,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 6,
+      "sample_count": 1536,
+      "score": 0.22742918816476917,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 7,
+      "sample_count": 1536,
+      "score": 0.22681006122993716,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_average_precision",
+      "rank": 8,
+      "sample_count": 1536,
+      "score": 0.22426364973444654,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 1,
+      "sample_count": 1536,
+      "score": 0.27655515593318863,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 2,
+      "sample_count": 1536,
+      "score": 0.266746503534854,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.26226085105335917,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 4,
+      "sample_count": 1536,
+      "score": 0.2583702925713727,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 5,
+      "sample_count": 1536,
+      "score": 0.2338398595241037,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 6,
+      "sample_count": 1536,
+      "score": 0.23048215371773473,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 7,
+      "sample_count": 1536,
+      "score": 0.2299953152277889,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "mean_reciprocal_rank",
+      "rank": 8,
+      "sample_count": 1536,
+      "score": 0.22690604445629606,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 1,
+      "sample_count": 1536,
+      "score": 0.28580369281769086,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 2,
+      "sample_count": 1536,
+      "score": 0.2679448565863914,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.2656252791628489,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 4,
+      "sample_count": 1536,
+      "score": 0.2607674669246403,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 5,
+      "sample_count": 1536,
+      "score": 0.2489316573791902,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 6,
+      "sample_count": 1536,
+      "score": 0.23756547802194908,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 7,
+      "sample_count": 1536,
+      "score": 0.23659112832650694,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "ndcg_at_k",
+      "rank": 8,
+      "sample_count": 1536,
+      "score": 0.2262781899197247,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 1,
+      "sample_count": 1536,
+      "score": 0.05000000000000001,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 2,
+      "sample_count": 1536,
+      "score": 0.049999999999999996,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.04583333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.04583333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.04583333333333334,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 6,
+      "sample_count": 1536,
+      "score": 0.04583333333333333,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 6,
+      "sample_count": 1536,
+      "score": 0.04583333333333333,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "precision_at_k",
+      "rank": 8,
+      "sample_count": 1536,
+      "score": 0.04166666666666668,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 1536,
+      "score": 0.375,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 1,
+      "sample_count": 1536,
+      "score": 0.375,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.3333333333333333,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.3333333333333333,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.3333333333333333,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.3333333333333333,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 3,
+      "sample_count": 1536,
+      "score": 0.3333333333333333,
+      "task_family": "retrieval"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "soco14",
+      "dataset_source": "zenodo",
+      "metric": "recall_at_k",
+      "rank": 8,
+      "sample_count": 1536,
+      "score": 0.2916666666666667,
+      "task_family": "retrieval"
+    }
+  ],
+  "schema_version": 1
+}

--- a/matheel/datasets.py
+++ b/matheel/datasets.py
@@ -2213,20 +2213,27 @@ def _find_conplag_versions_root(source_root):
     return None
 
 
-def _find_conplag_submission_file(versions_root, problem, submission):
+def _index_conplag_submission_files(versions_root):
+    base = _coerce_path(versions_root)
+    files_by_stem = {}
+    for path in sorted(candidate for candidate in base.rglob("*") if candidate.is_file()):
+        files_by_stem.setdefault(path.stem, []).append(path)
+    return files_by_stem
+
+
+def _find_conplag_submission_file(versions_root, problem, submission, files_by_stem=None):
     base = _coerce_path(versions_root)
     problem_text = str(problem).strip()
     submission_text = str(submission).strip()
-    search_roots = []
+    index = files_by_stem if files_by_stem is not None else _index_conplag_submission_files(base)
+    matches = index.get(submission_text, ())
     if problem_text:
-        search_roots.append(base / f"version_{problem_text}")
-    search_roots.append(base)
-    for search_root in search_roots:
-        if not search_root.exists():
-            continue
-        matches = sorted(search_root.rglob(f"{submission_text}.*"))
-        if matches:
-            return matches[0]
+        problem_root = base / f"version_{problem_text}"
+        for match in matches:
+            if _is_relative_to(match, problem_root):
+                return match
+    if matches:
+        return matches[0]
     return None
 
 
@@ -2251,10 +2258,21 @@ def _adapt_conplag_pair_dataset(source_root, destination, dataset_name=None, **o
     files = []
     file_ids_by_key = {}
     pairs = []
+    files_by_stem = _index_conplag_submission_files(versions_root)
     for row in labels.to_dict(orient="records"):
         problem = row.get(problem_col) if problem_col else ""
-        left_path = _find_conplag_submission_file(versions_root, problem, row[left_col])
-        right_path = _find_conplag_submission_file(versions_root, problem, row[right_col])
+        left_path = _find_conplag_submission_file(
+            versions_root,
+            problem,
+            row[left_col],
+            files_by_stem=files_by_stem,
+        )
+        right_path = _find_conplag_submission_file(
+            versions_root,
+            problem,
+            row[right_col],
+            files_by_stem=files_by_stem,
+        )
         if left_path is None or right_path is None:
             continue
         left_id = _add_tabular_file(
@@ -2805,20 +2823,25 @@ def _resolve_kaggle_dataset_source(identifier, destination, revision="main", tok
         from kaggle.api.kaggle_api_extended import KaggleApi
     except ImportError:
         kaggle_binary = shutil.which("kaggle")
-        if kaggle_binary is None:
-            raise ImportError("Kaggle dataset resolution requires the optional Kaggle API or CLI.")
-        subprocess.run(
-            [
-                kaggle_binary,
-                "datasets",
-                "download",
-                "-d",
-                str(identifier),
-                "-p",
-                os.fspath(destination),
-            ],
-            check=True,
-        )
+        if kaggle_binary is not None:
+            subprocess.run(
+                [
+                    kaggle_binary,
+                    "datasets",
+                    "download",
+                    "-d",
+                    str(identifier),
+                    "-p",
+                    os.fspath(destination),
+                ],
+                check=True,
+            )
+        else:
+            dataset_path = urllib.parse.quote(str(identifier).strip(), safe="/")
+            _download_url_to_file(
+                f"https://www.kaggle.com/api/v1/datasets/download/{dataset_path}",
+                destination / "kaggle_dataset.zip",
+            )
         return _extract_downloaded_archives(destination)
 
     api = KaggleApi()

--- a/matheel/leaderboard.py
+++ b/matheel/leaderboard.py
@@ -220,7 +220,7 @@ def _evaluate_pair_leaderboard_run(manifest, dataset_config, algorithm_config):
     scored, metrics = evaluate_pair_dataset(
         dataset,
         threshold=float(_first_not_none(algorithm_config.get("threshold"), dataset_config.get("threshold"), 0.5)),
-        similarity_options=algorithm_config["similarity_options"],
+        similarity_options=_leaderboard_similarity_options(dataset_config, algorithm_config),
         algorithm=algorithm_config.get("algorithm_path"),
         algorithm_options=algorithm_config.get("algorithm_options"),
     )
@@ -250,7 +250,7 @@ def _evaluate_retrieval_leaderboard_run(manifest, dataset_config, algorithm_conf
     scored, metrics = evaluate_retrieval_dataset(
         dataset,
         k=int(_first_not_none(algorithm_config.get("k"), dataset_config.get("k"), 10)),
-        similarity_options=algorithm_config["similarity_options"],
+        similarity_options=_leaderboard_similarity_options(dataset_config, algorithm_config),
         algorithm=algorithm_config.get("algorithm_path"),
         algorithm_options=algorithm_config.get("algorithm_options"),
     )
@@ -265,6 +265,13 @@ def _evaluate_retrieval_leaderboard_run(manifest, dataset_config, algorithm_conf
         )
         for metric in manifest["retrieval_metrics"]
     ]
+
+
+def _leaderboard_similarity_options(dataset_config, algorithm_config):
+    return {
+        **algorithm_config["similarity_options"],
+        **dataset_config.get("similarity_options", {}),
+    }
 
 
 def _leaderboard_row(task_family, dataset_config, algorithm_config, metric, value, sample_count):
@@ -330,6 +337,7 @@ def _normalize_leaderboard_dataset(item, index=1, base_dir=None):
     payload.pop("task", None)
     payload.pop("task_family", None)
     payload.pop("kind", None)
+    similarity_options = dict(payload.pop("similarity_options", {}))
     name = str(payload.get("name") or f"{task_family}_dataset_{index}")
     payload["name"] = name
     payload["task_families"] = (task_family,)
@@ -340,6 +348,7 @@ def _normalize_leaderboard_dataset(item, index=1, base_dir=None):
         "spec": payload,
         "threshold": item.get("threshold"),
         "k": item.get("k"),
+        "similarity_options": similarity_options,
     }
 
 

--- a/scripts/build_ready_leaderboard.py
+++ b/scripts/build_ready_leaderboard.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Build the sampled public leaderboard displayed by the Gradio app."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from matheel.datasets import (
+    available_dataset_presets,
+    get_dataset_preset,
+    load_code_texts,
+    load_pair_datasets,
+    load_retrieval_datasets,
+    write_pair_dataset,
+    write_retrieval_dataset,
+)
+from matheel.leaderboard import run_leaderboard, write_leaderboard_artifacts
+from matheel.leaderboard_presets import available_leaderboard_algorithm_presets
+
+
+DEFAULT_OUTPUT = Path("gradio_app/assets/ready_leaderboard.json")
+DATASET_LANGUAGES = {
+    "conplag": "java",
+    "criminal_minds": "java",
+    "ipca": "cpp",
+    "irplag": "java",
+    "soco14": "cpp",
+    "student_code_similarity": "python",
+}
+DATASET_LICENSES = {
+    "conplag": "CC-BY-4.0",
+    "criminal_minds": "CC-BY-4.0",
+    "ipca": "GPL-3.0",
+    "irplag": "Apache-2.0",
+    "soco14": "unknown",
+    "student_code_similarity": "unknown",
+}
+PAIR_METRICS = ("f1", "accuracy", "auroc", "average_precision")
+RETRIEVAL_METRICS = (
+    "mean_average_precision",
+    "mean_reciprocal_rank",
+    "ndcg_at_k",
+    "precision_at_k",
+    "recall_at_k",
+)
+
+
+def build_ready_leaderboard(
+    output_path,
+    work_dir,
+    *,
+    seed=7,
+    pair_sample_limit=128,
+    retrieval_query_limit=24,
+    retrieval_corpus_limit=64,
+):
+    output = Path(output_path)
+    workspace = Path(work_dir)
+    raw_root = workspace / "raw"
+    normalized_root = workspace / "normalized"
+    sampled_root = workspace / "sampled"
+    artifact_root = workspace / "artifacts"
+    for path in (raw_root, normalized_root, sampled_root, artifact_root):
+        path.mkdir(parents=True, exist_ok=True)
+
+    dataset_configs = []
+    dataset_sources = {}
+    for preset_name in available_dataset_presets():
+        preset = get_dataset_preset(preset_name)
+        for task_family in preset["task_families"]:
+            dataset_name = _dataset_task_name(preset_name, task_family, preset["task_families"])
+            print(f"Preparing {dataset_name}...", flush=True)
+            normalized = _load_preset_dataset(
+                preset_name,
+                task_family,
+                raw_root=raw_root,
+                normalized_root=normalized_root,
+            )
+            sample_destination = sampled_root / dataset_name
+            metadata = _sample_metadata(
+                preset_name,
+                preset,
+                task_family,
+                seed=seed,
+                pair_sample_limit=pair_sample_limit,
+                retrieval_query_limit=retrieval_query_limit,
+                retrieval_corpus_limit=retrieval_corpus_limit,
+            )
+            if task_family == "pair":
+                sample_path = _sample_pair_dataset(
+                    normalized,
+                    sample_destination,
+                    limit=pair_sample_limit,
+                    seed=seed,
+                    metadata=metadata,
+                )
+                task_defaults = {"threshold": 0.5}
+            else:
+                sample_path = _sample_retrieval_dataset(
+                    normalized,
+                    sample_destination,
+                    query_limit=retrieval_query_limit,
+                    corpus_limit=retrieval_corpus_limit,
+                    seed=seed,
+                    metadata=metadata,
+                )
+                task_defaults = {"k": 10}
+            dataset_configs.append(
+                {
+                    "name": dataset_name,
+                    "task": task_family,
+                    "path": str(sample_path),
+                    "similarity_options": {
+                        "code_language": DATASET_LANGUAGES[preset_name],
+                    },
+                    **task_defaults,
+                }
+            )
+            dataset_sources[dataset_name] = {
+                "preset": preset_name,
+                "source": preset["source"],
+                "identifier": str(preset["identifier"]),
+                "url": str(preset.get("url") or ""),
+            }
+
+    algorithm_names = available_leaderboard_algorithm_presets()
+    algorithms = [
+        {
+            "preset": name,
+            "similarity_options": {
+                "vector_backend": "static_hash",
+                "static_vector_dim": 256,
+                "device": "cpu",
+            },
+        }
+        for name in algorithm_names
+    ]
+    manifest = {
+        "name": "Matheel Ready-made Public Leaderboard",
+        "seed": int(seed),
+        "pair_metrics": list(PAIR_METRICS),
+        "retrieval_metrics": list(RETRIEVAL_METRICS),
+        "datasets": dataset_configs,
+        "algorithms": algorithms,
+    }
+    print(
+        f"Scoring {len(dataset_configs)} dataset tasks with {len(algorithms)} algorithms...",
+        flush=True,
+    )
+    report, _ = run_leaderboard(manifest)
+    _describe_snapshot(
+        report,
+        dataset_sources,
+        algorithm_names,
+        seed=seed,
+        pair_sample_limit=pair_sample_limit,
+        retrieval_query_limit=retrieval_query_limit,
+        retrieval_corpus_limit=retrieval_corpus_limit,
+    )
+    artifacts = write_leaderboard_artifacts(report, artifact_root, basename="ready_leaderboard")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(artifacts["json"], output)
+    return output
+
+
+def _load_preset_dataset(preset_name, task_family, *, raw_root, normalized_root):
+    spec = {
+        "preset": preset_name,
+        "destination": raw_root / preset_name,
+        "adapted_destination": normalized_root / f"{preset_name}_{task_family}",
+    }
+    if task_family == "pair":
+        return load_pair_datasets(spec)
+    return load_retrieval_datasets(spec)
+
+
+def _dataset_task_name(preset_name, task_family, task_families):
+    if len(task_families) == 1:
+        return preset_name
+    return f"{preset_name}_{task_family}"
+
+
+def _sample_metadata(
+    preset_name,
+    preset,
+    task_family,
+    *,
+    seed,
+    pair_sample_limit,
+    retrieval_query_limit,
+    retrieval_corpus_limit,
+):
+    return {
+        "name": _dataset_task_name(preset_name, task_family, preset["task_families"]),
+        "task_type": "plagiarism",
+        "license": DATASET_LICENSES[preset_name],
+        "source_preset": preset_name,
+        "source_url": str(preset.get("url") or ""),
+        "benchmark_sample": {
+            "seed": int(seed),
+            "pair_limit": int(pair_sample_limit),
+            "query_limit": int(retrieval_query_limit),
+            "corpus_limit": int(retrieval_corpus_limit),
+        },
+    }
+
+
+def _sample_pair_dataset(dataset, destination, *, limit, seed, metadata):
+    pairs = dataset.pairs.copy()
+    target = min(len(pairs), int(limit))
+    selected_indices = []
+    labels = sorted(pairs["label"].dropna().unique().tolist())
+    per_label = max(1, target // max(1, len(labels)))
+    for offset, label in enumerate(labels):
+        group = pairs[pairs["label"] == label]
+        count = min(len(group), per_label)
+        if count:
+            selected_indices.extend(
+                group.sample(n=count, random_state=int(seed) + offset).index.tolist()
+            )
+    remaining_count = target - len(selected_indices)
+    if remaining_count > 0:
+        remaining = pairs.drop(index=selected_indices)
+        selected_indices.extend(
+            remaining.sample(n=remaining_count, random_state=int(seed) + 101).index.tolist()
+        )
+    sampled_pairs = pairs.loc[selected_indices].reset_index(drop=True)
+    referenced_ids = set(sampled_pairs["left_id"].astype(str)) | set(
+        sampled_pairs["right_id"].astype(str)
+    )
+    files = _sampled_file_rows(dataset, referenced_ids)
+    payload = dict(metadata)
+    payload["benchmark_sample"] = {
+        **payload["benchmark_sample"],
+        "source_pairs": int(len(pairs)),
+        "sampled_pairs": int(len(sampled_pairs)),
+    }
+    return write_pair_dataset(
+        destination,
+        files=pd.DataFrame(files),
+        pairs=sampled_pairs,
+        metadata=payload,
+    ).root
+
+
+def _sample_retrieval_dataset(
+    dataset,
+    destination,
+    *,
+    query_limit,
+    corpus_limit,
+    seed,
+    metadata,
+):
+    query_count = min(len(dataset.queries), int(query_limit))
+    queries = dataset.queries.sample(n=query_count, random_state=int(seed)).reset_index(drop=True)
+    query_ids = set(queries["query_id"].astype(str))
+    qrels = dataset.qrels[dataset.qrels["query_id"].astype(str).isin(query_ids)].copy()
+    required_documents = set(qrels["document_id"].astype(str))
+    required_corpus = dataset.corpus[
+        dataset.corpus["document_id"].astype(str).isin(required_documents)
+    ]
+    remaining_corpus = dataset.corpus[
+        ~dataset.corpus["document_id"].astype(str).isin(required_documents)
+    ]
+    fill_count = min(
+        max(0, int(corpus_limit) - len(required_corpus)),
+        len(remaining_corpus),
+    )
+    if fill_count:
+        remaining_corpus = remaining_corpus.sample(n=fill_count, random_state=int(seed) + 211)
+    else:
+        remaining_corpus = remaining_corpus.iloc[0:0]
+    corpus = pd.concat([required_corpus, remaining_corpus], ignore_index=True)
+    corpus_ids = set(corpus["document_id"].astype(str))
+    qrels = qrels[qrels["document_id"].astype(str).isin(corpus_ids)].reset_index(drop=True)
+    referenced_ids = set(queries["file_id"].astype(str)) | set(corpus["file_id"].astype(str))
+    files = _sampled_file_rows(dataset, referenced_ids)
+    payload = dict(metadata)
+    payload["benchmark_sample"] = {
+        **payload["benchmark_sample"],
+        "source_queries": int(len(dataset.queries)),
+        "source_documents": int(len(dataset.corpus)),
+        "sampled_queries": int(len(queries)),
+        "sampled_documents": int(len(corpus)),
+    }
+    return write_retrieval_dataset(
+        destination,
+        files=pd.DataFrame(files),
+        queries=queries,
+        corpus=corpus,
+        qrels=qrels,
+        metadata=payload,
+    ).root
+
+
+def _sampled_file_rows(dataset, referenced_ids):
+    texts = load_code_texts(dataset)
+    source_files = dataset.files.set_index(dataset.files["file_id"].astype(str), drop=False)
+    rows = []
+    for file_id in sorted(referenced_ids):
+        source = source_files.loc[file_id]
+        suffix = Path(str(source["file_path"])).suffix or ".txt"
+        rows.append({"file_id": file_id, "text": texts[file_id], "suffix": suffix})
+    return rows
+
+
+def _describe_snapshot(
+    report,
+    dataset_sources,
+    algorithm_names,
+    *,
+    seed,
+    pair_sample_limit,
+    retrieval_query_limit,
+    retrieval_corpus_limit,
+):
+    profile = {
+        "profile": "sampled_public_snapshot",
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "dataset_presets": list(available_dataset_presets()),
+        "dataset_task_count": len(dataset_sources),
+        "algorithm_presets": list(algorithm_names),
+        "pair_sample_limit": int(pair_sample_limit),
+        "retrieval_query_limit": int(retrieval_query_limit),
+        "retrieval_corpus_limit": int(retrieval_corpus_limit),
+        "seed": int(seed),
+        "vector_backend": "static_hash",
+        "static_vector_dim": 256,
+    }
+    report["metadata"]["benchmark_profile"] = profile
+    source_by_dataset = {name: source["source"] for name, source in dataset_sources.items()}
+    report["per_dataset"]["dataset_source"] = report["per_dataset"]["dataset_name"].map(
+        source_by_dataset
+    )
+    for dataset_config in report["manifest"]["datasets"]:
+        source = dataset_sources[dataset_config["name"]]
+        dataset_config["spec"] = {
+            "name": dataset_config["name"],
+            "source": source["source"],
+            "identifier": source["identifier"],
+            "preset": source["preset"],
+            "url": source["url"],
+            "task_families": [dataset_config["task_family"]],
+        }
+    for card in report["cards"]["datasets"]:
+        source = dataset_sources[card["name"]]
+        card["source"] = source
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", default=str(DEFAULT_OUTPUT))
+    parser.add_argument(
+        "--work-dir",
+        default=str(Path(tempfile.gettempdir()) / "matheel_ready_leaderboard"),
+    )
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--pair-sample-limit", type=int, default=128)
+    parser.add_argument("--retrieval-query-limit", type=int, default=24)
+    parser.add_argument("--retrieval-corpus-limit", type=int, default=64)
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    output = build_ready_leaderboard(
+        args.output,
+        args.work_dir,
+        seed=args.seed,
+        pair_sample_limit=args.pair_sample_limit,
+        retrieval_query_limit=args.retrieval_query_limit,
+        retrieval_corpus_limit=args.retrieval_corpus_limit,
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    print(
+        f"Wrote {len(payload['aggregate'])} aggregate rows and "
+        f"{len(payload['per_dataset'])} per-dataset rows to {output}."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -368,6 +368,38 @@ def test_kaggle_cli_resolver_downloads_then_safe_extracts(tmp_path, monkeypatch)
     assert "--unzip" not in captured["command"]
     assert captured["check"] is True
     assert (destination / "rows.csv").read_text(encoding="utf-8") == "value\n1\n"
+
+
+def test_kaggle_public_resolver_downloads_without_optional_client(tmp_path, monkeypatch):
+    captured = {}
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "kaggle.api.kaggle_api_extended":
+            raise ImportError("blocked kaggle api")
+        return real_import(name, *args, **kwargs)
+
+    def fake_download(url, output_file, headers=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        with zipfile.ZipFile(output_file, "w") as archive:
+            archive.writestr("rows.csv", "value\n1\n")
+        return output_file
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    monkeypatch.setattr("matheel.datasets.shutil.which", lambda name: None)
+    monkeypatch.setattr("matheel.datasets._download_url_to_file", fake_download)
+
+    destination = tmp_path / "kaggle_public"
+    resolved = _resolve_kaggle_dataset_source("owner/public-dataset", destination)
+
+    assert resolved == destination.resolve()
+    assert captured == {
+        "url": "https://www.kaggle.com/api/v1/datasets/download/owner/public-dataset",
+        "headers": None,
+    }
+    assert (destination / "rows.csv").read_text(encoding="utf-8") == "value\n1\n"
+    assert not (destination / "kaggle_dataset.zip").exists()
     assert not (destination / "download.zip").exists()
 
 

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -32,6 +32,7 @@ EXPECTED_GRADIO_TABS = (
     "Dataset Map",
     "Pair Explanation",
     "Reports",
+    "Ready-made Leaderboard",
     "Build Leaderboard",
     "Inspect Artifacts",
 )
@@ -43,7 +44,7 @@ EXPECTED_PRIMARY_ACTIONS = {
     "Run Dataset Evaluation": "evaluate_dataset_gradio_with_state",
     "Generate Map": "generate_dataset_map_gradio",
     "Generate Explanation": "generate_pair_explanation_gradio",
-    "Run Ready Leaderboard": "run_ready_leaderboard_gradio",
+    "Run Custom Leaderboard": "run_ready_leaderboard_gradio",
     "Inspect Leaderboard": "inspect_leaderboard_artifacts_gradio",
 }
 
@@ -960,6 +961,33 @@ def test_ready_leaderboard_registered_datasets_frame_lists_all_presets():
     assert set(frame["Preset"]) == set(available_dataset_presets())
     assert "Evaluation Metrics" in frame.columns
     assert "Sampling Default" in frame.columns
+
+
+def test_ready_made_leaderboard_covers_all_presets_and_algorithms():
+    payload = gradio_app.load_ready_made_leaderboard_payload()
+    report = gradio_app._leaderboard_report_from_payload(payload)
+    profile = report["metadata"]["benchmark_profile"]
+    coverage = gradio_app.ready_made_leaderboard_coverage_frame(report)
+
+    assert set(profile["dataset_presets"]) == {
+        "conplag",
+        "criminal_minds",
+        "ipca",
+        "irplag",
+        "soco14",
+        "student_code_similarity",
+    }
+    assert set(profile["dataset_presets"]).issubset(set(available_dataset_presets()))
+    assert set(profile["algorithm_presets"]) == set(
+        gradio_app.READY_LEADERBOARD_ALGORITHM_CHOICES
+    )
+    assert profile["dataset_task_count"] == 7
+    assert len(coverage) == 7
+    assert set(report["per_dataset"]["algorithm_name"]) == set(
+        gradio_app.READY_LEADERBOARD_ALGORITHM_CHOICES
+    )
+    assert set(report["aggregate"]["task_family"]) == {"pair", "retrieval"}
+    assert "static_hash" in gradio_app.ready_made_leaderboard_summary_html(report)
 
 
 def test_ready_leaderboard_rejects_empty_algorithm_selection():

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -251,6 +251,34 @@ def test_leaderboard_manifest_preserves_remote_dataset_identifiers(tmp_path):
     assert spec["destination"] == str((config_dir / "cache" / "remote").resolve())
 
 
+def test_leaderboard_manifest_keeps_dataset_specific_similarity_options(tmp_path):
+    pair_root = _write_pair_fixture(tmp_path)
+
+    manifest = normalize_leaderboard_manifest(
+        {
+            "datasets": [
+                {
+                    "name": "python_pairs",
+                    "task": "pair",
+                    "path": str(pair_root),
+                    "similarity_options": {
+                        "code_language": "python",
+                        "vector_backend": "static",
+                    },
+                }
+            ],
+            "algorithms": ["CodeBLEU"],
+        }
+    )
+
+    dataset = manifest["datasets"][0]
+    assert dataset["similarity_options"] == {
+        "code_language": "python",
+        "vector_backend": "static",
+    }
+    assert "similarity_options" not in dataset["spec"]
+
+
 def test_leaderboard_payload_and_html_escape_values(tmp_path):
     pair_root = _write_pair_fixture(tmp_path)
     exact_path, _ = _write_algorithm_fixtures(tmp_path)

--- a/tests/test_ready_leaderboard.py
+++ b/tests/test_ready_leaderboard.py
@@ -1,0 +1,90 @@
+import pandas as pd
+
+from matheel.datasets import (
+    load_pair_dataset,
+    load_retrieval_dataset,
+    write_pair_dataset,
+    write_retrieval_dataset,
+)
+from scripts.build_ready_leaderboard import _sample_pair_dataset, _sample_retrieval_dataset
+
+
+def test_ready_leaderboard_pair_sample_is_deterministic_and_keeps_both_labels(tmp_path):
+    source = tmp_path / "source_pairs"
+    files = [
+        {"file_id": f"f{index}", "text": f"print({index})", "suffix": ".py"}
+        for index in range(10)
+    ]
+    pairs = [
+        {"left_id": f"f{index}", "right_id": f"f{index + 1}", "label": index % 2}
+        for index in range(8)
+    ]
+    dataset = write_pair_dataset(source, files=pd.DataFrame(files), pairs=pd.DataFrame(pairs))
+    metadata = {"name": "sample", "benchmark_sample": {"seed": 7}}
+
+    first = _sample_pair_dataset(
+        dataset,
+        tmp_path / "first",
+        limit=4,
+        seed=7,
+        metadata=metadata,
+    )
+    second = _sample_pair_dataset(
+        dataset,
+        tmp_path / "second",
+        limit=4,
+        seed=7,
+        metadata=metadata,
+    )
+    first_dataset = load_pair_dataset(first)
+    second_dataset = load_pair_dataset(second)
+
+    assert first_dataset.pairs.equals(second_dataset.pairs)
+    assert sorted(first_dataset.pairs["label"].unique()) == [0, 1]
+    assert len(first_dataset.pairs) == 4
+    assert first_dataset.metadata["benchmark_sample"]["source_pairs"] == 8
+
+
+def test_ready_leaderboard_retrieval_sample_keeps_judged_documents(tmp_path):
+    source = tmp_path / "source_retrieval"
+    files = [
+        {"file_id": f"q{index}", "text": f"query {index}", "suffix": ".txt"}
+        for index in range(4)
+    ] + [
+        {"file_id": f"d{index}", "text": f"document {index}", "suffix": ".txt"}
+        for index in range(8)
+    ]
+    queries = pd.DataFrame(
+        [{"query_id": f"query{index}", "file_id": f"q{index}"} for index in range(4)]
+    )
+    corpus = pd.DataFrame(
+        [{"document_id": f"doc{index}", "file_id": f"d{index}"} for index in range(8)]
+    )
+    qrels = pd.DataFrame(
+        [
+            {"query_id": f"query{index}", "document_id": f"doc{index}", "relevance": 1}
+            for index in range(4)
+        ]
+    )
+    dataset = write_retrieval_dataset(
+        source,
+        files=pd.DataFrame(files),
+        queries=queries,
+        corpus=corpus,
+        qrels=qrels,
+    )
+
+    sampled_path = _sample_retrieval_dataset(
+        dataset,
+        tmp_path / "sampled",
+        query_limit=2,
+        corpus_limit=3,
+        seed=7,
+        metadata={"name": "sample", "benchmark_sample": {"seed": 7}},
+    )
+    sampled = load_retrieval_dataset(sampled_path)
+
+    assert len(sampled.queries) == 2
+    assert len(sampled.corpus) == 3
+    assert set(sampled.qrels["document_id"]).issubset(set(sampled.corpus["document_id"]))
+    assert set(sampled.qrels["query_id"]) == set(sampled.queries["query_id"])


### PR DESCRIPTION
## Summary

- add a precomputed Gradio leaderboard covering all 6 registered public dataset presets, 7 task views, and all 8 built-in algorithm presets
- add a reproducible snapshot builder with deterministic, documented sampling
- make leaderboard scoring respect dataset-specific similarity options such as code language
- fix ConPlag adapter performance by indexing submission files once
- support anonymous downloads for public Kaggle datasets when the optional API/CLI is unavailable
- expand tests and documentation

## Why

The existing Reports workflow was only an upload-driven leaderboard builder. Users could see the dataset catalog, but there was no leaderboard to inspect immediately. Generating the public benchmark also exposed an O(rows × filesystem scan) ConPlag adapter bottleneck and a Kaggle public-access gap.

## Snapshot profile

- 6 registered public dataset presets
- 7 task views: 5 pair-classification and 2 retrieval
- 8 algorithm presets
- label-stratified pair samples capped at 128 rows
- retrieval samples capped at 24 queries and 64 documents
- seed 7 and deterministic 256-dimensional static-hash vectors

The UI labels this as a sampled product snapshot, not a full-corpus research benchmark.

## Validation

- `562 passed, 4 skipped, 3 deselected`
- `ruff check .`
- `git diff --check`
- local Gradio browser verification: Reports opens to Ready-made Leaderboard, tables/coverage/download render, no console errors

Tracks #178. This PR intentionally does not close that issue.
