### PR TITLE
Prepare v0.5.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matheel
 
 [![Tests](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/FahadEbrahim/matheel/actions/workflows/tests.yml)
-[![PyPI](https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=3600&release=v0.5.6)](https://pypi.org/project/matheel/)
+[![PyPI](https://img.shields.io/pypi/v/matheel.svg?cacheSeconds=3600&release=v0.5.7)](https://pypi.org/project/matheel/)
 [![Python versions](https://img.shields.io/pypi/pyversions/matheel.svg?cacheSeconds=3600)](https://pypi.org/project/matheel/)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue.svg)](https://fahadebrahim.github.io/matheel/)
 [![Latest release](https://img.shields.io/github/v/release/FahadEbrahim/matheel.svg)](https://github.com/FahadEbrahim/matheel/releases)

--- a/examples/notebooks/01_core_workflows.ipynb
+++ b/examples/notebooks/01_core_workflows.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.6\"\n",
+    "MATHEEL_REF = \"v0.5.7\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/02_datasets_and_reproducibility.ipynb
+++ b/examples/notebooks/02_datasets_and_reproducibility.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.6\"\n",
+    "MATHEEL_REF = \"v0.5.7\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/03_custom_algorithms.ipynb
+++ b/examples/notebooks/03_custom_algorithms.ipynb
@@ -20,7 +20,7 @@
     "import sys\n",
     "from pathlib import Path\n",
     "\n",
-    "MATHEEL_REF = \"v0.5.6\"\n",
+    "MATHEEL_REF = \"v0.5.7\"\n",
     "\n",
     "\n",
     "def run(*args, cwd=None):\n",

--- a/examples/notebooks/04_gradio_app.ipynb
+++ b/examples/notebooks/04_gradio_app.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%%bash\n",
     "set -euo pipefail\n",
-    "MATHEEL_REF=\"v0.5.6\"\n",
+    "MATHEEL_REF=\"v0.5.7\"\n",
     "pip uninstall -y torchvision || true\n",
     "rm -rf /content/matheel\n",
     "git clone https://github.com/FahadEbrahim/matheel.git /content/matheel\n",

--- a/examples/notebooks/05_visualization_and_leaderboard.ipynb
+++ b/examples/notebooks/05_visualization_and_leaderboard.ipynb
@@ -20,7 +20,7 @@
         "import sys\n",
         "from pathlib import Path\n",
         "\n",
-        "MATHEEL_REF = \"v0.5.6\"\n",
+        "MATHEEL_REF = \"v0.5.7\"\n",
         "\n",
         "\n",
         "def run(*args, cwd=None):\n",

--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -11,7 +11,7 @@ pinned: false
 
 Interactive code-similarity analysis with configurable embedding, lexical, chunking, preprocessing, and code-aware metrics.
 
-This Space is aligned with `matheel==0.5.6` and includes:
+This Space is aligned with `matheel==0.5.7` and includes:
 
 - Pair, collection, comparison-suite, normalized-dataset, dataset-validation, threshold-tuning, visualization, scored-pair explanation, ready-made public leaderboard, custom leaderboard, and leaderboard-inspection workflows
 - Metric presets for balanced, lexical, embedding-only, code-aware, and individual offline baselines

--- a/gradio_app/requirements.txt
+++ b/gradio_app/requirements.txt
@@ -1,1 +1,1 @@
-matheel[all]==0.5.6
+matheel[all]==0.5.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matheel"
-version = "0.5.6"
+version = "0.5.7"
 authors = [
   { name = "Fahad Ebrahim" }
 ]


### PR DESCRIPTION
## Summary

- bump the package version from 0.5.6 to 0.5.7
- sync the PyPI badge, Gradio package pin, Space README, and release notebook refs

## Release scope

This is the narrow release follow-up for #248. It publishes the ready-made leaderboard support plus the ConPlag, Kaggle, and dataset-specific leaderboard option fixes already merged and fully tested on `main`.

No feature code changes are included in this PR.

## Validation

- release version references are synced
- 7 release/notebook tests passed
- `matheel-0.5.7-py3-none-any.whl` built successfully
- `matheel-0.5.7.tar.gz` built successfully
- Twine checks passed for both artifacts
- `git diff --check` passed
