### PR TITLE
Add interactive all-metric leaderboard controls

### DIFF
--- a/docs/gradio.md
+++ b/docs/gradio.md
@@ -55,7 +55,7 @@ The top banner shows the recommended path from a quick comparison through evalua
 
 Collection and dataset uploads are ZIP-first. Keep source paths relative inside the archive, and use normalized dataset ZIPs for evaluation, explanation, and leaderboard tasks. Download generated artifacts if you need to retain them after the session ends.
 
-The first **Reports** subtab is a ready-made sampled leaderboard covering every registered public dataset preset and every built-in algorithm preset. It loads from a committed JSON artifact, so viewing it does not download datasets or run models. Its summary shows the sampling limits, seed, backend, and generation date; use **Build Leaderboard** for full-corpus or custom settings.
+The first **Reports** subtab is a ready-made sampled leaderboard covering every registered public dataset preset, every built-in algorithm preset, and all supported pair and retrieval metrics. It loads from a committed JSON artifact, so viewing it does not download datasets or run models. Pair rankings initially use F1 and retrieval rankings use Mean Average Precision, both sorted from highest to lowest. Filter by task, metric, dataset, algorithm, or source, and use the table filter for any visible column. Each table has explicit sort-column and direction controls for reliable ascending or descending sorting. Dataset and source filters recompute the aggregate ranking over the selected subset. The summary shows the sampling limits, seed, backend, and generation date; use **Build Leaderboard** for full-corpus or custom settings.
 
 ## Troubleshooting
 

--- a/docs/leaderboard.md
+++ b/docs/leaderboard.md
@@ -12,6 +12,8 @@ The Gradio app includes three leaderboard workflows:
 
 Open **Reports → Ready-made Leaderboard** to see rankings without uploading data or starting a benchmark run. The snapshot covers all six registered public dataset presets as seven task views: five pair-classification datasets plus SOCO14 and IRPlag retrieval views. All eight built-in algorithm presets are included.
 
+The ranking explorer includes every supported evaluation metric. Pair classification provides `f1`, `accuracy`, `precision`, `recall`, `auroc`, and `average_precision`; retrieval provides `mean_average_precision`, `mean_reciprocal_rank`, `ndcg_at_k`, `precision_at_k`, and `recall_at_k`. Pair views default to F1 and retrieval views default to Mean Average Precision, with scores sorted descending. Task, metric, dataset, algorithm, and source controls update both tables; dataset and source filters also recompute the aggregate ranking over the visible dataset subset. Use the table filter to search any visible column. Separate sort-column and direction controls reorder the aggregate and per-dataset tables, including ascending or descending score, rank, algorithm, dataset, source, and sample-based views where applicable.
+
 This is a deterministic product demo, not a claim of full-corpus research performance. Each pair dataset uses a label-stratified sample capped at 128 pairs; each retrieval view is capped at 24 queries and 64 documents while retaining the selected queries' judged documents. It uses seed `7`, task-appropriate code languages, and the offline `static_hash` vector backend with 256 dimensions. The app displays these limits alongside the rankings.
 
 Maintainers can regenerate the committed JSON artifact from the public source presets:
@@ -115,7 +117,7 @@ The example is deterministic and offline. It uses synthetic normalized datasets 
 
 The Gradio **Reports → Build Leaderboard** workflow expects normalized dataset ZIP uploads. Unlike the ready-made sampled snapshot, custom runs do not fetch or bundle real datasets or credentials. The registered dataset table lists the current dataset presets, their task families, their source resolver, and the default evaluation plan:
 
-- Pair-classification datasets use pair metrics such as `f1`, `accuracy`, `auroc`, and `average_precision`.
+- Pair-classification datasets use `f1`, `accuracy`, `precision`, `recall`, `auroc`, and `average_precision`.
 - Retrieval datasets use ranking metrics such as `mean_average_precision`, `mean_reciprocal_rank`, `ndcg_at_k`, `precision_at_k`, and `recall_at_k`.
 - Pair datasets use the selected pair threshold.
 - Retrieval datasets use the selected `k`.

--- a/gradio_app/app.py
+++ b/gradio_app/app.py
@@ -37,7 +37,11 @@ from matheel.evaluation import (
     evaluate_retrieval_dataset,
     evaluate_retrieval_resamples,
 )
-from matheel.leaderboard import run_leaderboard, write_leaderboard_artifacts
+from matheel.leaderboard import (
+    available_leaderboard_metrics,
+    run_leaderboard,
+    write_leaderboard_artifacts,
+)
 from matheel.leaderboard_presets import available_leaderboard_algorithm_presets, get_leaderboard_algorithm_preset
 from matheel.model_routing import available_vector_backends
 from matheel.preprocessing import available_preprocess_modes
@@ -185,14 +189,33 @@ METRIC_PRESETS = {
 DATASET_TASK_CHOICES = ("Pair Classification", "Retrieval")
 DEFAULT_DATASET_TASK = DATASET_TASK_CHOICES[0]
 READY_LEADERBOARD_ALGORITHM_CHOICES = tuple(METRIC_PRESETS)
-READY_LEADERBOARD_PAIR_METRICS = ("f1", "accuracy", "auroc", "average_precision")
-READY_LEADERBOARD_RETRIEVAL_METRICS = (
-    "mean_average_precision",
-    "mean_reciprocal_rank",
-    "ndcg_at_k",
-    "precision_at_k",
-    "recall_at_k",
+READY_LEADERBOARD_PAIR_METRICS = available_leaderboard_metrics("pair")
+READY_LEADERBOARD_RETRIEVAL_METRICS = available_leaderboard_metrics("retrieval")
+READY_LEADERBOARD_DEFAULT_METRICS = {
+    "pair": "f1",
+    "retrieval": "mean_average_precision",
+}
+READY_LEADERBOARD_TASK_CHOICES = tuple(READY_LEADERBOARD_DEFAULT_METRICS)
+READY_LEADERBOARD_ALL_DATASETS = "All datasets"
+READY_LEADERBOARD_ALL_ALGORITHMS = "All algorithms"
+READY_LEADERBOARD_ALL_SOURCES = "All sources"
+READY_LEADERBOARD_AGGREGATE_SORT_COLUMNS = (
+    "mean_score",
+    "median_score",
+    "algorithm_name",
+    "dataset_count",
+    "sample_count",
+    "rank",
 )
+READY_LEADERBOARD_PER_DATASET_SORT_COLUMNS = (
+    "score",
+    "dataset_name",
+    "algorithm_name",
+    "dataset_source",
+    "sample_count",
+    "rank",
+)
+READY_LEADERBOARD_SORT_DIRECTIONS = ("Descending", "Ascending")
 READY_MADE_LEADERBOARD_PATH = Path(__file__).resolve().parent / "assets" / "ready_leaderboard.json"
 THRESHOLD_OPTIMIZE_CHOICES = ("f1", "accuracy", "precision", "recall")
 PAIR_DATASET_SCORE_COLUMNS = [
@@ -2210,6 +2233,262 @@ def ready_made_leaderboard_coverage_frame(report):
     )
 
 
+def _ready_made_task_family(task_family):
+    task = str(task_family or "").strip().lower()
+    if task not in READY_LEADERBOARD_DEFAULT_METRICS:
+        return READY_LEADERBOARD_TASK_CHOICES[0]
+    return task
+
+
+def _ready_made_unique_values(frame, column):
+    if not isinstance(frame, pd.DataFrame) or column not in frame:
+        return []
+    return sorted(
+        {
+            str(value)
+            for value in frame[column].dropna().tolist()
+            if str(value).strip()
+        }
+    )
+
+
+def _ready_made_filter_options_from_report(report, task_family):
+    task = _ready_made_task_family(task_family)
+    per_dataset = report["per_dataset"]
+    task_rows = per_dataset[per_dataset["task_family"] == task]
+    configured_metrics = (
+        READY_LEADERBOARD_PAIR_METRICS
+        if task == "pair"
+        else READY_LEADERBOARD_RETRIEVAL_METRICS
+    )
+    available_metrics = set(_ready_made_unique_values(task_rows, "metric"))
+    metrics = [metric for metric in configured_metrics if metric in available_metrics]
+    if not metrics:
+        metrics = list(configured_metrics)
+    default_metric = READY_LEADERBOARD_DEFAULT_METRICS[task]
+    if default_metric not in metrics:
+        default_metric = metrics[0]
+    return {
+        "task": task,
+        "metric": default_metric,
+        "metrics": metrics,
+        "datasets": [
+            READY_LEADERBOARD_ALL_DATASETS,
+            *_ready_made_unique_values(task_rows, "dataset_name"),
+        ],
+        "algorithms": [
+            READY_LEADERBOARD_ALL_ALGORITHMS,
+            *_ready_made_unique_values(task_rows, "algorithm_name"),
+        ],
+        "sources": [
+            READY_LEADERBOARD_ALL_SOURCES,
+            *_ready_made_unique_values(task_rows, "dataset_source"),
+        ],
+    }
+
+
+def ready_made_leaderboard_filter_options(
+    task_family=READY_LEADERBOARD_TASK_CHOICES[0],
+    artifact_path=READY_MADE_LEADERBOARD_PATH,
+):
+    task = _ready_made_task_family(task_family)
+    try:
+        report = _leaderboard_report_from_payload(
+            load_ready_made_leaderboard_payload(artifact_path)
+        )
+    except (FileNotFoundError, OSError, ValueError):
+        metrics = (
+            READY_LEADERBOARD_PAIR_METRICS
+            if task == "pair"
+            else READY_LEADERBOARD_RETRIEVAL_METRICS
+        )
+        return {
+            "task": task,
+            "metric": READY_LEADERBOARD_DEFAULT_METRICS[task],
+            "metrics": list(metrics),
+            "datasets": [READY_LEADERBOARD_ALL_DATASETS],
+            "algorithms": [
+                READY_LEADERBOARD_ALL_ALGORITHMS,
+                *READY_LEADERBOARD_ALGORITHM_CHOICES,
+            ],
+            "sources": [READY_LEADERBOARD_ALL_SOURCES],
+        }
+    return _ready_made_filter_options_from_report(report, task)
+
+
+def _filter_ready_made_leaderboard_report(
+    report,
+    task_family,
+    metric,
+    dataset_name,
+    algorithm_name,
+    dataset_source,
+    aggregate_sort="mean_score",
+    aggregate_direction=READY_LEADERBOARD_SORT_DIRECTIONS[0],
+    per_dataset_sort="score",
+    per_dataset_direction=READY_LEADERBOARD_SORT_DIRECTIONS[0],
+):
+    options = _ready_made_filter_options_from_report(report, task_family)
+    task = options["task"]
+    selected_metric = str(metric or "")
+    if selected_metric not in options["metrics"]:
+        selected_metric = options["metric"]
+
+    per_dataset = report["per_dataset"].copy()
+    per_dataset = per_dataset[
+        (per_dataset["task_family"] == task)
+        & (per_dataset["metric"] == selected_metric)
+    ]
+    if dataset_name and dataset_name != READY_LEADERBOARD_ALL_DATASETS:
+        per_dataset = per_dataset[per_dataset["dataset_name"] == dataset_name]
+    if dataset_source and dataset_source != READY_LEADERBOARD_ALL_SOURCES:
+        per_dataset = per_dataset[per_dataset["dataset_source"] == dataset_source]
+
+    if per_dataset.empty:
+        aggregate = report["aggregate"].iloc[0:0].copy()
+    else:
+        aggregate = (
+            per_dataset.groupby(
+                ["task_family", "algorithm_name", "metric"],
+                as_index=False,
+            )
+            .agg(
+                mean_score=("score", "mean"),
+                median_score=("score", "median"),
+                dataset_count=("dataset_name", "nunique"),
+                sample_count=("sample_count", "sum"),
+            )
+        )
+        aggregate["rank"] = (
+            aggregate.groupby(["task_family", "metric"])["mean_score"]
+            .rank(method="min", ascending=False, na_option="bottom")
+            .astype(int)
+        )
+
+    if algorithm_name and algorithm_name != READY_LEADERBOARD_ALL_ALGORITHMS:
+        per_dataset = per_dataset[per_dataset["algorithm_name"] == algorithm_name]
+        aggregate = aggregate[aggregate["algorithm_name"] == algorithm_name]
+
+    aggregate = _sort_ready_made_leaderboard_frame(
+        aggregate,
+        aggregate_sort,
+        aggregate_direction,
+        READY_LEADERBOARD_AGGREGATE_SORT_COLUMNS,
+        tie_breakers=("algorithm_name",),
+    )
+    per_dataset = _sort_ready_made_leaderboard_frame(
+        per_dataset,
+        per_dataset_sort,
+        per_dataset_direction,
+        READY_LEADERBOARD_PER_DATASET_SORT_COLUMNS,
+        tie_breakers=("dataset_name", "algorithm_name"),
+    )
+    return leaderboard_display_frame(aggregate), leaderboard_display_frame(per_dataset)
+
+
+def _sort_ready_made_leaderboard_frame(
+    frame,
+    sort_column,
+    direction,
+    allowed_columns,
+    *,
+    tie_breakers,
+):
+    selected_column = str(sort_column or "")
+    if selected_column not in allowed_columns:
+        selected_column = allowed_columns[0]
+    sort_columns = [selected_column]
+    sort_columns.extend(
+        column
+        for column in tie_breakers
+        if column != selected_column and column in frame.columns
+    )
+    primary_ascending = str(direction) == "Ascending"
+    return frame.sort_values(
+        sort_columns,
+        ascending=[primary_ascending, *([True] * (len(sort_columns) - 1))],
+        na_position="last",
+        ignore_index=True,
+    )
+
+
+def filter_ready_made_leaderboard(
+    task_family,
+    metric,
+    dataset_name=READY_LEADERBOARD_ALL_DATASETS,
+    algorithm_name=READY_LEADERBOARD_ALL_ALGORITHMS,
+    dataset_source=READY_LEADERBOARD_ALL_SOURCES,
+    aggregate_sort="mean_score",
+    aggregate_direction=READY_LEADERBOARD_SORT_DIRECTIONS[0],
+    per_dataset_sort="score",
+    per_dataset_direction=READY_LEADERBOARD_SORT_DIRECTIONS[0],
+    artifact_path=READY_MADE_LEADERBOARD_PATH,
+):
+    try:
+        report = _leaderboard_report_from_payload(
+            load_ready_made_leaderboard_payload(artifact_path)
+        )
+    except (FileNotFoundError, OSError, ValueError):
+        return pd.DataFrame(), pd.DataFrame()
+    return _filter_ready_made_leaderboard_report(
+        report,
+        task_family,
+        metric,
+        dataset_name,
+        algorithm_name,
+        dataset_source,
+        aggregate_sort,
+        aggregate_direction,
+        per_dataset_sort,
+        per_dataset_direction,
+    )
+
+
+def change_ready_made_leaderboard_task(
+    task_family,
+    aggregate_sort,
+    aggregate_direction,
+    per_dataset_sort,
+    per_dataset_direction,
+):
+    options = ready_made_leaderboard_filter_options(task_family)
+    aggregate, per_dataset = filter_ready_made_leaderboard(
+        options["task"],
+        options["metric"],
+        aggregate_sort=aggregate_sort,
+        aggregate_direction=aggregate_direction,
+        per_dataset_sort=per_dataset_sort,
+        per_dataset_direction=per_dataset_direction,
+    )
+    return (
+        gr.update(choices=options["metrics"], value=options["metric"]),
+        gr.update(choices=options["datasets"], value=READY_LEADERBOARD_ALL_DATASETS),
+        gr.update(choices=options["algorithms"], value=READY_LEADERBOARD_ALL_ALGORITHMS),
+        gr.update(choices=options["sources"], value=READY_LEADERBOARD_ALL_SOURCES),
+        aggregate,
+        per_dataset,
+    )
+
+
+def reset_ready_made_leaderboard_filters():
+    task = READY_LEADERBOARD_TASK_CHOICES[0]
+    options = ready_made_leaderboard_filter_options(task)
+    aggregate, per_dataset = filter_ready_made_leaderboard(task, options["metric"])
+    return (
+        gr.update(value=task),
+        gr.update(choices=options["metrics"], value=options["metric"]),
+        gr.update(choices=options["datasets"], value=READY_LEADERBOARD_ALL_DATASETS),
+        gr.update(choices=options["algorithms"], value=READY_LEADERBOARD_ALL_ALGORITHMS),
+        gr.update(choices=options["sources"], value=READY_LEADERBOARD_ALL_SOURCES),
+        gr.update(value="mean_score"),
+        gr.update(value=READY_LEADERBOARD_SORT_DIRECTIONS[0]),
+        gr.update(value="score"),
+        gr.update(value=READY_LEADERBOARD_SORT_DIRECTIONS[0]),
+        aggregate,
+        per_dataset,
+    )
+
+
 def ready_made_leaderboard_values(artifact_path=READY_MADE_LEADERBOARD_PATH):
     try:
         payload = load_ready_made_leaderboard_payload(artifact_path)
@@ -2228,10 +2507,19 @@ def ready_made_leaderboard_values(artifact_path=READY_MADE_LEADERBOARD_PATH):
         )
     report = _leaderboard_report_from_payload(payload)
     title = str(report["metadata"].get("name") or "Matheel Ready-made Leaderboard")
+    task = READY_LEADERBOARD_TASK_CHOICES[0]
+    aggregate, per_dataset = _filter_ready_made_leaderboard_report(
+        report,
+        task,
+        READY_LEADERBOARD_DEFAULT_METRICS[task],
+        READY_LEADERBOARD_ALL_DATASETS,
+        READY_LEADERBOARD_ALL_ALGORITHMS,
+        READY_LEADERBOARD_ALL_SOURCES,
+    )
     return (
         ready_made_leaderboard_summary_html(report),
-        leaderboard_display_frame(report["aggregate"]),
-        leaderboard_display_frame(report["per_dataset"]),
+        aggregate,
+        per_dataset,
         ready_made_leaderboard_coverage_frame(report),
         benchmark_report_html(report, title=title),
         os.fspath(Path(artifact_path)),
@@ -3490,6 +3778,7 @@ def get_sim_list_gradio(
 
 
 ready_made_initial = ready_made_leaderboard_values()
+ready_made_filter_initial = ready_made_leaderboard_filter_options()
 
 
 with gr.Blocks(
@@ -5209,9 +5498,80 @@ with gr.Blocks(
                         "full-corpus or custom run."
                     )
                     ready_made_summary = gr.HTML(value=ready_made_initial[0], padding=False)
+                    with gr.Accordion("Explore rankings", open=True):
+                        gr.Markdown(
+                            "Pair classification defaults to **F1**; retrieval defaults to "
+                            "**Mean Average Precision**. Both rankings start in descending score "
+                            "order. Use the controls below to filter the snapshot, the table filter "
+                            "to search any visible column, and the explicit sort controls to reorder "
+                            "either table."
+                        )
+                        with gr.Row():
+                            ready_made_task = gr.Dropdown(
+                                choices=list(READY_LEADERBOARD_TASK_CHOICES),
+                                value=ready_made_filter_initial["task"],
+                                label="Task",
+                            )
+                            ready_made_metric = gr.Dropdown(
+                                choices=ready_made_filter_initial["metrics"],
+                                value=ready_made_filter_initial["metric"],
+                                label="Metric (higher is better)",
+                            )
+                            ready_made_dataset = gr.Dropdown(
+                                choices=ready_made_filter_initial["datasets"],
+                                value=READY_LEADERBOARD_ALL_DATASETS,
+                                label="Dataset",
+                            )
+                        with gr.Row():
+                            ready_made_algorithm = gr.Dropdown(
+                                choices=ready_made_filter_initial["algorithms"],
+                                value=READY_LEADERBOARD_ALL_ALGORITHMS,
+                                label="Algorithm",
+                            )
+                            ready_made_source = gr.Dropdown(
+                                choices=ready_made_filter_initial["sources"],
+                                value=READY_LEADERBOARD_ALL_SOURCES,
+                                label="Dataset Source",
+                            )
+                            ready_made_reset = gr.Button("Reset Leaderboard Filters")
+                        with gr.Row():
+                            ready_made_aggregate_sort = gr.Dropdown(
+                                choices=[
+                                    ("Mean score", "mean_score"),
+                                    ("Median score", "median_score"),
+                                    ("Algorithm", "algorithm_name"),
+                                    ("Dataset count", "dataset_count"),
+                                    ("Sample count", "sample_count"),
+                                    ("Rank", "rank"),
+                                ],
+                                value="mean_score",
+                                label="Sort Aggregate By",
+                            )
+                            ready_made_aggregate_direction = gr.Dropdown(
+                                choices=list(READY_LEADERBOARD_SORT_DIRECTIONS),
+                                value=READY_LEADERBOARD_SORT_DIRECTIONS[0],
+                                label="Aggregate Direction",
+                            )
+                            ready_made_per_dataset_sort = gr.Dropdown(
+                                choices=[
+                                    ("Score", "score"),
+                                    ("Dataset", "dataset_name"),
+                                    ("Algorithm", "algorithm_name"),
+                                    ("Dataset source", "dataset_source"),
+                                    ("Sample count", "sample_count"),
+                                    ("Rank", "rank"),
+                                ],
+                                value="score",
+                                label="Sort Per-Dataset By",
+                            )
+                            ready_made_per_dataset_direction = gr.Dropdown(
+                                choices=list(READY_LEADERBOARD_SORT_DIRECTIONS),
+                                value=READY_LEADERBOARD_SORT_DIRECTIONS[0],
+                                label="Per-Dataset Direction",
+                            )
                     ready_made_aggregate = gr.Dataframe(
                         value=ready_made_initial[1],
-                        label="Ranked Algorithms",
+                        label="Interactive Aggregate Ranking",
                         wrap=False,
                         interactive=False,
                         max_height=360,
@@ -5221,7 +5581,7 @@ with gr.Blocks(
                     )
                     ready_made_per_dataset = gr.Dataframe(
                         value=ready_made_initial[2],
-                        label="Per-Dataset Ranking",
+                        label="Interactive Per-Dataset Ranking",
                         wrap=False,
                         interactive=False,
                         max_height=420,
@@ -5245,6 +5605,66 @@ with gr.Blocks(
                         value=ready_made_initial[5],
                         label="Ready-made Leaderboard JSON",
                         interactive=False,
+                    )
+
+                    ready_made_task.input(
+                        change_ready_made_leaderboard_task,
+                        inputs=[
+                            ready_made_task,
+                            ready_made_aggregate_sort,
+                            ready_made_aggregate_direction,
+                            ready_made_per_dataset_sort,
+                            ready_made_per_dataset_direction,
+                        ],
+                        outputs=[
+                            ready_made_metric,
+                            ready_made_dataset,
+                            ready_made_algorithm,
+                            ready_made_source,
+                            ready_made_aggregate,
+                            ready_made_per_dataset,
+                        ],
+                    )
+                    for ready_made_filter in (
+                        ready_made_metric,
+                        ready_made_dataset,
+                        ready_made_algorithm,
+                        ready_made_source,
+                        ready_made_aggregate_sort,
+                        ready_made_aggregate_direction,
+                        ready_made_per_dataset_sort,
+                        ready_made_per_dataset_direction,
+                    ):
+                        ready_made_filter.input(
+                            filter_ready_made_leaderboard,
+                            inputs=[
+                                ready_made_task,
+                                ready_made_metric,
+                                ready_made_dataset,
+                                ready_made_algorithm,
+                                ready_made_source,
+                                ready_made_aggregate_sort,
+                                ready_made_aggregate_direction,
+                                ready_made_per_dataset_sort,
+                                ready_made_per_dataset_direction,
+                            ],
+                            outputs=[ready_made_aggregate, ready_made_per_dataset],
+                        )
+                    ready_made_reset.click(
+                        reset_ready_made_leaderboard_filters,
+                        outputs=[
+                            ready_made_task,
+                            ready_made_metric,
+                            ready_made_dataset,
+                            ready_made_algorithm,
+                            ready_made_source,
+                            ready_made_aggregate_sort,
+                            ready_made_aggregate_direction,
+                            ready_made_per_dataset_sort,
+                            ready_made_per_dataset_direction,
+                            ready_made_aggregate,
+                            ready_made_per_dataset,
+                        ],
                     )
 
                 with gr.Tab("Build Leaderboard"):

--- a/gradio_app/assets/ready_leaderboard.json
+++ b/gradio_app/assets/ready_leaderboard.json
@@ -93,8 +93,8 @@
     {
       "algorithm_name": "CodeBLEU",
       "dataset_count": 5,
-      "mean_score": 0.7445820807531681,
-      "median_score": 0.7314453125,
+      "mean_score": 0.7446797370031681,
+      "median_score": 0.7275390625,
       "metric": "auroc",
       "rank": 2,
       "sample_count": 640,
@@ -113,8 +113,8 @@
     {
       "algorithm_name": "Code-Aware",
       "dataset_count": 5,
-      "mean_score": 0.736485605078725,
-      "median_score": 0.698974609375,
+      "mean_score": 0.7363879488287249,
+      "median_score": 0.697998046875,
       "metric": "auroc",
       "rank": 4,
       "sample_count": 640,
@@ -173,8 +173,8 @@
     {
       "algorithm_name": "CodeBLEU",
       "dataset_count": 5,
-      "mean_score": 0.7751913428650271,
-      "median_score": 0.7326505640007483,
+      "mean_score": 0.7753789210563613,
+      "median_score": 0.7334185739629584,
       "metric": "average_precision",
       "rank": 2,
       "sample_count": 640,
@@ -203,8 +203,8 @@
     {
       "algorithm_name": "Code-Aware",
       "dataset_count": 5,
-      "mean_score": 0.7633969213241152,
-      "median_score": 0.7094727169942896,
+      "mean_score": 0.7633279501728424,
+      "median_score": 0.7094826815512534,
       "metric": "average_precision",
       "rank": 5,
       "sample_count": 640,
@@ -316,6 +316,166 @@
       "mean_score": 0.3455134718292613,
       "median_score": 0.2702702702702703,
       "metric": "f1",
+      "rank": 8,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 5,
+      "mean_score": 0.9444444444444444,
+      "median_score": 1.0,
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 5,
+      "mean_score": 0.8083117816091955,
+      "median_score": 0.8666666666666667,
+      "metric": "precision",
+      "rank": 2,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 5,
+      "mean_score": 0.7976681854730636,
+      "median_score": 0.8857142857142857,
+      "metric": "precision",
+      "rank": 3,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 5,
+      "mean_score": 0.7530821624196238,
+      "median_score": 0.8461538461538461,
+      "metric": "precision",
+      "rank": 4,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 5,
+      "mean_score": 0.48120816887361,
+      "median_score": 0.5210084033613446,
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 5,
+      "mean_score": 0.46767118666906216,
+      "median_score": 0.5,
+      "metric": "precision",
+      "rank": 6,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 5,
+      "mean_score": 0.46638872212078314,
+      "median_score": 0.5079365079365079,
+      "metric": "precision",
+      "rank": 7,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 5,
+      "mean_score": 0.4546875,
+      "median_score": 0.5,
+      "metric": "precision",
+      "rank": 8,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Embedding Only",
+      "dataset_count": 5,
+      "mean_score": 0.99375,
+      "median_score": 1.0,
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_count": 5,
+      "mean_score": 0.99375,
+      "median_score": 1.0,
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Balanced",
+      "dataset_count": 5,
+      "mean_score": 0.98125,
+      "median_score": 0.96875,
+      "metric": "recall",
+      "rank": 3,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Code-Aware",
+      "dataset_count": 5,
+      "mean_score": 0.928125,
+      "median_score": 0.953125,
+      "metric": "recall",
+      "rank": 4,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "GST",
+      "dataset_count": 5,
+      "mean_score": 0.6246428571428572,
+      "median_score": 0.625,
+      "metric": "recall",
+      "rank": 5,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "CodeBLEU",
+      "dataset_count": 5,
+      "mean_score": 0.6012500000000001,
+      "median_score": 0.6,
+      "metric": "recall",
+      "rank": 6,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Lexical Only",
+      "dataset_count": 5,
+      "mean_score": 0.45705357142857145,
+      "median_score": 0.4375,
+      "metric": "recall",
+      "rank": 7,
+      "sample_count": 640,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_name": "Winnowing",
+      "dataset_count": 5,
+      "mean_score": 0.2196428571428571,
+      "median_score": 0.15625,
+      "metric": "recall",
       "rank": 8,
       "sample_count": 640,
       "task_family": "pair"
@@ -1506,6 +1666,8 @@
     "pair_metrics": [
       "f1",
       "accuracy",
+      "precision",
+      "recall",
       "auroc",
       "average_precision"
     ],
@@ -1540,7 +1702,7 @@
         "student_code_similarity"
       ],
       "dataset_task_count": 7,
-      "generated_at": "2026-07-16T17:03:12+00:00",
+      "generated_at": "2026-07-16T20:47:27+00:00",
       "pair_sample_limit": 128,
       "profile": "sampled_public_snapshot",
       "retrieval_corpus_limit": 64,
@@ -1553,6 +1715,8 @@
     "pair_metrics": [
       "f1",
       "accuracy",
+      "precision",
+      "recall",
       "auroc",
       "average_precision"
     ],
@@ -1795,7 +1959,7 @@
       "metric": "average_precision",
       "rank": 5,
       "sample_count": 128,
-      "score": 0.7094727169942896,
+      "score": 0.7094826815512534,
       "task_family": "pair"
     },
     {
@@ -1828,7 +1992,7 @@
       "metric": "average_precision",
       "rank": 8,
       "sample_count": 128,
-      "score": 0.6881926897189472,
+      "score": 0.6879444927499692,
       "task_family": "pair"
     },
     {
@@ -1917,6 +2081,182 @@
       "rank": 8,
       "sample_count": 128,
       "score": 0.5274725274725275,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.9,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.8888888888888888,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.8666666666666667,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.8461538461538461,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5126050420168067,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.5079365079365079,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.96875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.953125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.421875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.40625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "conplag",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.375,
       "task_family": "pair"
     },
     {
@@ -2274,6 +2614,182 @@
     {
       "algorithm_kind": "builtin",
       "algorithm_name": "CodeBLEU",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.2734375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.6857142857142857,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.6,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.45714285714285713,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "criminal_minds",
+      "dataset_source": "zenodo",
+      "metric": "recall",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.2857142857142857,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
       "dataset_name": "ipca",
       "dataset_source": "github",
       "metric": "accuracy",
@@ -2361,35 +2877,24 @@
     },
     {
       "algorithm_kind": "builtin",
-      "algorithm_name": "CodeBLEU",
-      "dataset_name": "ipca",
-      "dataset_source": "github",
-      "metric": "auroc",
-      "rank": 1,
-      "sample_count": 128,
-      "score": 0.7314453125,
-      "task_family": "pair"
-    },
-    {
-      "algorithm_kind": "builtin",
       "algorithm_name": "Jaro-Winkler",
       "dataset_name": "ipca",
       "dataset_source": "github",
       "metric": "auroc",
-      "rank": 2,
+      "rank": 1,
       "sample_count": 128,
       "score": 0.730224609375,
       "task_family": "pair"
     },
     {
       "algorithm_kind": "builtin",
-      "algorithm_name": "Code-Aware",
+      "algorithm_name": "CodeBLEU",
       "dataset_name": "ipca",
       "dataset_source": "github",
       "metric": "auroc",
-      "rank": 3,
+      "rank": 2,
       "sample_count": 128,
-      "score": 0.719482421875,
+      "score": 0.7275390625,
       "task_family": "pair"
     },
     {
@@ -2409,9 +2914,20 @@
       "dataset_name": "ipca",
       "dataset_source": "github",
       "metric": "auroc",
-      "rank": 5,
+      "rank": 4,
       "sample_count": 128,
       "score": 0.7193603515625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "auroc",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.71923828125,
       "task_family": "pair"
     },
     {
@@ -2455,7 +2971,7 @@
       "metric": "average_precision",
       "rank": 1,
       "sample_count": 128,
-      "score": 0.7998428400706629,
+      "score": 0.7970348587769279,
       "task_family": "pair"
     },
     {
@@ -2466,7 +2982,7 @@
       "metric": "average_precision",
       "rank": 2,
       "sample_count": 128,
-      "score": 0.7926967435339002,
+      "score": 0.7926085628408309,
       "task_family": "pair"
     },
     {
@@ -2625,6 +3141,182 @@
     },
     {
       "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.9655172413793104,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.8857142857142857,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.8529411764705882,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5444444444444444,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.496,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.96875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.765625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.484375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.453125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.4375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "ipca",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
       "algorithm_name": "Balanced",
       "dataset_name": "irplag_pair",
       "dataset_source": "github",
@@ -2730,7 +3422,7 @@
       "metric": "auroc",
       "rank": 2,
       "sample_count": 128,
-      "score": 0.681884765625,
+      "score": 0.686767578125,
       "task_family": "pair"
     },
     {
@@ -2763,7 +3455,7 @@
       "metric": "auroc",
       "rank": 5,
       "sample_count": 128,
-      "score": 0.634765625,
+      "score": 0.635498046875,
       "task_family": "pair"
     },
     {
@@ -2818,7 +3510,7 @@
       "metric": "average_precision",
       "rank": 2,
       "sample_count": 128,
-      "score": 0.7287596311467154,
+      "score": 0.7334185739629584,
       "task_family": "pair"
     },
     {
@@ -2851,7 +3543,7 @@
       "metric": "average_precision",
       "rank": 5,
       "sample_count": 128,
-      "score": 0.6784288381525189,
+      "score": 0.6791040551756836,
       "task_family": "pair"
     },
     {
@@ -2977,6 +3669,182 @@
     },
     {
       "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.6,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.5565217391304348,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.5545454545454546,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5487804878048781,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.5423728813559322,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.54,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 1.0,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.953125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.84375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.703125,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "irplag_pair",
+      "dataset_source": "github",
+      "metric": "recall",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.15625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
       "algorithm_name": "CodeBLEU",
       "dataset_name": "student_code_similarity",
       "dataset_source": "kaggle",
@@ -3071,7 +3939,7 @@
       "metric": "auroc",
       "rank": 1,
       "sample_count": 128,
-      "score": 0.74853515625,
+      "score": 0.748046875,
       "task_family": "pair"
     },
     {
@@ -3093,7 +3961,7 @@
       "metric": "auroc",
       "rank": 3,
       "sample_count": 128,
-      "score": 0.698974609375,
+      "score": 0.697998046875,
       "task_family": "pair"
     },
     {
@@ -3159,7 +4027,7 @@
       "metric": "average_precision",
       "rank": 1,
       "sample_count": 128,
-      "score": 0.7326505640007483,
+      "score": 0.7319856904038895,
       "task_family": "pair"
     },
     {
@@ -3181,7 +4049,7 @@
       "metric": "average_precision",
       "rank": 3,
       "sample_count": 128,
-      "score": 0.7084010591212848,
+      "score": 0.7074592024778622,
       "task_family": "pair"
     },
     {
@@ -3325,6 +4193,182 @@
       "rank": 8,
       "sample_count": 128,
       "score": 0.2631578947368421,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.8333333333333334,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 2,
+      "sample_count": 128,
+      "score": 0.6538461538461539,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 3,
+      "sample_count": 128,
+      "score": 0.609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 4,
+      "sample_count": 128,
+      "score": 0.5263157894736842,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.5210084033613446,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.512396694214876,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.5081967213114754,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "precision",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.5,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Balanced",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.96875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Code-Aware",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.96875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Embedding Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.96875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Jaro-Winkler",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 1,
+      "sample_count": 128,
+      "score": 0.96875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "CodeBLEU",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 5,
+      "sample_count": 128,
+      "score": 0.796875,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "GST",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 6,
+      "sample_count": 128,
+      "score": 0.625,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Lexical Only",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 7,
+      "sample_count": 128,
+      "score": 0.609375,
+      "task_family": "pair"
+    },
+    {
+      "algorithm_kind": "builtin",
+      "algorithm_name": "Winnowing",
+      "dataset_name": "student_code_similarity",
+      "dataset_source": "kaggle",
+      "metric": "recall",
+      "rank": 8,
+      "sample_count": 128,
+      "score": 0.15625,
       "task_family": "pair"
     },
     {

--- a/scripts/build_ready_leaderboard.py
+++ b/scripts/build_ready_leaderboard.py
@@ -21,7 +21,11 @@ from matheel.datasets import (
     write_pair_dataset,
     write_retrieval_dataset,
 )
-from matheel.leaderboard import run_leaderboard, write_leaderboard_artifacts
+from matheel.leaderboard import (
+    available_leaderboard_metrics,
+    run_leaderboard,
+    write_leaderboard_artifacts,
+)
 from matheel.leaderboard_presets import available_leaderboard_algorithm_presets
 
 
@@ -42,14 +46,8 @@ DATASET_LICENSES = {
     "soco14": "unknown",
     "student_code_similarity": "unknown",
 }
-PAIR_METRICS = ("f1", "accuracy", "auroc", "average_precision")
-RETRIEVAL_METRICS = (
-    "mean_average_precision",
-    "mean_reciprocal_rank",
-    "ndcg_at_k",
-    "precision_at_k",
-    "recall_at_k",
-)
+PAIR_METRICS = available_leaderboard_metrics("pair")
+RETRIEVAL_METRICS = available_leaderboard_metrics("retrieval")
 
 
 def build_ready_leaderboard(

--- a/tests/test_gradio_app.py
+++ b/tests/test_gradio_app.py
@@ -987,7 +987,94 @@ def test_ready_made_leaderboard_covers_all_presets_and_algorithms():
         gradio_app.READY_LEADERBOARD_ALGORITHM_CHOICES
     )
     assert set(report["aggregate"]["task_family"]) == {"pair", "retrieval"}
+    assert tuple(report["metadata"]["pair_metrics"]) == (
+        "f1",
+        "accuracy",
+        "precision",
+        "recall",
+        "auroc",
+        "average_precision",
+    )
+    assert tuple(report["metadata"]["retrieval_metrics"]) == (
+        "mean_average_precision",
+        "mean_reciprocal_rank",
+        "ndcg_at_k",
+        "precision_at_k",
+        "recall_at_k",
+    )
+    assert len(report["aggregate"]) == 88
+    assert len(report["per_dataset"]) == 320
     assert "static_hash" in gradio_app.ready_made_leaderboard_summary_html(report)
+
+
+def test_ready_made_leaderboard_uses_task_metrics_and_descending_defaults():
+    pair_options = gradio_app.ready_made_leaderboard_filter_options("pair")
+    retrieval_options = gradio_app.ready_made_leaderboard_filter_options("retrieval")
+
+    assert pair_options["metric"] == "f1"
+    assert pair_options["metrics"] == list(gradio_app.READY_LEADERBOARD_PAIR_METRICS)
+    assert retrieval_options["metric"] == "mean_average_precision"
+    assert retrieval_options["metrics"] == list(
+        gradio_app.READY_LEADERBOARD_RETRIEVAL_METRICS
+    )
+
+    aggregate, per_dataset = gradio_app.filter_ready_made_leaderboard(
+        "pair",
+        "f1",
+    )
+
+    assert set(aggregate["task_family"]) == {"pair"}
+    assert set(aggregate["metric"]) == {"f1"}
+    assert aggregate["mean_score"].is_monotonic_decreasing
+    assert per_dataset["score"].is_monotonic_decreasing
+
+
+def test_ready_made_leaderboard_supports_explicit_sort_controls():
+    aggregate, per_dataset = gradio_app.filter_ready_made_leaderboard(
+        "pair",
+        "f1",
+        aggregate_sort="algorithm_name",
+        aggregate_direction="Ascending",
+        per_dataset_sort="dataset_name",
+        per_dataset_direction="Descending",
+    )
+
+    assert aggregate["algorithm_name"].is_monotonic_increasing
+    assert per_dataset["dataset_name"].is_monotonic_decreasing
+
+    config = gradio_app.demo.get_config_file()
+    labels = {
+        component["props"].get("label")
+        for component in config["components"]
+        if component["type"] == "dropdown"
+    }
+    assert {
+        "Sort Aggregate By",
+        "Aggregate Direction",
+        "Sort Per-Dataset By",
+        "Per-Dataset Direction",
+    }.issubset(labels)
+
+
+def test_ready_made_leaderboard_filters_dataset_algorithm_and_source():
+    payload = gradio_app.load_ready_made_leaderboard_payload()
+    report = gradio_app._leaderboard_report_from_payload(payload)
+    row = report["per_dataset"].query("task_family == 'retrieval'").iloc[0]
+
+    aggregate, per_dataset = gradio_app.filter_ready_made_leaderboard(
+        "retrieval",
+        "mean_average_precision",
+        row["dataset_name"],
+        row["algorithm_name"],
+        row["dataset_source"],
+    )
+
+    assert set(per_dataset["dataset_name"]) == {row["dataset_name"]}
+    assert set(per_dataset["algorithm_name"]) == {row["algorithm_name"]}
+    assert set(per_dataset["dataset_source"]) == {row["dataset_source"]}
+    assert set(per_dataset["metric"]) == {"mean_average_precision"}
+    assert aggregate.iloc[0]["dataset_count"] == 1
+    assert aggregate.iloc[0]["algorithm_name"] == row["algorithm_name"]
 
 
 def test_ready_leaderboard_rejects_empty_algorithm_selection():


### PR DESCRIPTION
## Summary

- include every supported pair and retrieval evaluation metric in the ready-made snapshot and custom Gradio leaderboard runs
- default pair rankings to F1 and retrieval rankings to Mean Average Precision, sorted from highest to lowest
- add task, metric, dataset, algorithm, and source filters plus independent sort-column and direction controls for both ranking tables
- recompute aggregate rankings when dataset or source filters change
- regenerate the deterministic public snapshot and document the interaction model

## Why

The ready-made leaderboard exposed only four of the six supported pair metrics and relied on Gradio's less-accessible table controls for sorting. Users need a complete, task-aware ranking explorer that is usable without running a benchmark.

## Impact

The committed snapshot now contains 88 aggregate rows and 320 per-dataset rows across six pair metrics, five retrieval metrics, seven dataset task views, and eight algorithm presets. The underlying benchmark profile remains deterministic with the same samples, seed, and static-hash backend.

## Validation

- `.venv/bin/python -m pytest -q` — 565 passed, 4 skipped, 3 deselected
- `.venv/bin/ruff check .`
- `git diff --check`
- live local Gradio browser validation covering task defaults, metric/dataset filtering, aggregate recomputation, ascending/descending sorting, reset behavior, and console errors

Related to #178 (keep open).
